### PR TITLE
[16] Tests for logging to validate 1.4.10 (#1)

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -26,8 +26,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.slf4j:slf4j-log4j12:1.7.36'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1'
+    implementation 'org.slf4j:slf4j-api:1.7.36'
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:30.1.1-jre'
@@ -35,6 +35,8 @@ dependencies {
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testImplementation 'org.mockito:mockito-core:4+'
+    testImplementation 'uk.org.lidalia:slf4j-test:1.1.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'


### PR DESCRIPTION
This PR addresses #16 and can be used as a blueprint for other tests asserting log messages.

-removes dependency to log4j binding for slf4j, so clients can choose a different binding
-adds dependency to slf4j-api
-adds test logging binding by adding (test) dependency to uk.org.lidalia:slf4j-test
-adds (test) dependency to assertj for better readable assertions