### PR TITLE
Fixes ClassCastExceptions when hooks are called (address #23)

### DIFF
--- a/lib/src/main/java/dev/openfeature/javasdk/BooleanHook.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/BooleanHook.java
@@ -1,0 +1,9 @@
+package dev.openfeature.javasdk;
+
+public interface BooleanHook extends Hook<Boolean> {
+
+    @Override
+    default FlagValueType supportsFlagValueType() {
+        return FlagValueType.BOOLEAN;
+    }
+}

--- a/lib/src/main/java/dev/openfeature/javasdk/FlagEvaluationDetails.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/FlagEvaluationDetails.java
@@ -11,11 +11,11 @@ import javax.annotation.Nullable;
  */
 @Data @Builder
 public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
-    String flagKey;
-    T value;
-    @Nullable String variant;
-    Reason reason;
-    @Nullable String errorCode;
+    private String flagKey;
+    private T value;
+    @Nullable private String variant;
+    private Reason reason;
+    @Nullable private String errorCode;
 
     public static <T> FlagEvaluationDetails<T> from(ProviderEvaluation<T> providerEval, String flagKey) {
         return FlagEvaluationDetails.<T>builder()

--- a/lib/src/main/java/dev/openfeature/javasdk/FlagEvaluationOptions.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/FlagEvaluationOptions.java
@@ -1,15 +1,14 @@
 package dev.openfeature.javasdk;
 
-import com.google.common.collect.ImmutableMap;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Singular;
+import java.util.*;
 
-import java.util.List;
+import lombok.*;
 
-@Data @Builder
+@Value
+@Builder
 public class FlagEvaluationOptions {
-    @Singular private List<Hook> hooks;
+    @Singular
+    List<Hook> hooks;
     @Builder.Default
-    private ImmutableMap<String, Object> hookHints = ImmutableMap.of();
+    Map<String, Object> hookHints = Map.of();
 }

--- a/lib/src/main/java/dev/openfeature/javasdk/Hook.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/Hook.java
@@ -1,45 +1,53 @@
 package dev.openfeature.javasdk;
 
-import com.google.common.collect.ImmutableMap;
-
-import java.util.Optional;
+import java.util.*;
 
 /**
  * An extension point which can run around flag resolution. They are intended to be used as a way to add custom logic
  * to the lifecycle of flag evaluation.
+ *
  * @param <T> The type of the flag being evaluated.
  */
 public interface Hook<T> {
     /**
      * Runs before flag is resolved.
-     * @param ctx Information about the particular flag evaluation
+     *
+     * @param ctx   Information about the particular flag evaluation
      * @param hints An immutable mapping of data for users to communicate to the hooks.
      * @return An optional {@link EvaluationContext}. If returned, it will be merged with the EvaluationContext instances from other hooks, the client and API.
      */
-    default Optional<EvaluationContext> before(HookContext<T> ctx, ImmutableMap<String, Object> hints) {
+    default Optional<EvaluationContext> before(HookContext<T> ctx, Map<String, Object> hints) {
         return Optional.empty();
     }
 
     /**
      * Runs after a flag is resolved.
-     * @param ctx Information about the particular flag evaluation
+     *
+     * @param ctx     Information about the particular flag evaluation
      * @param details Information about how the flag was resolved, including any resolved values.
-     * @param hints An immutable mapping of data for users to communicate to the hooks.
+     * @param hints   An immutable mapping of data for users to communicate to the hooks.
      */
-    default void after(HookContext<T> ctx, FlagEvaluationDetails<T> details, ImmutableMap<String, Object> hints) {}
+    default void after(HookContext<T> ctx, FlagEvaluationDetails<T> details, Map<String, Object> hints) {
+    }
 
     /**
      * Run when evaluation encounters an error. This will always run. Errors thrown will be swallowed.
-     * @param ctx Information about the particular flag evaluation
+     *
+     * @param ctx   Information about the particular flag evaluation
      * @param error The exception that was thrown.
      * @param hints An immutable mapping of data for users to communicate to the hooks.
      */
-    default void error(HookContext<T> ctx, Exception error, ImmutableMap<String, Object> hints) {}
+    default void error(HookContext<T> ctx, Exception error, Map<String, Object> hints) {
+    }
 
     /**
      * Run after flag evaluation, including any error processing. This will always run. Errors will be swallowed.
-     * @param ctx Information about the particular flag evaluation
+     *
+     * @param ctx   Information about the particular flag evaluation
      * @param hints An immutable mapping of data for users to communicate to the hooks.
      */
-    default void finallyAfter(HookContext<T> ctx, ImmutableMap<String, Object> hints) {}
+    default void finallyAfter(HookContext<T> ctx, Map<String, Object> hints) {
+    }
+
+    FlagValueType supportsFlagValueType();
 }

--- a/lib/src/main/java/dev/openfeature/javasdk/HookSupport.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/HookSupport.java
@@ -1,0 +1,69 @@
+package dev.openfeature.javasdk;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import com.google.common.collect.Lists;
+import lombok.*;
+import org.slf4j.Logger;
+
+@RequiredArgsConstructor
+class HookSupport {
+
+    private final Logger log;
+
+    public void errorHooks(FlagValueType flagValueType, HookContext hookCtx, Exception e, List<Hook> hooks, Map<String, Object> hints) {
+        executeHooks(flagValueType, hooks, "error", hook -> hook.error(hookCtx, e, hints));
+    }
+
+    public void afterAllHooks(FlagValueType flagValueType, HookContext hookCtx, List<Hook> hooks, Map<String, Object> hints) {
+        executeHooks(flagValueType, hooks, "finally", hook -> hook.finallyAfter(hookCtx, hints));
+    }
+
+    public void afterHooks(FlagValueType flagValueType, HookContext hookContext, FlagEvaluationDetails details, List<Hook> hooks, Map<String, Object> hints) {
+        executeHooksUnsafe(flagValueType, hooks, hook -> hook.after(hookContext, details, hints));
+    }
+
+    private <T> void executeHooks(
+        FlagValueType flagValueType, List<Hook> hooks,
+        String hookMethod,
+        Consumer<Hook<T>> hookCode
+    ) {
+        hooks
+            .stream()
+            .filter(hook -> hook.supportsFlagValueType() == flagValueType)
+            .forEach(hook -> executeChecked(hook, hookCode, hookMethod));
+    }
+
+    private <T> void executeHooksUnsafe(
+        FlagValueType flagValueType, List<Hook> hooks,
+        Consumer<Hook<T>> hookCode
+    ) {
+        hooks
+            .stream()
+            .filter(hook -> hook.supportsFlagValueType() == flagValueType)
+            .forEach(hookCode::accept);
+    }
+
+    private <T> void executeChecked(Hook<T> hook, Consumer<Hook<T>> hookCode, String hookMethod) {
+        try {
+            hookCode.accept(hook);
+        } catch (Exception exception) {
+            log.error("Exception when running {} hooks {}", hookMethod, hook.getClass(), exception);
+        }
+    }
+
+    public EvaluationContext beforeHooks(HookContext hookCtx, List<Hook> hooks, Map<String, Object> hints) {
+        // These traverse backwards from normal.
+        EvaluationContext ctx = hookCtx.getCtx();
+        for (Hook hook : Lists.reverse(hooks)) {
+            Optional<EvaluationContext> newCtx = hook.before(hookCtx, hints);
+            if (newCtx != null && newCtx.isPresent()) {
+                ctx = EvaluationContext.merge(ctx, newCtx.get());
+                hookCtx = hookCtx.withCtx(ctx);
+            }
+        }
+        return ctx;
+    }
+
+}

--- a/lib/src/main/java/dev/openfeature/javasdk/HookSupport.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/HookSupport.java
@@ -2,9 +2,10 @@ package dev.openfeature.javasdk;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
-import lombok.*;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 
 @RequiredArgsConstructor
@@ -12,18 +13,22 @@ class HookSupport {
 
     private final Logger log;
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void errorHooks(FlagValueType flagValueType, HookContext hookCtx, Exception e, List<Hook> hooks, Map<String, Object> hints) {
         executeHooks(flagValueType, hooks, "error", hook -> hook.error(hookCtx, e, hints));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void afterAllHooks(FlagValueType flagValueType, HookContext hookCtx, List<Hook> hooks, Map<String, Object> hints) {
         executeHooks(flagValueType, hooks, "finally", hook -> hook.finallyAfter(hookCtx, hints));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void afterHooks(FlagValueType flagValueType, HookContext hookContext, FlagEvaluationDetails details, List<Hook> hooks, Map<String, Object> hints) {
-        executeHooksUnsafe(flagValueType, hooks, hook -> hook.after(hookContext, details, hints));
+        executeHooksUnchecked(flagValueType, hooks, hook -> hook.after(hookContext, details, hints));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private <T> void executeHooks(
         FlagValueType flagValueType, List<Hook> hooks,
         String hookMethod,
@@ -35,7 +40,8 @@ class HookSupport {
             .forEach(hook -> executeChecked(hook, hookCode, hookMethod));
     }
 
-    private <T> void executeHooksUnsafe(
+    @SuppressWarnings("rawtypes")
+    private <T> void executeHooksUnchecked(
         FlagValueType flagValueType, List<Hook> hooks,
         Consumer<Hook<T>> hookCode
     ) {
@@ -53,17 +59,28 @@ class HookSupport {
         }
     }
 
-    public EvaluationContext beforeHooks(HookContext hookCtx, List<Hook> hooks, Map<String, Object> hints) {
-        // These traverse backwards from normal.
-        EvaluationContext ctx = hookCtx.getCtx();
-        for (Hook hook : Lists.reverse(hooks)) {
-            Optional<EvaluationContext> newCtx = hook.before(hookCtx, hints);
-            if (newCtx != null && newCtx.isPresent()) {
-                ctx = EvaluationContext.merge(ctx, newCtx.get());
-                hookCtx = hookCtx.withCtx(ctx);
-            }
-        }
-        return ctx;
+    @SuppressWarnings("rawtypes")
+    public EvaluationContext beforeHooks(FlagValueType flagValueType, HookContext hookCtx, List<Hook> hooks, Map<String, Object> hints) {
+        var result = callBeforeHooks(flagValueType, hookCtx, hooks, hints);
+        return EvaluationContext.merge(hookCtx.getCtx(), collectContexts(result));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Stream<EvaluationContext> callBeforeHooks(FlagValueType flagValueType, HookContext hookCtx, List<Hook> hooks, Map<String, Object> hints) {
+        // These traverse backwards from normal.
+        return Lists
+            .reverse(hooks)
+            .stream()
+            .filter(hook -> hook.supportsFlagValueType() == flagValueType)
+            .map(hook -> hook.before(hookCtx, hints))
+            .filter(Objects::nonNull)
+            .flatMap(Optional::stream);
+    }
+
+    //for whatever reason, an error `error: incompatible types: invalid method reference` is thrown on compilation with javac
+    //when the reduce call is appended directly as stream call chain above. moving it to its own method works however...
+    private EvaluationContext collectContexts(Stream<EvaluationContext> result) {
+        return result
+            .reduce(new EvaluationContext(), EvaluationContext::merge, EvaluationContext::merge);
+    }
 }

--- a/lib/src/main/java/dev/openfeature/javasdk/IntegerHook.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/IntegerHook.java
@@ -1,0 +1,9 @@
+package dev.openfeature.javasdk;
+
+public interface IntegerHook extends Hook<Integer> {
+
+    @Override
+    default FlagValueType supportsFlagValueType() {
+        return FlagValueType.INTEGER;
+    }
+}

--- a/lib/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
@@ -1,41 +1,42 @@
 package dev.openfeature.javasdk;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import dev.openfeature.javasdk.exceptions.*;
+import java.util.*;
+
+import dev.openfeature.javasdk.exceptions.GeneralError;
+import dev.openfeature.javasdk.internal.ObjectUtils;
 import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
-@SuppressWarnings("PMD.DataflowAnomalyAnalysis")
+@SuppressWarnings({"PMD.DataflowAnomalyAnalysis", "unchecked", "rawtypes"})
 public class OpenFeatureClient implements Client {
-    private transient final OpenFeatureAPI openfeatureApi;
-    @Getter private final String name;
-    @Getter private final String version;
-    @Getter private final List<Hook> clientHooks;
     private static final Logger log = LoggerFactory.getLogger(OpenFeatureClient.class);
+
+    private final OpenFeatureAPI openfeatureApi;
+    @Getter
+    private final String name;
+    @Getter
+    private final String version;
+    @Getter
+    private final List<Hook> clientHooks;
+    private final HookSupport hookSupport;
 
     public OpenFeatureClient(OpenFeatureAPI openFeatureAPI, String name, String version) {
         this.openfeatureApi = openFeatureAPI;
         this.name = name;
         this.version = version;
         this.clientHooks = new ArrayList<>();
+        this.hookSupport = new HookSupport(log);
     }
 
     @Override
     public void addHooks(Hook... hooks) {
-        this.clientHooks.addAll(Arrays.asList(hooks));
+        this.clientHooks.addAll(List.of(hooks));
     }
 
-    <T> FlagEvaluationDetails<T> evaluateFlag(FlagValueType type, String key, T defaultValue, EvaluationContext ctx, FlagEvaluationOptions options) {
-        FeatureProvider provider = this.openfeatureApi.getProvider();
-        ImmutableMap<String, Object> hints = options.getHookHints();
+    private <T> FlagEvaluationDetails<T> evaluateFlag(FlagValueType type, String key, T defaultValue, EvaluationContext ctx, FlagEvaluationOptions options) {
+        var flagOptions = ObjectUtils.defaultIfNull(options, () -> FlagEvaluationOptions.builder().build());
+        FeatureProvider provider = openfeatureApi.getProvider();
+        Map<String, Object> hints = Collections.unmodifiableMap(flagOptions.getHookHints());
         if (ctx == null) {
             ctx = new EvaluationContext();
         }
@@ -43,93 +44,55 @@ public class OpenFeatureClient implements Client {
         // merge of: API.context, client.context, invocation.context
 
         // TODO: Context transformation?
-        HookContext hookCtx = HookContext.from(key, type, this.getMetadata(), OpenFeatureAPI.getInstance().getProvider().getMetadata(), ctx, defaultValue);
+        HookContext<T> hookCtx = HookContext.from(key, type, this.getMetadata(), openfeatureApi.getProvider().getMetadata(), ctx, defaultValue);
 
-        List<Hook> mergedHooks;
-        if (options != null && options.getHooks() != null) {
-            mergedHooks = ImmutableList.<Hook>builder()
-                    .addAll(options.getHooks())
-                    .addAll(clientHooks)
-                    .addAll(openfeatureApi.getApiHooks())
-                    .build();
-        } else {
-            mergedHooks = clientHooks;
-        }
+        List<Hook> mergedHooks = ObjectUtils.merge(flagOptions.getHooks(), clientHooks, openfeatureApi.getApiHooks());
 
         FlagEvaluationDetails<T> details = null;
         try {
-            EvaluationContext ctxFromHook = this.beforeHooks(hookCtx, mergedHooks, hints);
+            EvaluationContext ctxFromHook = hookSupport.beforeHooks(hookCtx, mergedHooks, hints);
             EvaluationContext invocationContext = EvaluationContext.merge(ctxFromHook, ctx);
 
-            ProviderEvaluation<T> providerEval;
-            if (type == FlagValueType.BOOLEAN) {
-                // TODO: Can we guarantee that defaultValue is a boolean? If not, how to we handle that?
-                providerEval = (ProviderEvaluation<T>) provider.getBooleanEvaluation(key, (Boolean) defaultValue, invocationContext, options);
-            } else if(type == FlagValueType.STRING) {
-                providerEval = (ProviderEvaluation<T>) provider.getStringEvaluation(key, (String) defaultValue, invocationContext, options);
-            } else if (type == FlagValueType.INTEGER) {
-                providerEval = (ProviderEvaluation<T>) provider.getIntegerEvaluation(key, (Integer) defaultValue, invocationContext, options);
-            } else if (type == FlagValueType.OBJECT) {
-                providerEval = (ProviderEvaluation<T>) provider.getObjectEvaluation(key, defaultValue, invocationContext, options);
-            } else {
-                throw new GeneralError("Unknown flag type");
-            }
+            ProviderEvaluation<T> providerEval = (ProviderEvaluation<T>) createProviderEvaluation(type, key, defaultValue, options, provider, invocationContext);
 
             details = FlagEvaluationDetails.from(providerEval, key);
-            this.afterHooks(hookCtx, details, mergedHooks, hints);
+            hookSupport.afterHooks(type, hookCtx, details, mergedHooks, hints);
         } catch (Exception e) {
             log.error("Unable to correctly evaluate flag with key {} due to exception {}", key, e.getMessage());
             if (details == null) {
-                details = FlagEvaluationDetails.<T>builder().value(defaultValue).reason(Reason.ERROR).build();
+                details = FlagEvaluationDetails.<T>builder().build();
             }
-            details.value = defaultValue;
-            details.reason = Reason.ERROR;
-            details.errorCode = e.getMessage();
-            this.errorHooks(hookCtx, e, mergedHooks, hints);
+            details.setValue(defaultValue);
+            details.setReason(Reason.ERROR);
+            details.setErrorCode(e.getMessage());
+            hookSupport.errorHooks(type, hookCtx, e, mergedHooks, hints);
         } finally {
-            this.afterAllHooks(hookCtx, mergedHooks, hints);
+            hookSupport.afterAllHooks(type, hookCtx, mergedHooks, hints);
         }
 
         return details;
     }
 
-    private void errorHooks(HookContext hookCtx, Exception e, List<Hook> hooks, ImmutableMap<String, Object> hints) {
-        for (Hook hook : hooks) {
-            try {
-                hook.error(hookCtx, e, hints);
-            } catch (Exception inner_exception) {
-                log.error("Exception when running error hooks " + hook.getClass().toString(), inner_exception);
-            }
+    private <T> ProviderEvaluation<?> createProviderEvaluation(
+        FlagValueType type,
+        String key,
+        T defaultValue,
+        FlagEvaluationOptions options,
+        FeatureProvider provider,
+        EvaluationContext invocationContext
+    ) {
+        switch (type) {
+            case BOOLEAN:
+                return provider.getBooleanEvaluation(key, (Boolean) defaultValue, invocationContext, options);
+            case STRING:
+                return provider.getStringEvaluation(key, (String) defaultValue, invocationContext, options);
+            case INTEGER:
+                return provider.getIntegerEvaluation(key, (Integer) defaultValue, invocationContext, options);
+            case OBJECT:
+                return provider.getObjectEvaluation(key, defaultValue, invocationContext, options);
+            default:
+                throw new GeneralError("Unknown flag type");
         }
-    }
-
-    private void afterAllHooks(HookContext hookCtx, List<Hook> hooks, ImmutableMap<String, Object> hints) {
-        for (Hook hook : hooks) {
-            try {
-                hook.finallyAfter(hookCtx, hints);
-            } catch (Exception inner_exception) {
-                log.error("Exception when running finally hooks " + hook.getClass().toString(), inner_exception);
-            }
-        }
-    }
-
-    private <T> void afterHooks(HookContext hookContext, FlagEvaluationDetails<T> details, List<Hook> hooks, ImmutableMap<String, Object> hints) {
-        for (Hook hook : hooks) {
-            hook.after(hookContext, details, hints);
-        }
-    }
-
-    private EvaluationContext beforeHooks(HookContext hookCtx, List<Hook> hooks, ImmutableMap<String, Object> hints) {
-        // These traverse backwards from normal.
-        EvaluationContext ctx = hookCtx.getCtx();
-        for (Hook hook : Lists.reverse(hooks)) {
-            Optional<EvaluationContext> newCtx = hook.before(hookCtx, hints);
-            if (newCtx != null && newCtx.isPresent()) {
-                ctx = EvaluationContext.merge(ctx, newCtx.get());
-                hookCtx = hookCtx.withCtx(ctx);
-            }
-        }
-        return ctx;
     }
 
     @Override
@@ -179,7 +142,7 @@ public class OpenFeatureClient implements Client {
 
     @Override
     public FlagEvaluationDetails<String> getStringDetails(String key, String defaultValue) {
-        return getStringDetails(key, defaultValue,  null);
+        return getStringDetails(key, defaultValue, null);
     }
 
     @Override
@@ -254,11 +217,6 @@ public class OpenFeatureClient implements Client {
 
     @Override
     public Metadata getMetadata() {
-        return new Metadata() {
-            @Override
-            public String getName() {
-                return name;
-            }
-        };
+        return () -> name;
     }
 }

--- a/lib/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
@@ -50,7 +50,7 @@ public class OpenFeatureClient implements Client {
 
         FlagEvaluationDetails<T> details = null;
         try {
-            EvaluationContext ctxFromHook = hookSupport.beforeHooks(hookCtx, mergedHooks, hints);
+            EvaluationContext ctxFromHook = hookSupport.beforeHooks(type, hookCtx, mergedHooks, hints);
             EvaluationContext invocationContext = EvaluationContext.merge(ctxFromHook, ctx);
 
             ProviderEvaluation<T> providerEval = (ProviderEvaluation<T>) createProviderEvaluation(type, key, defaultValue, options, provider, invocationContext);

--- a/lib/src/main/java/dev/openfeature/javasdk/StringHook.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/StringHook.java
@@ -1,0 +1,9 @@
+package dev.openfeature.javasdk;
+
+public interface StringHook extends Hook<String> {
+
+    @Override
+    default FlagValueType supportsFlagValueType() {
+        return FlagValueType.STRING;
+    }
+}

--- a/lib/src/main/java/dev/openfeature/javasdk/internal/ObjectUtils.java
+++ b/lib/src/main/java/dev/openfeature/javasdk/internal/ObjectUtils.java
@@ -1,0 +1,41 @@
+package dev.openfeature.javasdk.internal;
+
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ObjectUtils {
+
+    public static <T> List<T> defaultIfNull(List<T> source, Supplier<List<T>> defaultValue) {
+        if (source == null) {
+            return defaultValue.get();
+        }
+        return source;
+    }
+
+    public static <K, V> Map<K, V> defaultIfNull(Map<K, V> source, Supplier<Map<K, V>> defaultValue) {
+        if (source == null) {
+            return defaultValue.get();
+        }
+        return source;
+    }
+
+    public static <T> T defaultIfNull(T source, Supplier<T> defaultValue) {
+        if (source == null) {
+            return defaultValue.get();
+        }
+        return source;
+    }
+
+    @SafeVarargs
+    public static <T> List<T> merge(List<T>... sources) {
+        return Arrays
+            .stream(sources)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/lib/src/test/java/dev/openfeature/javasdk/DeveloperExperienceTest.java
+++ b/lib/src/test/java/dev/openfeature/javasdk/DeveloperExperienceTest.java
@@ -6,8 +6,7 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 
 @SuppressWarnings("unchecked")
@@ -22,7 +21,7 @@ class DeveloperExperienceTest {
     }
 
     @Test void clientHooks() {
-        Hook<Boolean> exampleHook = (Hook<Boolean>) Mockito.mock(Hook.class);
+        Hook<Boolean> exampleHook = createBooleanHook();
 
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider());
@@ -33,9 +32,15 @@ class DeveloperExperienceTest {
         assertFalse(retval);
     }
 
+    private Hook<Boolean> createBooleanHook() {
+        var hook = Mockito.mock(Hook.class);
+        when(hook.supportsFlagValueType()).thenReturn(FlagValueType.BOOLEAN);
+        return hook;
+    }
+
     @Test void evalHooks() {
-        Hook<Boolean> clientHook = (Hook<Boolean>) Mockito.mock(Hook.class);
-        Hook<Boolean> evalHook = (Hook<Boolean>) Mockito.mock(Hook.class);
+        Hook<Boolean> clientHook = createBooleanHook();
+        Hook<Boolean> evalHook = createBooleanHook();
 
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider());

--- a/lib/src/test/java/dev/openfeature/javasdk/DoSomethingProvider.java
+++ b/lib/src/test/java/dev/openfeature/javasdk/DoSomethingProvider.java
@@ -4,12 +4,7 @@ public class DoSomethingProvider implements FeatureProvider {
 
     @Override
     public Metadata getMetadata() {
-        return new Metadata() {
-            @Override
-            public String getName() {
-                return "test";
-            }
-        };
+        return () -> "test";
     }
 
     @Override

--- a/lib/src/test/java/dev/openfeature/javasdk/FlagEvaluationSpecTests.java
+++ b/lib/src/test/java/dev/openfeature/javasdk/FlagEvaluationSpecTests.java
@@ -1,7 +1,7 @@
 package dev.openfeature.javasdk;
 
+import dev.openfeature.javasdk.fixtures.HookFixtures;
 import org.junit.jupiter.api.*;
-import org.slf4j.*;
 import uk.org.lidalia.slf4jtest.*;
 
 import java.util.List;
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-class FlagEvaluationSpecTests {
+class FlagEvaluationSpecTests implements HookFixtures {
 
     private static final TestLogger TEST_LOGGER = TestLoggerFactory.getTestLogger(OpenFeatureClient.class);
 
@@ -143,9 +143,9 @@ class FlagEvaluationSpecTests {
 
     @Specification(number="1.5.1", text="The evaluation options structure's hooks field denotes an ordered collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.")
     @Test void hooks() {
-        Client c = _client();
-        Hook clientHook = mock(Hook.class);
-        Hook invocationHook = mock(Hook.class);
+        var c = _client();
+        var clientHook = mockBooleanHook();
+        var invocationHook = mockBooleanHook();
         c.addHooks(clientHook);
         c.getBooleanValue("key", false, null, FlagEvaluationOptions.builder()
                         .hook(invocationHook)

--- a/lib/src/test/java/dev/openfeature/javasdk/HookSupportTest.java
+++ b/lib/src/test/java/dev/openfeature/javasdk/HookSupportTest.java
@@ -1,0 +1,43 @@
+package dev.openfeature.javasdk;
+
+import java.util.*;
+
+import org.junit.jupiter.api.*;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class HookSupportTest {
+
+    @Test
+    @DisplayName("should merge EvaluationContexts on before hooks correctly")
+    void shouldMergeEvaluationContextsOnBeforeHooksCorrectly() {
+        var baseContext = new EvaluationContext();
+        baseContext.addStringAttribute("baseKey", "baseValue");
+        var hookContext = new HookContext<>("flagKey", FlagValueType.STRING, "defaultValue", baseContext, () -> "client", () -> "provider");
+        var hook1 = stringHookMock();
+        var hook2 = stringHookMock();
+        when(hook1.before(any(), any())).thenReturn(Optional.of(evaluationContextWithValue("bla", "blubber")));
+        when(hook2.before(any(), any())).thenReturn(Optional.of(evaluationContextWithValue("foo", "bar")));
+
+        var hookSupport = new HookSupport(LoggerFactory.getLogger("test"));
+
+        var result = hookSupport.beforeHooks(FlagValueType.STRING, hookContext, List.of(hook1, hook2), Map.of());
+
+        assertThat(result.getStringAttribute("bla")).isEqualTo("blubber");
+        assertThat(result.getStringAttribute("foo")).isEqualTo("bar");
+        assertThat(result.getStringAttribute("baseKey")).isEqualTo("baseValue");
+    }
+
+    private EvaluationContext evaluationContextWithValue(String key, String value) {
+        var result = new EvaluationContext();
+        result.addStringAttribute(key, value);
+        return result;
+    }
+
+    private StringHook stringHookMock() {
+        return spy(StringHook.class);
+    }
+
+}

--- a/lib/src/test/java/dev/openfeature/javasdk/OpenFeatureClientTest.java
+++ b/lib/src/test/java/dev/openfeature/javasdk/OpenFeatureClientTest.java
@@ -2,7 +2,8 @@ package dev.openfeature.javasdk;
 
 import java.util.*;
 
-import com.google.common.collect.ImmutableMap;
+import dev.openfeature.javasdk.fixtures.HookFixtures;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.*;
 import uk.org.lidalia.slf4jext.Level;
 import uk.org.lidalia.slf4jtest.*;
@@ -10,7 +11,7 @@ import uk.org.lidalia.slf4jtest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-class OpenFeatureClientTest {
+class OpenFeatureClientTest implements HookFixtures {
 
     private static final TestLogger TEST_LOGGER = TestLoggerFactory.getTestLogger(OpenFeatureClient.class);
 
@@ -20,49 +21,13 @@ class OpenFeatureClientTest {
         TEST_LOGGER.clear();
         var api = mock(OpenFeatureAPI.class);
         when(api.getProvider()).thenReturn(new DoSomethingProvider());
-        when(api.getApiHooks()).thenReturn(List.of(new BooleanHook(), new StringHook()));
+        when(api.getApiHooks()).thenReturn(List.of(mockBooleanHook(), mockStringHook()));
 
         var client = new OpenFeatureClient(api, "name", "version");
 
         var actual = client.getBooleanDetails("feature key", Boolean.FALSE);
 
-        assertThat(actual.getValue()).isFalse();
+        assertThat(actual.getValue()).isTrue();
         assertThat(TEST_LOGGER.getLoggingEvents()).filteredOn(event -> event.getLevel().equals(Level.ERROR)).isEmpty();
-    }
-
-    private static class BooleanHook implements Hook<Boolean> {
-        @Override
-        public FlagValueType supportsFlagValueType() {
-            return FlagValueType.BOOLEAN;
-        }
-    }
-
-    private static class StringHook implements Hook<String> {
-        @Override
-        public Optional<EvaluationContext> before(HookContext<String> ctx, Map<String, Object> hints) {
-            var result = new EvaluationContext();
-            result.addStringAttribute("lowercase", ctx.getDefaultValue().toLowerCase());
-            return Optional.of(result);
-        }
-
-        @Override
-        public void after(HookContext<String> ctx, FlagEvaluationDetails<String> details, Map<String, Object> hints) {
-            Hook.super.after(ctx, details, hints);
-        }
-
-        @Override
-        public void error(HookContext<String> ctx, Exception error, Map<String, Object> hints) {
-            Hook.super.error(ctx, error, hints);
-        }
-
-        @Override
-        public void finallyAfter(HookContext<String> ctx, Map<String, Object> hints) {
-            Hook.super.finallyAfter(ctx, hints);
-        }
-
-        @Override
-        public FlagValueType supportsFlagValueType() {
-            return FlagValueType.STRING;
-        }
     }
 }

--- a/lib/src/test/java/dev/openfeature/javasdk/OpenFeatureClientTest.java
+++ b/lib/src/test/java/dev/openfeature/javasdk/OpenFeatureClientTest.java
@@ -1,0 +1,68 @@
+package dev.openfeature.javasdk;
+
+import java.util.*;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.*;
+import uk.org.lidalia.slf4jext.Level;
+import uk.org.lidalia.slf4jtest.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class OpenFeatureClientTest {
+
+    private static final TestLogger TEST_LOGGER = TestLoggerFactory.getTestLogger(OpenFeatureClient.class);
+
+    @Test
+    @DisplayName("should not throw exception if hook has different type argument than hookContext")
+    void shouldNotThrowExceptionIfHookHasDifferentTypeArgumentThanHookContext() {
+        TEST_LOGGER.clear();
+        var api = mock(OpenFeatureAPI.class);
+        when(api.getProvider()).thenReturn(new DoSomethingProvider());
+        when(api.getApiHooks()).thenReturn(List.of(new BooleanHook(), new StringHook()));
+
+        var client = new OpenFeatureClient(api, "name", "version");
+
+        var actual = client.getBooleanDetails("feature key", Boolean.FALSE);
+
+        assertThat(actual.getValue()).isFalse();
+        assertThat(TEST_LOGGER.getLoggingEvents()).filteredOn(event -> event.getLevel().equals(Level.ERROR)).isEmpty();
+    }
+
+    private static class BooleanHook implements Hook<Boolean> {
+        @Override
+        public FlagValueType supportsFlagValueType() {
+            return FlagValueType.BOOLEAN;
+        }
+    }
+
+    private static class StringHook implements Hook<String> {
+        @Override
+        public Optional<EvaluationContext> before(HookContext<String> ctx, Map<String, Object> hints) {
+            var result = new EvaluationContext();
+            result.addStringAttribute("lowercase", ctx.getDefaultValue().toLowerCase());
+            return Optional.of(result);
+        }
+
+        @Override
+        public void after(HookContext<String> ctx, FlagEvaluationDetails<String> details, Map<String, Object> hints) {
+            Hook.super.after(ctx, details, hints);
+        }
+
+        @Override
+        public void error(HookContext<String> ctx, Exception error, Map<String, Object> hints) {
+            Hook.super.error(ctx, error, hints);
+        }
+
+        @Override
+        public void finallyAfter(HookContext<String> ctx, Map<String, Object> hints) {
+            Hook.super.finallyAfter(ctx, hints);
+        }
+
+        @Override
+        public FlagValueType supportsFlagValueType() {
+            return FlagValueType.STRING;
+        }
+    }
+}

--- a/lib/src/test/java/dev/openfeature/javasdk/fixtures/HookFixtures.java
+++ b/lib/src/test/java/dev/openfeature/javasdk/fixtures/HookFixtures.java
@@ -1,0 +1,25 @@
+package dev.openfeature.javasdk.fixtures;
+
+import dev.openfeature.javasdk.*;
+
+import static org.mockito.Mockito.spy;
+
+public interface HookFixtures {
+
+    default Hook<Boolean> mockBooleanHook() {
+        return spy(BooleanHook.class);
+    }
+
+    default Hook<String> mockStringHook() {
+        return spy(StringHook.class);
+    }
+
+    default Hook<Integer> mockIntegerHook() {
+        return spy(IntegerHook.class);
+    }
+
+    default Hook<?> mockGenericHook() {
+        return spy(Hook.class);
+    }
+
+}


### PR DESCRIPTION
Due to the nature of this issue, there are two options to mitigate it.

1. call only these hooks, which support the type of the evaluated flag
2. call all hooks, but let the hooks be untyped, leaving it up to the hook author to check the type and apply logic.

In my PR I opted for the first option, but with some sort of expressiveness by introducing dedicated interfaces for boolean, string and integer typed hooks. If hook authors still wants their hook to get called everytime, they still can use the generic form.

-fixes ClassCastException by only calling hooks, that support the flag value
-introduces specialized hook interfaces for supported types
-adds a fixture for hooks for tests
-moves out calling of hooks from OpenFeatureClient to dedicated class HookSupport
-introduces method in Hook showing the supported flag value type
-makes FlagEvaluationOptions immutable