### PR TITLE
Quick hacky investigation into event hooks

### DIFF
--- a/src/main/java/dev/openfeature/javasdk/EventAwareFeatureProvider.java
+++ b/src/main/java/dev/openfeature/javasdk/EventAwareFeatureProvider.java
@@ -1,0 +1,7 @@
+package dev.openfeature.javasdk;
+
+import java.util.function.Consumer;
+
+public interface EventAwareFeatureProvider extends FeatureProvider {
+    void setEventHookCallback(Consumer<String> eventHookConsumer);
+}

--- a/src/main/java/dev/openfeature/javasdk/EventFiringProvider.java
+++ b/src/main/java/dev/openfeature/javasdk/EventFiringProvider.java
@@ -1,0 +1,30 @@
+package dev.openfeature.javasdk;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.function.Consumer;
+
+/**
+ * A {@link FeatureProvider} that simply returns the default values passed to it.
+ */
+public class EventFiringProvider extends NoOpProvider implements EventAwareFeatureProvider {
+    private Consumer<String> eventConsumer;
+
+    public EventFiringProvider() {
+        Timer timer = new Timer();
+        timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                if(eventConsumer != null) {
+                    eventConsumer.accept("Event was triggered from the provider");
+                }
+            }
+        }, 0, 1000);
+    }
+
+    @Override
+    public void setEventHookCallback(Consumer<String> eventHookConsumer) {
+        // maybe it's best to wrap this up in the constructor?
+        this.eventConsumer = eventHookConsumer;
+    }
+}

--- a/src/main/java/dev/openfeature/javasdk/EventHook.java
+++ b/src/main/java/dev/openfeature/javasdk/EventHook.java
@@ -1,0 +1,5 @@
+package dev.openfeature.javasdk;
+
+public interface EventHook {
+    default void onEvent(String event) {}
+}

--- a/src/test/java/dev/openfeature/javasdk/EventFiringProviderTest.java
+++ b/src/test/java/dev/openfeature/javasdk/EventFiringProviderTest.java
@@ -1,0 +1,20 @@
+package dev.openfeature.javasdk;
+
+import org.junit.jupiter.api.Test;
+
+class EventFiringProviderTest {
+    @Test
+    public void test() throws InterruptedException {
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+        api.addEventHooks(new EventHook() {
+            @Override
+            public void onEvent(String event) {
+                System.out.println(event);
+            }
+        });
+        api.setProvider(new EventFiringProvider());
+
+        Thread.sleep(10_000);
+        // You should see "Event was triggered from the provider" scrolling in stdout
+    }
+}


### PR DESCRIPTION
OK, this registers hooks with the global singleton `OpenFeatureApi`. It would probably be better to register the hooks with the `client` instead of the singleton, but this works for the moment. Also, `OpenFeatureAPI` doesn't maintain references to the individual `client`s so it's hard to trigger a callback on the client without some work in that area.

Anyway, It  was a quick look into the mechanism. Many improvements could be made (at the moment, I just registered a hook as receiving a generic string, but we want to properly type it in future)