### PR TITLE
fix: EvaluationContext make constructor public

### DIFF
--- a/src/main/java/dev/openfeature/javasdk/EvaluationContext.java
+++ b/src/main/java/dev/openfeature/javasdk/EvaluationContext.java
@@ -18,7 +18,7 @@ public class EvaluationContext {
     private final Map<String, Boolean> booleanAttributes;
     final Map<String, String> jsonAttributes;
 
-    EvaluationContext() {
+    public EvaluationContext() {
         objMapper = new ObjectMapper();
         this.targetingKey = "";
         this.integerAttributes = new HashMap<>();


### PR DESCRIPTION
The `EvaluationContext` constructor is not public.
I tried this simple class on my side and was not able to use the `EvaluationContext`

```java
package org.gofeatureflag;

import dev.openfeature.javasdk.EvaluationContext;
import dev.openfeature.javasdk.NoOpProvider;
import dev.openfeature.javasdk.OpenFeatureAPI;

public class Main {
    public static void main(String[] args) {
        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
        api.setProvider(new NoOpProvider());
        var client = api.getClient();
        var ctx = new EvaluationContext();
        ctx.setTargetingKey("uniqID");
        client.getBooleanValue("test-flag", Boolean.FALSE, ctx);
    }
}
```

For information, the error I receive is:

```
'EvaluationContext()' is not public in 'dev.openfeature.javasdk.EvaluationContext'. Cannot be accessed from outside package
```

This pull request just make the constructor public.