### PR TITLE
ignore GPG Key for fork repos

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -28,6 +28,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Configure GPG Key
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --import
         env:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,7 +35,12 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify -Dgpg.skip
+        run: |
+        if [ ${{ github.event.pull_request.head.repo.full_name }} = ${{ github.repository }} ]; then
+          mvn --batch-mode --update-snapshots verify
+        else
+          mvn --batch-mode --update-snapshots verify -Dgpg.skip
+        fi
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,7 +35,7 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots
+        run: mvn --batch-mode
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,7 +35,7 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify
+        run: mvn --batch-mode --update-snapshots
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,7 +35,7 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
 
       - name: Build with Maven
-        run: mvn --batch-mode
+        run: mvn --batch-mode --update-snapshots verify -Dgpg.skip
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Build with Maven
         run: |
-        if [ ${{ github.event.pull_request.head.repo.full_name }} = ${{ github.repository }} ]; then
-          mvn --batch-mode --update-snapshots verify
-        else
-          mvn --batch-mode --update-snapshots verify -Dgpg.skip
-        fi
+          if [ ${{ github.event.pull_request.head.repo.full_name }} = ${{ github.repository }} ]; then
+            mvn --batch-mode --update-snapshots verify
+          else
+            mvn --batch-mode --update-snapshots verify -Dgpg.skip
+          fi
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
This PR ensures that we are signing the jar in our pull request only if it is not a fork repo.