### PR TITLE
fix merge of eval context targeting key

### DIFF
--- a/src/main/java/dev/openfeature/javasdk/EvaluationContext.java
+++ b/src/main/java/dev/openfeature/javasdk/EvaluationContext.java
@@ -133,11 +133,11 @@ public class EvaluationContext {
         ec.attributes.putAll(ctx1.attributes);
         ec.attributes.putAll(ctx2.attributes);
 
-        if (ctx1.getTargetingKey() != null) {
+        if (ctx1.getTargetingKey() != null && !ctx1.getTargetingKey().equals("")) {
             ec.setTargetingKey(ctx1.getTargetingKey());
         }
 
-        if (ctx2.getTargetingKey() != null) {
+        if (ctx2.getTargetingKey() != null && !ctx2.getTargetingKey().equals("")) {
             ec.setTargetingKey(ctx2.getTargetingKey());
         }
 

--- a/src/main/java/dev/openfeature/javasdk/EvaluationContext.java
+++ b/src/main/java/dev/openfeature/javasdk/EvaluationContext.java
@@ -133,11 +133,11 @@ public class EvaluationContext {
         ec.attributes.putAll(ctx1.attributes);
         ec.attributes.putAll(ctx2.attributes);
 
-        if (ctx1.getTargetingKey() != null && !ctx1.getTargetingKey().equals("")) {
+        if (ctx1.getTargetingKey() != null && !ctx1.getTargetingKey().trim().equals("")) {
             ec.setTargetingKey(ctx1.getTargetingKey());
         }
 
-        if (ctx2.getTargetingKey() != null && !ctx2.getTargetingKey().equals("")) {
+        if (ctx2.getTargetingKey() != null && !ctx2.getTargetingKey().trim().equals("")) {
             ec.setTargetingKey(ctx2.getTargetingKey());
         }
 

--- a/src/test/java/dev/openfeature/javasdk/EvalContextTest.java
+++ b/src/test/java/dev/openfeature/javasdk/EvalContextTest.java
@@ -118,4 +118,23 @@ public class EvalContextTest {
                 .addStructureAttribute("str", new Node<Integer>());
         assertEquals(EvaluationContext.class, out.getClass());
     }
+
+    @Test void merge_targeting_key() {
+        String key1 = "key1";
+        EvaluationContext ctx1 = new EvaluationContext();
+        ctx1.setTargetingKey(key1);
+        EvaluationContext ctx2 = new EvaluationContext();
+
+        EvaluationContext ctxMerged = EvaluationContext.merge(ctx1, ctx2);
+        assertEquals(key1, ctxMerged.getTargetingKey());
+
+        String key2 = "key2";
+        ctx2.setTargetingKey(key2);
+        ctxMerged = EvaluationContext.merge(ctx1, ctx2);
+        assertEquals(key2, ctxMerged.getTargetingKey());
+
+        ctx2.setTargetingKey("  ");
+        ctxMerged = EvaluationContext.merge(ctx1, ctx2);
+        assertEquals(key1, ctxMerged.getTargetingKey());
+    }
 }


### PR DESCRIPTION
The evaluation context sets the targeting key to `""` by default in the constructor. Therefore when two contexts are merged the targeting key is never null and these checks are always true. This results in setting the targeting key always to `""` if `ctx2` did not have a targeting key set, regardless if `ctx1` does have it set