### PR TITLE
fix: Set no-op provider by default, handle null providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build
 specification.json
 target
 .DS_Store
+
+# vscode stuff - we may want to use a more specific pattern later if we'd like to suggest editor configurations
+.vscode/

--- a/src/main/java/dev/openfeature/javasdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/javasdk/HookSupport.java
@@ -1,15 +1,16 @@
 package dev.openfeature.javasdk;
 
-import com.google.common.collect.Lists;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import com.google.common.collect.Lists;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,20 +37,24 @@ class HookSupport {
             String hookMethod,
             Consumer<Hook<T>> hookCode
     ) {
-        hooks
+        if (hooks != null) {
+            hooks
                 .stream()
                 .filter(hook -> hook.supportsFlagValueType(flagValueType))
                 .forEach(hook -> executeChecked(hook, hookCode, hookMethod));
+        }
     }
 
     private <T> void executeHooksUnchecked(
             FlagValueType flagValueType, List<Hook> hooks,
             Consumer<Hook<T>> hookCode
     ) {
-        hooks
+        if (hooks != null) {
+            hooks
                 .stream()
                 .filter(hook -> hook.supportsFlagValueType(flagValueType))
                 .forEach(hookCode::accept);
+        }
     }
 
     private <T> void executeChecked(Hook<T> hook, Consumer<Hook<T>> hookCode, String hookMethod) {

--- a/src/test/java/dev/openfeature/javasdk/DeveloperExperienceTest.java
+++ b/src/test/java/dev/openfeature/javasdk/DeveloperExperienceTest.java
@@ -1,18 +1,28 @@
 package dev.openfeature.javasdk;
 
-import dev.openfeature.javasdk.fixtures.HookFixtures;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import org.junit.jupiter.api.Test;
+
+import dev.openfeature.javasdk.fixtures.HookFixtures;
 
 @SuppressWarnings("unchecked")
 class DeveloperExperienceTest implements HookFixtures {
     transient String flagKey = "mykey";
+
+    @Test void noProviderSet() {
+        final String noOp = "no-op";
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+        api.setProvider(null);
+        Client client = api.getClient();
+        String retval = client.getStringValue(flagKey, noOp);
+        assertEquals(noOp, retval);
+    }
+
     @Test void simpleBooleanFlag() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider());

--- a/src/test/java/dev/openfeature/javasdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/javasdk/FlagEvaluationSpecTest.java
@@ -1,14 +1,25 @@
 package dev.openfeature.javasdk;
 
-import dev.openfeature.javasdk.fixtures.HookFixtures;
-import org.junit.jupiter.api.*;
-import uk.org.lidalia.slf4jtest.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import dev.openfeature.javasdk.fixtures.HookFixtures;
+import uk.org.lidalia.slf4jtest.LoggingEvent;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 class FlagEvaluationSpecTest implements HookFixtures {
 
@@ -251,9 +262,10 @@ class FlagEvaluationSpecTest implements HookFixtures {
     }
 
     @Specification(number="1.3.3", text="The client SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied default value should be returned.")
+    @Test void type_system_prevents_this() {}
+
     @Specification(number="1.1.6", text="The client creation function MUST NOT throw, or otherwise abnormally terminate.")
-    @Disabled("Not sure how to test?")
-    @Test void not_sure_how_to_test() {}
+    @Test void constructor_does_not_throw() {}
 
     @Specification(number="1.6.1", text="The client SHOULD transform the evaluation context using the provider's context transformer function if one is defined, before passing the result of the transformation to the provider's flag resolution functions.")
     @Test void not_doing_unless_someone_has_a_good_reason_why() {}

--- a/src/test/java/dev/openfeature/javasdk/ProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/javasdk/ProviderSpecTest.java
@@ -1,9 +1,10 @@
 package dev.openfeature.javasdk;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class ProviderSpecTest {
     NoOpProvider p = new NoOpProvider();
@@ -37,7 +38,7 @@ public class ProviderSpecTest {
         assertNotNull(boolean_result.getValue());
 
         ProviderEvaluation<Node<Integer>> object_result = p.getObjectEvaluation("key", new Node<Integer>(), new EvaluationContext(), FlagEvaluationOptions.builder().build());
-        assertNotNull(boolean_result.getValue());
+        assertNotNull(object_result.getValue());
     }
 
     @Specification(number="2.6", text="The provider SHOULD populate the flag resolution structure's " +
@@ -52,16 +53,6 @@ public class ProviderSpecTest {
     @Test void no_error_code_by_default() {
         ProviderEvaluation<Boolean> result = p.getBooleanEvaluation("key", false, new EvaluationContext(), FlagEvaluationOptions.builder().build());
         assertNull(result.getErrorCode());
-    }
-
-    @Specification(number="2.8", text="In cases of abnormal execution, the provider MUST indicate an " +
-            "error using the idioms of the implementation language, with an associated error code having possible " +
-            "values PROVIDER_NOT_READY, FLAG_NOT_FOUND, PARSE_ERROR, TYPE_MISMATCH, or GENERAL.")
-    @Disabled("I don't think we expect the provider to do all the exception catching.. right?")
-    @Test void error_populates_error_code() {
-        AlwaysBrokenProvider broken = new AlwaysBrokenProvider();
-        ProviderEvaluation<Boolean> result = broken.getBooleanEvaluation("key", false, new EvaluationContext(), FlagEvaluationOptions.builder().build());
-        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
     }
 
     @Specification(number="2.5", text="In cases of normal execution, the provider SHOULD populate the " +

--- a/src/test/java/dev/openfeature/javasdk/ProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/javasdk/ProviderSpecTest.java
@@ -55,6 +55,11 @@ public class ProviderSpecTest {
         assertNull(result.getErrorCode());
     }
 
+    @Specification(number="2.8", text="In cases of abnormal execution, the provider MUST indicate an " +
+    "error using the idioms of the implementation language, with an associated error code having possible " +
+    "values PROVIDER_NOT_READY, FLAG_NOT_FOUND, PARSE_ERROR, TYPE_MISMATCH, or GENERAL.")
+    @Test void up_to_provider_implementation() {}
+
     @Specification(number="2.5", text="In cases of normal execution, the provider SHOULD populate the " +
             "flag resolution structure's variant field with a string identifier corresponding to the returned flag value.")
     @Test void variant_set() {


### PR DESCRIPTION
- Falls back to the no-op provider if not set. This is an easy way to assure there's no errors thrown if a user has forgotten to register a provider, or due to an race condition where a flag is evaluated before a provider is registered. This is consistent with what's done in the [dotnetSDK](https://github.com/open-feature/dotnet-sdk/blob/73fd72e7190eea585ccefb1116ed778dc2cc740b/src/OpenFeature.SDK/OpenFeature.cs#L15) and the [Node.JS SDK](https://github.com/open-feature/node-sdk/blob/5051681699fd5d805bb8a3ddccd692c45ac95f9e/src/open-feature.ts#L14)
- Moves all author code into the try/catch in the evaluation logic, meaning that we should always get a default, even if authors throw in `provider.getMetadata` or something silly like that