### PR TITLE
fix: update provider object eval, T -> Structure

### DIFF
--- a/src/main/java/dev/openfeature/javasdk/FeatureProvider.java
+++ b/src/main/java/dev/openfeature/javasdk/FeatureProvider.java
@@ -25,6 +25,6 @@ public interface FeatureProvider {
     ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx,
                                                    FlagEvaluationOptions options);
 
-    <T> ProviderEvaluation<T> getObjectEvaluation(String key, T defaultValue, EvaluationContext invocationContext,
-                                                  FlagEvaluationOptions options);
+    ProviderEvaluation<Structure> getObjectEvaluation(String key, Structure defaultValue,
+                                                    EvaluationContext invocationContext, FlagEvaluationOptions options);
 }

--- a/src/main/java/dev/openfeature/javasdk/NoOpProvider.java
+++ b/src/main/java/dev/openfeature/javasdk/NoOpProvider.java
@@ -61,10 +61,10 @@ public class NoOpProvider implements FeatureProvider {
     }
 
     @Override
-    public <T> ProviderEvaluation<T> getObjectEvaluation(String key, T defaultValue,
+    public ProviderEvaluation<Structure> getObjectEvaluation(String key, Structure defaultValue,
                                                          EvaluationContext invocationContext,
                                                          FlagEvaluationOptions options) {
-        return ProviderEvaluation.<T>builder()
+        return ProviderEvaluation.<Structure>builder()
                 .value(defaultValue)
                 .variant(PASSED_IN_DEFAULT)
                 .reason(Reason.DEFAULT)

--- a/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
@@ -123,7 +123,7 @@ public class OpenFeatureClient implements Client {
             case DOUBLE:
                 return provider.getDoubleEvaluation(key, (Double) defaultValue, invocationContext, options);
             case OBJECT:
-                return provider.getObjectEvaluation(key, defaultValue, invocationContext, options);
+                return provider.getObjectEvaluation(key, (Structure) defaultValue, invocationContext, options);
             default:
                 throw new GeneralError("Unknown flag type");
         }

--- a/src/test/java/dev/openfeature/javasdk/AlwaysBrokenProvider.java
+++ b/src/test/java/dev/openfeature/javasdk/AlwaysBrokenProvider.java
@@ -33,7 +33,7 @@ public class AlwaysBrokenProvider implements FeatureProvider {
     }
 
     @Override
-    public <T> ProviderEvaluation<T> getObjectEvaluation(String key, T defaultValue, EvaluationContext invocationContext, FlagEvaluationOptions options) {
+    public ProviderEvaluation<Structure> getObjectEvaluation(String key, Structure defaultValue, EvaluationContext invocationContext, FlagEvaluationOptions options) {
         throw new NotImplementedException("BORK");
     }
 }

--- a/src/test/java/dev/openfeature/javasdk/DoSomethingProvider.java
+++ b/src/test/java/dev/openfeature/javasdk/DoSomethingProvider.java
@@ -44,9 +44,9 @@ public class DoSomethingProvider implements FeatureProvider {
     }
 
     @Override
-    public <T> ProviderEvaluation<T> getObjectEvaluation(String key, T defaultValue, EvaluationContext invocationContext, FlagEvaluationOptions options) {
+    public ProviderEvaluation<Structure> getObjectEvaluation(String key, Structure defaultValue, EvaluationContext invocationContext, FlagEvaluationOptions options) {
         savedContext = invocationContext;
-        return ProviderEvaluation.<T>builder()
+        return ProviderEvaluation.<Structure>builder()
                 .value(null)
                 .build();
     }


### PR DESCRIPTION
I neglected to change T -> Structure in the `FeatureProvider` interface (I only got the `Features` interface which corresponds to the evaluation API) in https://github.com/open-feature/java-sdk/pull/51. T is so permissive, that it was easy to miss since there wasn't compilation errors.

We certainly want the type in the provider to match the evaluation API.

Since this just changes generics, I believe there is no runtime changes here.