### PR TITLE
use mvn version to remove -SNAPSHOT, bump 0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,14 @@ jobs:
         echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --import
       env:
         GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      
+    - name: Remove SNAPSHOT
+      run: mvn versions:set -DremoveSnapshot
 
     - name: Deploy
-      run: |        
+      run: |
         mvn --batch-mode \
-          --settings release/m2-settings.xml clean deploy -Dversion.modifier=''
+          --settings release/m2-settings.xml clean deploy
       env:
         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ class MyClass {
 <dependency>
     <groupId>dev.openfeature</groupId>
     <artifactId>javasdk</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ If you would like snapshot builds, this is the relevant repository information:
 #### Gradle
 ```groovy
 dependencies {
-    implementation 'dev.openfeature:javasdk:0.1.0'
+    implementation 'dev.openfeature:javasdk:0.1.1'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,9 @@
 
   <groupId>dev.openfeature</groupId>
   <artifactId>javasdk</artifactId>
-  <version>0.1.0${version.modifier}</version>
+  <version>0.1.1-SNAPSHOT</version>
 
   <properties>
-    <!-- During releases, we override this to make it empty -->
-    <version.modifier>-SNAPSHOT</version.modifier>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>


### PR DESCRIPTION
An expression in the `version` attr (e.g. `<version>0.1.0${version.modifier}</version>`) is causing [issues](https://github.com/open-feature/java-sdk/issues/56#issuecomment-1236223635) for gradle.

Instead of using expressions in the pom, this PR modifies the release action to use `mvn versions:set -DremoveSnapshot` to remove the `-SNAPSHOT` modifier, which is built-in functionality of the maven version plugin.

I think long term, we want to move to [release please](https://github.com/googleapis/release-please) for a few reasons:

- it uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to keep track of when we should consider versions breaking
- it can be configured to update all instances of a version, across all files in the repo (so even our readme will be updated correctly)
- it keeps a running PR of the potential release, so we can democratically and transparently decide when to cut one.
- other OpenFeature SDKs and contribs are already using it

For now I'm just doing this, which is a quick fix.