### PR TITLE
!feat: Make evaluation accessors setters consistent

### DIFF
--- a/src/main/java/dev/openfeature/javasdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/javasdk/OpenFeatureAPI.java
@@ -19,7 +19,7 @@ public class OpenFeatureAPI {
     private FeatureProvider provider;
     @Getter
     @Setter
-    private EvaluationContext ctx;
+    private EvaluationContext evaluationContext;
     @Getter
     private List<Hook> apiHooks;
 

--- a/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/javasdk/OpenFeatureClient.java
@@ -78,7 +78,7 @@ public class OpenFeatureClient implements Client {
             // merge of: API.context, client.context, invocation.context
             EvaluationContext mergedCtx = EvaluationContext.merge(
                     EvaluationContext.merge(
-                            openfeatureApi.getCtx(),
+                            openfeatureApi.getEvaluationContext(),
                             this.getEvaluationContext()
                     ),
                     invocationCtx

--- a/src/test/java/dev/openfeature/javasdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/javasdk/FlagEvaluationSpecTest.java
@@ -33,7 +33,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
 
     @AfterEach void reset_ctx() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-        api.setCtx(null);
+        api.setEvaluationContext(null);
     }
 
     @Specification(number="1.1.1", text="The API, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the API are present at runtime.")
@@ -235,7 +235,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
         apiCtx.add("common", "1");
         apiCtx.add("common2", "1");
         apiCtx.add("api", "2");
-        api.setCtx(apiCtx);
+        api.setEvaluationContext(apiCtx);
 
         Client c = api.getClient();
         EvaluationContext clientCtx = new EvaluationContext();


### PR DESCRIPTION
BREAKING: We had `setCtx()` on the global API and `setEvaluationContext()` on the client. This PR makes them both:  `setEvaluationContext()`

We don't have to do this, but since we already have breaking changes for the next release, I think it makes sense. Let me know if the previous was was intentional.