### PR TITLE
fix!: add rw locks to client/api, hook accessor name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
           <argLine>
             ${surefireArgLine}
           </argLine>
-          <!-- fork a new JVM to isolate test suites, especially import with singletons -->
+          <!-- fork a new JVM to isolate test suites, especially important with singletons -->
           <forkCount>${cpu.count}</forkCount>
           <reuseForks>false</reuseForks>
           <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,21 @@
     <plugins>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <id>get-cpu-count</id>
+            <goals>
+              <goal>cpu-count</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
         <version>2.7.2</version>
@@ -231,6 +246,9 @@
           <argLine>
             ${surefireArgLine}
           </argLine>
+          <!-- fork a new JVM to isolate test suites, especially import with singletons -->
+          <forkCount>${cpu.count}</forkCount>
+          <reuseForks>false</reuseForks>
           <excludes>
             <!-- tests to exclude -->
             <exclude>${testExclusions}</exclude>

--- a/spotbugs-exclusions.xml
+++ b/spotbugs-exclusions.xml
@@ -9,11 +9,16 @@
         <Class name="dev.openfeature.sdk.OpenFeatureAPI"/>
         <Bug pattern="MS_EXPOSE_REP"/>
     </And>
-    <!-- similarly, client using the singleton doesn't seem bad -->
+    <!-- evaluation context is mutable if mutable impl is used -->
     <And>
         <Class name="dev.openfeature.sdk.OpenFeatureClient"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </And>
+    <And>
+        <Class name="dev.openfeature.sdk.OpenFeatureAPI"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </And>
+
 
     <!-- Test class that should be excluded -->
     <Match>

--- a/spotbugs-exclusions.xml
+++ b/spotbugs-exclusions.xml
@@ -9,15 +9,25 @@
         <Class name="dev.openfeature.sdk.OpenFeatureAPI"/>
         <Bug pattern="MS_EXPOSE_REP"/>
     </And>
-    <!-- evaluation context is mutable if mutable impl is used -->
+    <!-- evaluation context and hooks are mutable if mutable impl is used -->
+    <And>
+        <Class name="dev.openfeature.sdk.OpenFeatureClient"/>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </And>
     <And>
         <Class name="dev.openfeature.sdk.OpenFeatureClient"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </And>
     <And>
         <Class name="dev.openfeature.sdk.OpenFeatureAPI"/>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </And>
+    <And>
+        <Class name="dev.openfeature.sdk.OpenFeatureAPI"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </And>
+
+
 
 
     <!-- Test class that should be excluded -->

--- a/src/main/java/dev/openfeature/sdk/Client.java
+++ b/src/main/java/dev/openfeature/sdk/Client.java
@@ -32,5 +32,5 @@ public interface Client extends Features {
      * Fetch the hooks associated to this client.
      * @return A list of {@link Hook}s.
      */
-    List<Hook> getClientHooks();
+    List<Hook> getHooks();
 }

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -8,7 +8,6 @@ import javax.annotation.Nullable;
 
 import dev.openfeature.sdk.internal.AutoCloseableLock;
 import dev.openfeature.sdk.internal.AutoCloseableReentrantReadWriteLock;
-import lombok.Getter;
 
 /**
  * A global singleton which holds base configuration for the OpenFeature library.
@@ -16,12 +15,11 @@ import lombok.Getter;
  */
 public class OpenFeatureAPI {
     // package-private multi-read/single-write lock
-    static AutoCloseableReentrantReadWriteLock rwLock = new AutoCloseableReentrantReadWriteLock();
-    @Getter
+    static AutoCloseableReentrantReadWriteLock hooksLock = new AutoCloseableReentrantReadWriteLock();
+    static AutoCloseableReentrantReadWriteLock providerLock = new AutoCloseableReentrantReadWriteLock();
+    static AutoCloseableReentrantReadWriteLock contextLock = new AutoCloseableReentrantReadWriteLock();
     private FeatureProvider provider;
-    @Getter
     private EvaluationContext evaluationContext;
-    @Getter
     private List<Hook> apiHooks;
 
     private OpenFeatureAPI() {
@@ -60,7 +58,7 @@ public class OpenFeatureAPI {
      * {@inheritDoc}
      */
     public void setEvaluationContext(EvaluationContext evaluationContext) {
-        try (AutoCloseableLock __ = rwLock.writeLockAutoCloseable()) {
+        try (AutoCloseableLock __ = contextLock.writeLockAutoCloseable()) {
             this.evaluationContext = evaluationContext;
         }
     }
@@ -68,8 +66,17 @@ public class OpenFeatureAPI {
     /**
      * {@inheritDoc}
      */
+    public EvaluationContext getEvaluationContext() {
+        try (AutoCloseableLock __ = contextLock.readLockAutoCloseable()) {
+            return this.evaluationContext;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void setProvider(FeatureProvider provider) {
-        try (AutoCloseableLock __ = rwLock.writeLockAutoCloseable()) {
+        try (AutoCloseableLock __ = providerLock.writeLockAutoCloseable()) {
             this.provider = provider;
         }
     }
@@ -77,8 +84,17 @@ public class OpenFeatureAPI {
     /**
      * {@inheritDoc}
      */
+    public FeatureProvider getProvider() {
+        try (AutoCloseableLock __ = providerLock.readLockAutoCloseable()) {
+            return this.provider;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void addHooks(Hook... hooks) {
-        try (AutoCloseableLock __ = rwLock.writeLockAutoCloseable()) {
+        try (AutoCloseableLock __ = hooksLock.writeLockAutoCloseable()) {
             this.apiHooks.addAll(Arrays.asList(hooks));
         }
     }
@@ -86,8 +102,17 @@ public class OpenFeatureAPI {
     /**
      * {@inheritDoc}
      */
+    public List<Hook> getHooks() {
+        try (AutoCloseableLock __ = hooksLock.readLockAutoCloseable()) {
+            return this.apiHooks;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void clearHooks() {
-        try (AutoCloseableLock __ = rwLock.writeLockAutoCloseable()) {
+        try (AutoCloseableLock __ = hooksLock.writeLockAutoCloseable()) {
             this.apiHooks.clear();
         }
     }

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -9,7 +9,6 @@ import javax.annotation.Nullable;
 import dev.openfeature.sdk.internal.AutoCloseableLock;
 import dev.openfeature.sdk.internal.AutoCloseableReentrantReadWriteLock;
 import lombok.Getter;
-import lombok.Setter;
 
 /**
  * A global singleton which holds base configuration for the OpenFeature library.
@@ -21,7 +20,6 @@ public class OpenFeatureAPI {
     @Getter
     private FeatureProvider provider;
     @Getter
-    @Setter
     private EvaluationContext evaluationContext;
     @Getter
     private List<Hook> apiHooks;
@@ -56,6 +54,15 @@ public class OpenFeatureAPI {
 
     public Client getClient(@Nullable String name, @Nullable String version) {
         return new OpenFeatureClient(this, name, version);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setEvaluationContext(EvaluationContext evaluationContext) {
+        try (AutoCloseableLock __ = rwLock.writeLockAutoCloseable()) {
+            this.evaluationContext = evaluationContext;
+        }
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -85,7 +85,7 @@ public class OpenFeatureClient implements Client {
             EvaluationContext clientContext;
 
             // lock while getting the provider and hooks
-            // the retrieval any mutable state on client/API MUST be done in this block.
+            // the retrieval of any mutable state on client/API MUST be done in this block.
             try (AutoCloseableLock __ = OpenFeatureAPI.rwLock.readLockAutoCloseable();
                     AutoCloseableLock ___ = this.rwLock.readLockAutoCloseable()) {
                 provider = ObjectUtils.defaultIfNull(openfeatureApi.getProvider(), () -> {

--- a/src/main/java/dev/openfeature/sdk/internal/AutoCloseableLock.java
+++ b/src/main/java/dev/openfeature/sdk/internal/AutoCloseableLock.java
@@ -1,0 +1,10 @@
+package dev.openfeature.sdk.internal;
+
+public interface AutoCloseableLock extends AutoCloseable {
+    
+    /**
+     * Override the exception in AutoClosable.
+     */
+    @Override
+    void close();
+}

--- a/src/main/java/dev/openfeature/sdk/internal/AutoCloseableReentrantReadWriteLock.java
+++ b/src/main/java/dev/openfeature/sdk/internal/AutoCloseableReentrantReadWriteLock.java
@@ -1,0 +1,28 @@
+package dev.openfeature.sdk.internal;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A utility class that wraps a multi-read/single-write lock construct as AutoCloseable, so it can
+ * be used in a try-with-resources.
+ */
+public class AutoCloseableReentrantReadWriteLock extends ReentrantReadWriteLock {
+
+    /**
+     * Get the single write lock as an AutoCloseableLock.
+     * @return unlock method ref
+     */
+    public AutoCloseableLock writeLockAutoCloseable() {
+        this.writeLock().lock();
+        return this.writeLock()::unlock;
+    }
+
+    /**
+     * Get the multi read lock as an AutoCloseableLock.
+     * @return unlock method ref
+     */
+    public AutoCloseableLock readLockAutoCloseable() {
+        this.readLock().lock();
+        return this.readLock()::unlock;
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
+++ b/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
@@ -2,6 +2,7 @@ package dev.openfeature.sdk;
 
 public class DoSomethingProvider implements FeatureProvider {
 
+    public static final String name = "Something";
     private EvaluationContext savedContext;
 
     public EvaluationContext getMergedContext() {
@@ -10,7 +11,7 @@ public class DoSomethingProvider implements FeatureProvider {
 
     @Override
     public Metadata getMetadata() {
-        return () -> "test";
+        return () -> name;
     }
 
     @Override

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -53,7 +53,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
     @Test void provider_metadata() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new DoSomethingProvider());
-        assertEquals("test", api.getProviderMetadata().getName());
+        assertEquals(DoSomethingProvider.name, api.getProviderMetadata().getName());
     }
 
     @Specification(number="1.1.3", text="The API MUST provide a function to add hooks which accepts one or more API-conformant hooks, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -63,12 +63,12 @@ class FlagEvaluationSpecTest implements HookFixtures {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.addHooks(h1);
 
-        assertEquals(1, api.getApiHooks().size());
-        assertEquals(h1, api.getApiHooks().get(0));
+        assertEquals(1, api.getHooks().size());
+        assertEquals(h1, api.getHooks().get(0));
 
         api.addHooks(h2);
-        assertEquals(2, api.getApiHooks().size());
-        assertEquals(h2, api.getApiHooks().get(1));
+        assertEquals(2, api.getHooks().size());
+        assertEquals(h2, api.getHooks().get(1));
     }
 
     @Specification(number="1.1.5", text="The API MUST provide a function for creating a client which accepts the following options:  - name (optional): A logical string identifier for the client.")
@@ -85,7 +85,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
         Hook m2 = mock(Hook.class);
         c.addHooks(m1);
         c.addHooks(m2);
-        List<Hook> hooks = c.getClientHooks();
+        List<Hook> hooks = c.getHooks();
         assertEquals(2, hooks.size());
         assertTrue(hooks.contains(m1));
         assertTrue(hooks.contains(m2));

--- a/src/test/java/dev/openfeature/sdk/LockingTest.java
+++ b/src/test/java/dev/openfeature/sdk/LockingTest.java
@@ -45,15 +45,6 @@ class LockingTest {
         client.hooksLock = clientHooksLock;
     }
 
-    // @Test
-    // void evaluationShouldReadLockandReadUnlockClientAndApi() {
-    //     client.getBooleanValue("a-key", false);
-    //     verify(clientHooksLock.readLock()).lock();
-    //     verify(clientHooksLock.readLock()).unlock();
-    //     verify(clientContextLock.readLock()).lock();
-    //     verify(clientContextLock.readLock()).unlock();
-    // }
-
     @Test
     void addHooksShouldWriteLockAndUnlock() {
         client.addHooks(new Hook() {

--- a/src/test/java/dev/openfeature/sdk/LockingTest.java
+++ b/src/test/java/dev/openfeature/sdk/LockingTest.java
@@ -1,0 +1,117 @@
+package dev.openfeature.sdk;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.openfeature.sdk.internal.AutoCloseableReentrantReadWriteLock;
+
+class LockingTest {
+
+    private static OpenFeatureAPI api;
+    private OpenFeatureClient client;
+    private AutoCloseableReentrantReadWriteLock apiRwLock;
+    private AutoCloseableReentrantReadWriteLock clientRwLock;
+    private ReentrantReadWriteLock.ReadLock mockClientReadLock;
+    private ReentrantReadWriteLock.WriteLock mockClientWriteLock;
+    private ReentrantReadWriteLock.ReadLock mockApiReadLock;
+    private ReentrantReadWriteLock.WriteLock mockApiWriteLock;
+
+    @BeforeAll
+    static void beforeAll() {
+        api = OpenFeatureAPI.getInstance();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        client = (OpenFeatureClient)api.getClient();
+
+        // mock the inner read and write locks
+        mockClientReadLock = mockInnerReadLock();
+        mockClientWriteLock = mockInnerWriteLock();
+        mockApiReadLock = mockInnerReadLock();
+        mockApiWriteLock = mockInnerWriteLock();
+
+        // mock the client rwLock
+        clientRwLock = mock(AutoCloseableReentrantReadWriteLock.class);
+        when(clientRwLock.readLockAutoCloseable()).thenCallRealMethod();
+        when(clientRwLock.readLock()).thenReturn(mockClientReadLock);
+        when(clientRwLock.writeLockAutoCloseable()).thenCallRealMethod();
+        when(clientRwLock.writeLock()).thenReturn(mockClientWriteLock);
+        client.rwLock = clientRwLock;
+
+        // mock the API rwLock
+        apiRwLock = mock(AutoCloseableReentrantReadWriteLock.class);
+        when(apiRwLock.readLockAutoCloseable()).thenCallRealMethod();
+        when(apiRwLock.readLock()).thenReturn(mockApiReadLock);
+        when(apiRwLock.writeLockAutoCloseable()).thenCallRealMethod();
+        when(apiRwLock.writeLock()).thenReturn(mockApiWriteLock);
+        OpenFeatureAPI.rwLock = apiRwLock;
+    }
+
+    @Test
+    void evaluationShouldReadLockandReadUnlockClientAndApi() {
+        client.getBooleanValue("a-key", false);
+        verify(mockApiReadLock).lock();
+        verify(mockApiReadLock).unlock();
+        verify(mockClientReadLock).lock();
+        verify(mockClientReadLock).unlock();
+    }
+
+    @Test
+    void addHooksShouldWriteLockAndUnlock() {
+        client.addHooks(new Hook(){});
+        verify(mockClientWriteLock).lock();
+        verify(mockClientWriteLock).unlock();
+
+        api.addHooks(new Hook(){});
+        verify(mockApiWriteLock).lock();
+        verify(mockApiWriteLock).unlock();
+    }
+
+    @Test
+    void setContextShouldWriteLockAndUnlock() {
+        client.setEvaluationContext(new MutableContext());
+        verify(mockClientWriteLock).lock();
+        verify(mockClientWriteLock).unlock();
+
+        api.setEvaluationContext(new MutableContext());
+        verify(mockApiWriteLock).lock();
+        verify(mockApiWriteLock).unlock();
+    }
+
+    @Test
+    void setProviderShouldWriteLockAndUnlock() {
+        api.setProvider(new DoSomethingProvider());
+        verify(mockApiWriteLock).lock();
+        verify(mockApiWriteLock).unlock();
+    }
+
+    @Test
+    void clearHooksShouldWriteLockAndUnlock() {
+        api.clearHooks();
+        verify(mockApiWriteLock).lock();
+        verify(mockApiWriteLock).unlock();
+    }
+
+    private static ReentrantReadWriteLock.ReadLock mockInnerReadLock() {
+        ReentrantReadWriteLock.ReadLock readLockMock = mock(ReentrantReadWriteLock.ReadLock.class);
+        doNothing().when(readLockMock).lock();
+        doNothing().when(readLockMock).unlock();
+        return readLockMock;
+    }
+
+    private static ReentrantReadWriteLock.WriteLock mockInnerWriteLock() {
+        ReentrantReadWriteLock.WriteLock writeLockMock = mock(ReentrantReadWriteLock.WriteLock.class);
+        doNothing().when(writeLockMock).lock();
+        doNothing().when(writeLockMock).unlock();
+        return writeLockMock;
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/LockingTest.java
+++ b/src/test/java/dev/openfeature/sdk/LockingTest.java
@@ -45,14 +45,14 @@ class LockingTest {
         client.hooksLock = clientHooksLock;
     }
 
-    @Test
-    void evaluationShouldReadLockandReadUnlockClientAndApi() {
-        client.getBooleanValue("a-key", false);
-        verify(clientHooksLock.readLock()).lock();
-        verify(clientHooksLock.readLock()).unlock();
-        verify(clientContextLock.readLock()).lock();
-        verify(clientContextLock.readLock()).unlock();
-    }
+    // @Test
+    // void evaluationShouldReadLockandReadUnlockClientAndApi() {
+    //     client.getBooleanValue("a-key", false);
+    //     verify(clientHooksLock.readLock()).lock();
+    //     verify(clientHooksLock.readLock()).unlock();
+    //     verify(clientContextLock.readLock()).lock();
+    //     verify(clientContextLock.readLock()).unlock();
+    // }
 
     @Test
     void addHooksShouldWriteLockAndUnlock() {
@@ -65,6 +65,17 @@ class LockingTest {
         });
         verify(apiHooksLock.writeLock()).lock();
         verify(apiHooksLock.writeLock()).unlock();
+    }
+
+    @Test
+    void getHooksShouldReadLockAndUnlock() {
+        client.getHooks();
+        verify(clientHooksLock.readLock()).lock();
+        verify(clientHooksLock.readLock()).unlock();
+
+        api.getHooks();
+        verify(apiHooksLock.readLock()).lock();
+        verify(apiHooksLock.readLock()).unlock();
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -20,7 +20,7 @@ class OpenFeatureClientTest implements HookFixtures {
         TEST_LOGGER.clear();
         OpenFeatureAPI api = mock(OpenFeatureAPI.class);
         when(api.getProvider()).thenReturn(new DoSomethingProvider());
-        when(api.getApiHooks()).thenReturn(Arrays.asList(mockBooleanHook(), mockStringHook()));
+        when(api.getHooks()).thenReturn(Arrays.asList(mockBooleanHook(), mockStringHook()));
 
         OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
 


### PR DESCRIPTION
This PR adds multi-read/single-write locks to both the global singleton and the client. Particularly it addresses problems relating to the providers/hooks being mutated while an evaluation is occurring. This is especially important since some providers have provider hooks, and if we dont lock, it's possible hooks from proivder1 run on provider2 if an interleaving thread switched the provider.

To make things cleaner and less error-prone, I've created a little wrapper so we can use `try-with-resources` blocks.

This way, locking can be done like:

```
    public void addHooks(Hook... hooks) {
        try (AutoCloseableLock __ = rwLock.writeLockAutoCloseable()) {
            this.apiHooks.addAll(Arrays.asList(hooks));
        }
    }
```

...with no need to explicitly close the lock.

I'm going to write some tests in the morning for this before I mark it as ready.

Closes: https://github.com/open-feature/java-sdk/issues/64