### PR TITLE
chore: exclude component in git tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,8 @@
     ".": {
       "package-name": "dev.openfeature.sdk",
       "release-type": "simple",
+      "monorepo-tags": false,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default",


### PR DESCRIPTION
Release Please will no longer include the component name in the git tag.

Here's an example:

- [Before](https://github.com/open-feature/playground/releases/tag/openfeature-v0.0.9)
- [After](https://github.com/open-feature/playground/releases/tag/v0.1.0)

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>