### PR TITLE
fix: merge eval context

### DIFF
--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -118,7 +118,7 @@ public class OpenFeatureClient implements Client {
             apiContext = openfeatureApi.getEvaluationContext() != null
                     ? openfeatureApi.getEvaluationContext()
                     : new MutableContext();
-            clientContext = openfeatureApi.getEvaluationContext() != null
+            clientContext = this.getEvaluationContext() != null
                     ? this.getEvaluationContext()
                     : new MutableContext();
 


### PR DESCRIPTION
Signed-off-by: Robert Grassian <robert.grassian@split.io>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Fixes merging of eval contexts. Client eval context was ignored due to a bug.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
Added a new test for this in `OpenFeatureClientTest`. It passes with my fix and fails without it.

