### PR TITLE
chore: fix issues with compilation on later JDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ class MyClass {
 For complete documentation, visit: https://docs.openfeature.dev/docs/category/concepts
 
 ## Requirements
-- Java 8+
+- Java 8+ (compiler target is 1.8)
 
 ## Installation
 

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <!-- checkstyle suppressions can go here -->
+</suppressions>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -34,6 +34,7 @@
         <property name="optional" value="true"/>
     </module>
 
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.org/config_whitespace.html -->
     <module name="FileTabCharacter">
@@ -46,7 +47,23 @@
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 
+    <module name="SuppressWarningsFilter" />
+
     <module name="TreeWalker">
+        <!-- needed for SuppressWarningsFilter -->
+        <module name="SuppressWarningsHolder" />
+        
+        <module name="SuppressWarnings">
+            <property name="id" value="checkstyle:suppresswarnings"/>
+        </module>
+
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+                        default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
+    
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
@@ -223,7 +240,7 @@
             <property name="arrayInitIndent" value="4"/>
         </module>
         <module name="AbbreviationAsWordInName">
-            <property name="ignoreFinal" value="false"/>
+            <property name="ignoreFinal" value="true"/>
             <property name="allowedAbbreviations" value="API" />
             <property name="allowedAbbreviationLength" value="1"/>
             <property name="tokens"
@@ -292,6 +309,12 @@
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
         </module>
+        <module name="MissingJavadocType">
+            <property name="scope" value="protected"/>
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+            <property name="excludeScope" value="nothing"/>
+        </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
             <message key="name.invalidPattern"
@@ -306,12 +329,5 @@
         <module name="CommentsIndentation">
             <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
         </module>
-        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
-        <module name="SuppressionXpathFilter">
-            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
-                      default="checkstyle-xpath-suppressions.xml" />
-            <property name="optional" value="true"/>
-        </module>
     </module>
 </module>
-

--- a/pom.xml
+++ b/pom.xml
@@ -369,6 +369,7 @@
         <version>3.4.1</version>
         <configuration>
           <failOnWarnings>true</failOnWarnings>
+          <doclint>all,-missing</doclint>  <!-- ignore missing javadoc, these are enforced with more customizability in the checkstyle plugin -->
         </configuration>
         <executions>
           <execution>

--- a/spotbugs-exclusions.xml
+++ b/spotbugs-exclusions.xml
@@ -27,9 +27,6 @@
         <Bug pattern="EI_EXPOSE_REP2"/>
     </And>
 
-
-
-
     <!-- Test class that should be excluded -->
     <Match>
         <Class name="dev.openfeature.sdk.DoSomethingProvider"/>

--- a/src/main/java/dev/openfeature/sdk/BooleanHook.java
+++ b/src/main/java/dev/openfeature/sdk/BooleanHook.java
@@ -1,5 +1,8 @@
 package dev.openfeature.sdk;
 
+/**
+ * {@inheritDoc}
+ */
 public interface BooleanHook extends Hook<Boolean> {
 
     @Override

--- a/src/main/java/dev/openfeature/sdk/DoubleHook.java
+++ b/src/main/java/dev/openfeature/sdk/DoubleHook.java
@@ -1,5 +1,8 @@
 package dev.openfeature.sdk;
 
+/**
+ * {@inheritDoc}
+ */
 public interface DoubleHook extends Hook<Double> {
 
     @Override

--- a/src/main/java/dev/openfeature/sdk/ErrorCode.java
+++ b/src/main/java/dev/openfeature/sdk/ErrorCode.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 public enum ErrorCode {
     PROVIDER_NOT_READY, FLAG_NOT_FOUND, PARSE_ERROR, TYPE_MISMATCH, TARGETING_KEY_MISSING, INVALID_CONTEXT, GENERAL
 }

--- a/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
+++ b/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
@@ -20,6 +20,7 @@ public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
 
     /**
      * Generate detail payload from the provider response.
+     *
      * @param providerEval provider response
      * @param flagKey key for the flag being evaluated
      * @param <T> type of flag being returned

--- a/src/main/java/dev/openfeature/sdk/FlagEvaluationOptions.java
+++ b/src/main/java/dev/openfeature/sdk/FlagEvaluationOptions.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import lombok.Builder;
 import lombok.Singular;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 @lombok.Value
 @Builder
 public class FlagEvaluationOptions {

--- a/src/main/java/dev/openfeature/sdk/FlagValueType.java
+++ b/src/main/java/dev/openfeature/sdk/FlagValueType.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 public enum FlagValueType {
     STRING, INTEGER, DOUBLE, OBJECT, BOOLEAN;
 }

--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -1,6 +1,9 @@
 package dev.openfeature.sdk;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/src/main/java/dev/openfeature/sdk/IntegerHook.java
+++ b/src/main/java/dev/openfeature/sdk/IntegerHook.java
@@ -1,5 +1,8 @@
 package dev.openfeature.sdk;
 
+/**
+ * {@inheritDoc}
+ */
 public interface IntegerHook extends Hook<Integer> {
 
     @Override

--- a/src/main/java/dev/openfeature/sdk/MutableStructure.java
+++ b/src/main/java/dev/openfeature/sdk/MutableStructure.java
@@ -1,7 +1,10 @@
 package dev.openfeature.sdk;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import dev.openfeature.sdk.exceptions.ValueNotConvertableError;
@@ -16,7 +19,7 @@ import lombok.ToString;
  */
 @ToString
 @EqualsAndHashCode
-@SuppressWarnings("PMD.BeanMembersShouldSerialize")
+@SuppressWarnings({"PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType"})
 public class MutableStructure implements Structure {
 
     protected final Map<String, Value> attributes;
@@ -66,13 +69,6 @@ public class MutableStructure implements Structure {
         return this;
     }
 
-    /**
-     * Add date-time relevant key.
-     *
-     * @param key feature key
-     * @param value date-time value
-     * @return Structure
-     */
     public MutableStructure add(String key, Instant value) {
         attributes.put(key, new Value(value));
         return this;
@@ -116,6 +112,7 @@ public class MutableStructure implements Structure {
 
     /**
      * convertValue is converting the object type Value in a primitive type.
+     *
      * @param value - Value object to convert
      * @return an Object containing the primitive type.
      */

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -14,6 +14,9 @@ import dev.openfeature.sdk.internal.ObjectUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * {@inheritDoc}
+ */
 @Slf4j
 @SuppressWarnings({ "PMD.DataflowAnomalyAnalysis", "PMD.BeanMembersShouldSerialize", "unchecked", "rawtypes" })
 public class OpenFeatureClient implements Client {

--- a/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
@@ -5,6 +5,7 @@ import lombok.Data;
 
 import javax.annotation.Nullable;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 @Data @Builder
 public class ProviderEvaluation<T> implements BaseEvaluation<T> {
     T value;

--- a/src/main/java/dev/openfeature/sdk/Reason.java
+++ b/src/main/java/dev/openfeature/sdk/Reason.java
@@ -1,5 +1,8 @@
 package dev.openfeature.sdk;
 
+/**
+ * Predefined resolution reasons.
+ */
 public enum Reason {
     DISABLED, SPLIT, TARGETING_MATCH, DEFAULT, UNKNOWN, ERROR
 }

--- a/src/main/java/dev/openfeature/sdk/StringHook.java
+++ b/src/main/java/dev/openfeature/sdk/StringHook.java
@@ -1,5 +1,8 @@
 package dev.openfeature.sdk;
 
+/**
+ * {@inheritDoc}
+ */
 public interface StringHook extends Hook<String> {
 
     @Override

--- a/src/main/java/dev/openfeature/sdk/Value.java
+++ b/src/main/java/dev/openfeature/sdk/Value.java
@@ -13,11 +13,14 @@ import lombok.ToString;
  */
 @ToString
 @EqualsAndHashCode
-@SuppressWarnings("PMD.BeanMembersShouldSerialize")
+@SuppressWarnings({"PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType"})
 public class Value {
 
     private final Object innerObject;
 
+    /**
+     * Construct a new null Value.
+     */
     public Value() {
         this.innerObject = null;
     }

--- a/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
@@ -4,6 +4,7 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 @StandardException
 public class FlagNotFoundError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/exceptions/GeneralError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/GeneralError.java
@@ -4,6 +4,7 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 @StandardException
 public class GeneralError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/exceptions/InvalidContextError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/InvalidContextError.java
@@ -4,6 +4,9 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
+/**
+ * The evaluation context does not meet provider requirements.
+ */
 @StandardException
 public class InvalidContextError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.java
@@ -3,6 +3,7 @@ package dev.openfeature.sdk.exceptions;
 import dev.openfeature.sdk.ErrorCode;
 import lombok.experimental.StandardException;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 @StandardException
 public abstract class OpenFeatureError extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/exceptions/ParseError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/ParseError.java
@@ -4,6 +4,9 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
+/**
+ * An error was encountered parsing data, such as a flag configuration.
+ */
 @StandardException
 public class ParseError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/exceptions/TargetingKeyMissingError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/TargetingKeyMissingError.java
@@ -4,6 +4,9 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
+/**
+ * The provider requires a targeting key and one was not provided in the evaluation context.
+ */
 @StandardException
 public class TargetingKeyMissingError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
@@ -4,6 +4,9 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
+/**
+ * The type of the flag value does not match the expected type.
+ */
 @StandardException
 public class TypeMismatchError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/exceptions/ValueNotConvertableError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/ValueNotConvertableError.java
@@ -4,6 +4,9 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
+/**
+ * The value can not be converted to a {@link dev.openfeature.sdk.Value}.
+ */
 @StandardException
 public class ValueNotConvertableError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/dev/openfeature/sdk/internal/AutoCloseableLock.java
+++ b/src/main/java/dev/openfeature/sdk/internal/AutoCloseableLock.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk.internal;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 public interface AutoCloseableLock extends AutoCloseable {
     
     /**

--- a/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
+++ b/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
@@ -1,11 +1,15 @@
 package dev.openfeature.sdk.internal;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.experimental.UtilityClass;
 
+@SuppressWarnings("checkstyle:MissingJavadocType")
 @UtilityClass
 public class ObjectUtils {
 


### PR DESCRIPTION
This just fixes an issue that prevents JDK 11+ from working with our build and adds some associated missing javadoc. This is troublesome if you happen to be working with other projects that require a later version of the JDK.

Specifically, there were changes in later versions of `javac` that applied more rules, mostly around javadoc. These caused errors we could not customize, so I've disabled the lint checks in the `maven-javadoc-plugin` and I instead enforce them with `checkstyle`, which is more customizable.