### PR TITLE
chore: renovate automerge for minor/patch on 1+ pkgs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
This configures renovate to automerge a change if:

- CI passes
- the change is a minor/patch
- the dep version is >= 1.0