### PR TITLE
chore: automerge action updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,13 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "fileMatch": [
+        "^(workflow-templates|\\.github\\/workflows)\\/[^/]+\\.ya?ml$",
+        "(^|\\/)action\\.ya?ml$"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
I believe this will auto-merge action updates on successful CI (see: https://docs.renovatebot.com/modules/manager/github-actions/#default-config)

The risk here is that it breaks an action (or action paths) not used in the PR CI, but I _think_ it's worth it?