### PR TITLE
chore: renovate matchUpdateTypes digest to actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
       "automerge": true
     },
     {
+      "matchUpdateTypes": ["digest"],
       "fileMatch": [
         "^(workflow-templates|\\.github\\/workflows)\\/[^/]+\\.ya?ml$",
         "(^|\\/)action\\.ya?ml$"


### PR DESCRIPTION
Giving this one more shot, otherwise I'll revert the actions auto-merge and just keep it for java deps for now.

Closes: https://github.com/open-feature/java-sdk/issues/201