### PR TITLE
chore: renovate regex manager to monitor test-harness version

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,15 @@ We are also present on the `#openfeature` channel in the [CNCF slack](https://sl
 
 ### Integration tests
 
-The continuous integration runs a set of [gherkin integration tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests do not run with the default maven profile. If you'd like to run them locally, you can start the flagd testbed with `docker run -p 8013:8013 ghcr.io/open-feature/flagd-testbed:latest` and then run `mvn test -P integration-test`.
+The continuous integration runs a set of [gherkin integration tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests do not run with the default maven profile. If you'd like to run them locally, you can start the flagd testbed with
+
+```
+docker run -p 8013:8013 ghcr.io/open-feature/flagd-testbed:latest
+```
+and then run 
+```
+mvn test -P integration-test
+```
 
 ## Releasing
 

--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,13 @@
       "matchManagers": ["github-actions"],
       "automerge": true
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^README.md$", "^.github/workflows/pullrequest.yml$"],
+      "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd-testbed:(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "open-feature/test-harness",
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }


### PR DESCRIPTION


## This PR
<!-- add the description of the PR here -->

Add renovate config to monitor test-harness version and upgrade flagd-testbed image.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #237 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

