### PR TITLE
chore: update test annotations, spec badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/dev.openfeature/sdk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/dev.openfeature/sdk)
 [![javadoc](https://javadoc.io/badge2/dev.openfeature/sdk/javadoc.svg)](https://javadoc.io/doc/dev.openfeature/sdk) 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![v0.5.1](https://img.shields.io/static/v1?label=Specification&message=v0.5.1&color=yellow)](https://github.com/open-feature/spec/tree/v0.5.1)
+[![Specification](https://img.shields.io/static/v1?label=Specification&message=v0.5.2&color=yellow)](https://github.com/open-feature/spec/tree/v0.5.2)
 [![Known Vulnerabilities](https://snyk.io/test/github/open-feature/java-sdk/badge.svg)](https://snyk.io/test/github/open-feature/java-sdk)
 [![on-merge](https://github.com/open-feature/java-sdk/actions/workflows/merge.yml/badge.svg)](https://github.com/open-feature/java-sdk/actions/workflows/merge.yml)
 [![codecov](https://codecov.io/gh/open-feature/java-sdk/branch/main/graph/badge.svg?token=XMS9L7PBY1)](https://codecov.io/gh/open-feature/java-sdk)

--- a/src/test/java/dev/openfeature/sdk/ProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderSpecTest.java
@@ -15,14 +15,9 @@ public class ProviderSpecTest {
 
     @Specification(number="2.2.2.1", text="The feature provider interface MUST define methods for typed " +
             "flag resolution, including boolean, numeric, string, and structure.")
-    @Specification(number="2.2.3", text="In cases of normal execution, the provider MUST populate the " +
-            "flag resolution structure's value field with the resolved flag value.")
-    @Specification(number="2.2.1", text="The feature provider interface MUST define methods to resolve " +
-            "flag values, with parameters flag key (string, required), default value " +
-            "(boolean | number | string | structure, required) and evaluation context (optional), " +
-            "which returns a flag resolution structure.")
-    @Specification(number="2.2.8.1", text="The flag resolution structure SHOULD accept a generic " +
-            "argument (or use an equivalent language feature) which indicates the type of the wrapped value field.")
+    @Specification(number="2.2.3", text="In cases of normal execution, the `provider` MUST populate the `resolution details` structure's `value` field with the resolved flag value.")
+    @Specification(number="2.2.1", text="The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `resolution details` structure.")
+    @Specification(number="2.2.8.1", text="The `resolution details` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.")
     @Test void flag_value_set() {
         ProviderEvaluation<Integer> int_result = p.getIntegerEvaluation("key", 4, new MutableContext());
         assertNotNull(int_result.getValue());
@@ -41,26 +36,24 @@ public class ProviderSpecTest {
 
     }
 
-    @Specification(number="2.2.5", text="The `provider` SHOULD populate the `flag resolution` structure's `reason` field with `\"DEFAULT\",` `\"TARGETING_MATCH\"`, `\"SPLIT\"`, `\"DISABLED\"`, `\"UNKNOWN\"`, `\"ERROR\"` or some other string indicating the semantic reason for the returned flag value.")
+    @Specification(number="2.2.5", text="The `provider` SHOULD populate the `resolution details` structure's `reason` field with `\"STATIC\"`, `\"DEFAULT\",` `\"TARGETING_MATCH\"`, `\"SPLIT\"`, `\"CACHED\"`, `\"DISABLED\"`, `\"UNKNOWN\"`, `\"ERROR\"` or some other string indicating the semantic reason for the returned flag value.")
     @Test void has_reason() {
         ProviderEvaluation<Boolean> result = p.getBooleanEvaluation("key", false, new MutableContext());
         assertEquals(Reason.DEFAULT.toString(), result.getReason());
     }
 
-    @Specification(number="2.2.6", text="In cases of normal execution, the provider MUST NOT populate " +
-            "the flag resolution structure's error code field, or otherwise must populate it with a null or falsy value.")
+    @Specification(number="2.2.6", text="In cases of normal execution, the `provider` MUST NOT populate the `resolution details` structure's `error code` field, or otherwise must populate it with a null or falsy value.")
     @Test void no_error_code_by_default() {
         ProviderEvaluation<Boolean> result = p.getBooleanEvaluation("key", false, new MutableContext());
         assertNull(result.getErrorCode());
     }
 
     @Specification(number="2.2.7", text="In cases of abnormal execution, the `provider` **MUST** indicate an error using the idioms of the implementation language, with an associated `error code` and optional associated `error message`.")
-    @Specification(number="2.3.2", text="In cases of normal execution, the `provider` **MUST NOT** populate the `flag resolution` structure's `error message` field, or otherwise must populate it with a null or falsy value.")
-    @Specification(number="2.3.3", text="In cases of abnormal execution, the `evaluation details` structure's `error message` field **MAY** contain a string containing additional detail about the nature of the error.")
+    @Specification(number="2.3.2", text="In cases of normal execution, the `provider` MUST NOT populate the `resolution details` structure's `error message` field, or otherwise must populate it with a null or falsy value.")
+    @Specification(number="2.3.3", text="In cases of abnormal execution, the `resolution details` structure's `error message` field MAY contain a string containing additional detail about the nature of the error.")
     @Test void up_to_provider_implementation() {}
 
-    @Specification(number="2.2.4", text="In cases of normal execution, the provider SHOULD populate the " +
-            "flag resolution structure's variant field with a string identifier corresponding to the returned flag value.")
+    @Specification(number="2.2.4", text="In cases of normal execution, the `provider` SHOULD populate the `resolution details` structure's `variant` field with a string identifier corresponding to the returned flag value.")
     @Test void variant_set() {
         ProviderEvaluation<Integer> int_result = p.getIntegerEvaluation("key", 4, new MutableContext());
         assertNotNull(int_result.getReason());


### PR DESCRIPTION
Update the test annotations with new spec verbiage, and update the spec compliance badge. The functional changes have already been merged/released.