### PR TITLE
fix: improve error logs for evaluation failure

### DIFF
--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -137,7 +137,7 @@ public class OpenFeatureClient implements Client {
             details = FlagEvaluationDetails.from(providerEval, key);
             hookSupport.afterHooks(type, hookCtx, details, mergedHooks, hints);
         } catch (Exception e) {
-            log.error("Unable to correctly evaluate flag with key {} due to exception {}", key, e.getMessage());
+            log.error("Unable to correctly evaluate flag with key '{}'", key, e);
             if (details == null) {
                 details = FlagEvaluationDetails.<T>builder().build();
             }


### PR DESCRIPTION
## This PR

Fixes #275

Consider the following log entry with detailed logs explaining the underlying issue by logging stacktrace, 

<img width="1360" alt="image" src="https://user-images.githubusercontent.com/8186721/216462684-6922df6f-1d43-4727-a58c-35f4af497a5c.png">


