### PR TITLE
fix: MutableContext and ImmutableContext merge are made recursive

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -88,33 +88,10 @@ public final class ImmutableContext implements EvaluationContext {
             newTargetingKey = overridingContext.getTargetingKey();
         }
 
-        Map<String, Value> merged = this.merge(this.asMap(), overridingContext.asMap());
+        Map<String, Value> merged = this.merge(m -> new ImmutableStructure(m),
+                                               this.asMap(),
+                                               overridingContext.asMap());
 
         return new ImmutableContext(newTargetingKey, merged);
-    }
-
-    /**
-     * Recursively merges the base map from this EvaluationContext with the passed EvaluationContext.
-     * 
-     * @param base base map to merge
-     * @param overriding overriding map to merge
-     * @return resulting merged map
-     */
-    private Map<String, Value> merge(Map<String, Value> base, Map<String, Value> overriding) {
-        Map<String, Value> merged = new HashMap<>();
-
-        merged.putAll(base);
-        for (Entry<String, Value> overridingEntry : overriding.entrySet()) {
-            String key = overridingEntry.getKey();
-            if (overridingEntry.getValue().isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {
-                Structure mergedValue = merged.get(key).asStructure();
-                Structure overridingValue = overridingEntry.getValue().asStructure();
-                Map<String, Value> newMap = this.merge(mergedValue.asMap(), overridingValue.asMap());
-                merged.put(key, new Value(new ImmutableContext(newMap)));
-            } else {
-                merged.put(key, overridingEntry.getValue());
-            }
-        }
-        return merged;
     }
 }

--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -2,6 +2,8 @@ package dev.openfeature.sdk;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Delegate;
@@ -101,15 +103,15 @@ public final class ImmutableContext implements EvaluationContext {
     private Map<String, Value> merge(Map<String, Value> base, Map<String, Value> overriding) {
         Map<String, Value> merged = new HashMap<>();
 
-        merged.putAll(base);
-        for (String key : overriding.keySet()) {
-            if (overriding.get(key).isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {
+        for (Entry<String, Value> overridingEntry : overriding.entrySet()) {
+            String key = overridingEntry.getKey();
+            if (overridingEntry.getValue().isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {
                 Structure mergedValue = merged.get(key).asStructure();
-                Structure overridingValue = overriding.get(key).asStructure();
+                Structure overridingValue = overridingEntry.getValue().asStructure();
                 Map<String, Value> newMap = this.merge(mergedValue.asMap(), overridingValue.asMap());
                 merged.put(key, new Value(new ImmutableContext(newMap)));
             } else {
-                merged.put(key, overriding.get(key));
+                merged.put(key, overridingEntry.getValue());
             }
         }
         return merged;

--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -2,7 +2,6 @@ package dev.openfeature.sdk;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -103,6 +103,7 @@ public final class ImmutableContext implements EvaluationContext {
     private Map<String, Value> merge(Map<String, Value> base, Map<String, Value> overriding) {
         Map<String, Value> merged = new HashMap<>();
 
+        merged.putAll(base);
         for (Entry<String, Value> overridingEntry : overriding.entrySet()) {
             String key = overridingEntry.getKey();
             if (overridingEntry.getValue().isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {

--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -1,10 +1,8 @@
 package dev.openfeature.sdk;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -126,14 +127,15 @@ public class MutableContext implements EvaluationContext {
         Map<String, Value> merged = new HashMap<>();
 
         merged.putAll(base);
-        for (String key : overriding.keySet()) {
-            if (overriding.get(key).isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {
+        for (Entry<String, Value> overridingEntry : overriding.entrySet()) {
+            String key = overridingEntry.getKey();
+            if (overridingEntry.getValue().isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {
                 Structure mergedValue = merged.get(key).asStructure();
-                Structure overridingValue = overriding.get(key).asStructure();
+                Structure overridingValue = overridingEntry.getValue().asStructure();
                 Map<String, Value> newMap = this.merge(mergedValue.asMap(), overridingValue.asMap());
                 merged.put(key, new Value(new MutableContext(newMap)));
             } else {
-                merged.put(key, overriding.get(key));
+                merged.put(key, overridingEntry.getValue());
             }
         }
         return merged;

--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -93,7 +93,9 @@ public class MutableContext implements EvaluationContext {
             return new MutableContext(this.asMap());
         }
 
-        Map<String, Value> merged = this.merge(this.asMap(), overridingContext.asMap());
+        Map<String, Value> merged = this.merge(map -> new MutableStructure(map),
+                                               this.asMap(),
+                                               overridingContext.asMap());
 
         String newTargetingKey = "";
 
@@ -113,32 +115,6 @@ public class MutableContext implements EvaluationContext {
         }
 
         return ec;
-    }
-    
-
-    /**
-     * Recursively merges the base map from this EvaluationContext with the passed EvaluationContext.
-     * 
-     * @param base base map to merge
-     * @param overriding overriding map to merge
-     * @return resulting merged map
-     */
-    private Map<String, Value> merge(Map<String, Value> base, Map<String, Value> overriding) {
-        Map<String, Value> merged = new HashMap<>();
-
-        merged.putAll(base);
-        for (Entry<String, Value> overridingEntry : overriding.entrySet()) {
-            String key = overridingEntry.getKey();
-            if (overridingEntry.getValue().isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {
-                Structure mergedValue = merged.get(key).asStructure();
-                Structure overridingValue = overridingEntry.getValue().asStructure();
-                Map<String, Value> newMap = this.merge(mergedValue.asMap(), overridingValue.asMap());
-                merged.put(key, new Value(new MutableContext(newMap)));
-            } else {
-                merged.put(key, overridingEntry.getValue());
-            }
-        }
-        return merged;
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/Structure.java
+++ b/src/main/java/dev/openfeature/sdk/Structure.java
@@ -95,7 +95,7 @@ public interface Structure {
     }
 
     /**
-     * Recursively merges the base map from this EvaluationContext with the passed EvaluationContext.
+     * Recursively merges the base map with the overriding map.
      * 
      * @param <T> Structure type
      * @param newStructure function to create the right structure

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -103,7 +103,7 @@ class ImmutableContextTest {
         attributes.put("key1", new Value(new ImmutableStructure(key1Attributes)));
         attributes.put("key2", new Value("val2"));
         
-        EvaluationContext ctx = new ImmutableContext("targeting_key", attributes);
+        EvaluationContext ctx = new ImmutableContext(attributes);
         EvaluationContext overriding = new ImmutableContext("");
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -92,4 +92,27 @@ class ImmutableContextTest {
         Structure value = key1.asStructure();
         assertArrayEquals(new Object[]{"key1_1","overriding_key1_1"}, value.keySet().toArray());
     }
+    
+    @DisplayName("Merge should retain subkeys from the existing context when the overriding context doesn't have targeting key")
+    @Test
+    void mergeShouldRetainItsSubkeysWhenOverridingContextHasNoTargetingKey() {
+        HashMap<String, Value> attributes = new HashMap<>();
+        HashMap<String, Value> key1Attributes = new HashMap<>();
+
+        key1Attributes.put("key1_1", new Value("val1_1"));
+        attributes.put("key1", new Value(new ImmutableStructure(key1Attributes)));
+        attributes.put("key2", new Value("val2"));
+        
+        EvaluationContext ctx = new ImmutableContext("targeting_key", attributes);
+        EvaluationContext overriding = new ImmutableContext("");
+        EvaluationContext merge = ctx.merge(overriding);
+        assertEquals("targeting_key", merge.getTargetingKey());
+        assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
+        
+        Value key1 = merge.getValue("key1");
+        assertTrue(key1.isStructure());
+        
+        Structure value = key1.asStructure();
+        assertArrayEquals(new Object[]{"key1_1"}, value.keySet().toArray());
+    }
 }

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -106,7 +106,6 @@ class ImmutableContextTest {
         EvaluationContext ctx = new ImmutableContext(attributes);
         EvaluationContext overriding = new ImmutableContext("");
         EvaluationContext merge = ctx.merge(overriding);
-        assertEquals("targeting_key", merge.getTargetingKey());
         assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
         
         Value key1 = merge.getValue("key1");

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -73,18 +73,22 @@ class ImmutableContextTest {
         HashMap<String, Value> overridingAttributes = new HashMap<>();
         HashMap<String, Value> key1Attributes = new HashMap<>();
         HashMap<String, Value> ovKey1Attributes = new HashMap<>();
+
         key1Attributes.put("key1_1", new Value("val1_1"));
-        attributes.put("key1", new Value(new ImmutableContext(key1Attributes)));
+        attributes.put("key1", new Value(new ImmutableStructure(key1Attributes)));
         attributes.put("key2", new Value("val2"));
         ovKey1Attributes.put("overriding_key1_1", new Value("overriding_val_1_1"));
-        overridingAttributes.put("key1", new Value(new ImmutableContext(ovKey1Attributes)));
+        overridingAttributes.put("key1", new Value(new ImmutableStructure(ovKey1Attributes)));
+        
         EvaluationContext ctx = new ImmutableContext("targeting_key", attributes);
         EvaluationContext overriding = new ImmutableContext("targeting_key", overridingAttributes);
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());
         assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
+        
         Value key1 = merge.getValue("key1");
         assertTrue(key1.isStructure());
+        
         Structure value = key1.asStructure();
         assertArrayEquals(new Object[]{"key1_1","overriding_key1_1"}, value.keySet().toArray());
     }

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -104,7 +104,7 @@ class ImmutableContextTest {
         attributes.put("key2", new Value("val2"));
         
         EvaluationContext ctx = new ImmutableContext(attributes);
-        EvaluationContext overriding = new ImmutableContext("");
+        EvaluationContext overriding = new ImmutableContext();
         EvaluationContext merge = ctx.merge(overriding);
         assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
         

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ImmutableContextTest {
 
@@ -63,5 +64,28 @@ class ImmutableContextTest {
         EvaluationContext merge = ctx.merge(null);
         assertEquals("targeting_key", merge.getTargetingKey());
         assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
+    }
+
+    @DisplayName("Merge should retain subkeys from the existing context when the overriding context has the same targeting key")
+    @Test
+    void mergeShouldRetainItsSubkeysWhenOverridingContextHasTheSameKey() {
+        HashMap<String, Value> attributes = new HashMap<>();
+        HashMap<String, Value> overridingAttributes = new HashMap<>();
+        HashMap<String, Value> key1Attributes = new HashMap<>();
+        HashMap<String, Value> ovKey1Attributes = new HashMap<>();
+        key1Attributes.put("key1_1", new Value("val1_1"));
+        attributes.put("key1", new Value(new ImmutableContext(key1Attributes)));
+        attributes.put("key2", new Value("val2"));
+        ovKey1Attributes.put("overriding_key1_1", new Value("overriding_val_1_1"));
+        overridingAttributes.put("key1", new Value(new ImmutableContext(ovKey1Attributes)));
+        EvaluationContext ctx = new ImmutableContext("targeting_key", attributes);
+        EvaluationContext overriding = new ImmutableContext("targeting_key", overridingAttributes);
+        EvaluationContext merge = ctx.merge(overriding);
+        assertEquals("targeting_key", merge.getTargetingKey());
+        assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
+        Value key1 = merge.getValue("key1");
+        assertTrue(key1.isStructure());
+        Structure value = key1.asStructure();
+        assertArrayEquals(new Object[]{"key1_1","overriding_key1_1"}, value.keySet().toArray());
     }
 }


### PR DESCRIPTION
Signed-off-by: Javier Collado <javicv@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Makes the evaluation context merge recursive for both MutableContext and ImmutableContext

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #270

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
- A new test method _mergeShouldRetainItsSubkeysWhenOverridingContextHasTheSameKey_ in _dev.openfeature.sdk.ImmutableContextTest_ has been added
