### PR TITLE
feat: remove the deprecated setTargetingKey method in EvaluationContext.

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EvaluationContext.java
+++ b/src/main/java/dev/openfeature/sdk/EvaluationContext.java
@@ -7,12 +7,6 @@ package dev.openfeature.sdk;
 @SuppressWarnings("PMD.BeanMembersShouldSerialize")
 public interface EvaluationContext extends Structure {
     String getTargetingKey();
-    
-    /**
-     * Mutating targeting key is not supported in all implementations and will be removed.
-     */
-    @Deprecated
-    void setTargetingKey(String targetingKey);
 
     /**
      * Merges this EvaluationContext object with the second overriding the this in

--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -59,15 +59,6 @@ public final class ImmutableContext implements EvaluationContext {
     }
 
     /**
-     * Mutating targeting key is not supported in ImmutableContext and will be removed.
-     */
-    @Override
-    @Deprecated
-    public void setTargetingKey(String targetingKey) {
-        throw new UnsupportedOperationException("changing of targeting key is not allowed");
-    }
-
-    /**
      * Merges this EvaluationContext object with the passed EvaluationContext, overriding in case of conflict.
      *
      * @param overridingContext overriding context

--- a/src/test/java/dev/openfeature/sdk/EvalContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/EvalContextTest.java
@@ -164,8 +164,8 @@ public class EvalContextTest {
 
     @Test void merge_targeting_key() {
         String key1 = "key1";
-        EvaluationContext ctx1 = new MutableContext(key1);
-        EvaluationContext ctx2 = new MutableContext();
+        MutableContext ctx1 = new MutableContext(key1);
+        MutableContext ctx2 = new MutableContext();
 
         EvaluationContext ctxMerged = ctx1.merge(ctx2);
         assertEquals(key1, ctxMerged.getTargetingKey());

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -12,13 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ImmutableContextTest {
 
-    @Test
-    @DisplayName("Mutating targeting key is not allowed on Immutable Context")
-    void shouldThrowUnsupportedExceptionWhenMutatingTargetingKey() {
-        EvaluationContext ctx = new ImmutableContext("targeting key", new HashMap<>());
-        assertThrows(UnsupportedOperationException.class, () -> ctx.setTargetingKey(""));
-    }
-
     @DisplayName("attributes mutation should not affect the immutable context")
     @Test
     void shouldCreateCopyOfAttributesForImmutableContext() {


### PR DESCRIPTION
Signed-off-by: thiyagu06 <thiyagu103@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

remove the deprecated setTargetingKey method in EvaluationContext.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/java-sdk/issues/253

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

