### PR TITLE
fix: Do not throw null reference exception accessing a missing item.

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableStructure.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableStructure.java
@@ -50,7 +50,7 @@ public final class ImmutableStructure implements Structure {
     @Override
     public Value getValue(String key) {
         Value value = this.attributes.get(key);
-        return value.clone();
+        return value != null ? value.clone() : null;
     }
 
     /**

--- a/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
@@ -10,11 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ImmutableStructureTest {
     @Test void noArgShouldContainEmptyAttributes() {
@@ -107,5 +103,12 @@ class ImmutableStructureTest {
         Set<String> keys = structure.keySet();
         keys.remove("key1");
         assertEquals(2, structure.keySet().size());
+    }
+
+    @Test
+    void GettingAMissingValueShouldReturnNull() {
+        ImmutableStructure structure = new ImmutableStructure();
+        Object value = structure.getValue("missing");
+        assertNull(value);
     }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

I noticed when implementing a provider that accessing a missing item from an ImmutableContext throws an exception instead of returning null. I do not believe this to be the desired behavior.

### How to test

I think the added unit test should cover it.

