### PR TITLE
fix: validate list content to be values

### DIFF
--- a/src/main/java/dev/openfeature/sdk/Value.java
+++ b/src/main/java/dev/openfeature/sdk/Value.java
@@ -125,14 +125,27 @@ public class Value implements Cloneable {
     }
     
     /** 
-     * Check if this Value represents a List.
+     * Check if this Value represents a List of Values.
      * 
      * @return boolean
      */
     public boolean isList() {
-        return this.innerObject instanceof List
-            && (((List) this.innerObject).isEmpty()
-            || ((List) this.innerObject).get(0) instanceof Value);
+        if (!(this.innerObject instanceof List)) {
+            return false;
+        }
+
+        List<?> list = (List<?>) this.innerObject;
+        if (list.isEmpty()) {
+            return true;
+        }
+
+        for (Object obj : list) {
+            if (!(obj instanceof Value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /** 

--- a/src/test/java/dev/openfeature/sdk/ValueTest.java
+++ b/src/test/java/dev/openfeature/sdk/ValueTest.java
@@ -134,4 +134,12 @@ public class ValueTest {
             fail("Unexpected exception occurred.", e);
         }
     }
+
+    @Test public void valueConstructorValidateListInternals() {
+        List<Object> list = new ArrayList<>();
+        list.add(new Value("item"));
+        list.add("item");
+
+        assertThrows(InstantiationException.class, ()-> new Value(list));
+    }
 }


### PR DESCRIPTION
## This PR

Fixes #286

`Value.isList()` now validate list internal objects to be `Value` typed