### PR TITLE
fix: added an automatic module name (#362)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <junit.jupiter.version>5.9.2</junit.jupiter.version>
     <!-- exclusion expression for integration tests -->
     <testExclusions>**/integration/*.java</testExclusions>
+    <module-name>${groupId}.${artifactId}</module-name>
   </properties>
 
   <name>OpenFeature Java SDK</name>
@@ -356,7 +357,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>dev.openfeature.sdk</Automatic-Module-Name>
+              <Automatic-Module-Name>${module-name}</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,18 @@
       </plugin>
       <!-- End publish to maven central -->
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>dev.openfeature.sdk</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <!-- Begin source & javadocs being generated -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## This PR
- Adds an automatic module name that is more descriptive than `sdk`.  The new module name is `dev.openfeature.sdk`.

### Related Issues

Fixes #362  

### Notes
This is the easy fix, modularizing the entire Jar would take longer.  There might be a better way to achieve this but I am not a maven expert.

### How to test
After the change the produced Jar should have `Automatic-Module-Name: dev.openfeature.sdk` in the `META-INF/MANIFEST.MF` file.

