### PR TITLE
feat: Support mapping a client to a given provider.

### DIFF
--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -16,6 +17,7 @@ import lombok.experimental.Delegate;
  * be modified after instantiation.
  */
 @ToString
+@EqualsAndHashCode
 @SuppressWarnings("PMD.BeanMembersShouldSerialize")
 public class MutableContext implements EvaluationContext {
 

--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -90,7 +90,7 @@ public class MutableContext implements EvaluationContext {
     @Override
     public EvaluationContext merge(EvaluationContext overridingContext) {
         if (overridingContext == null) {
-            return new MutableContext(this.asMap());
+            return new MutableContext(this.targetingKey, this.asMap());
         }
 
         Map<String, Value> merged = this.merge(map -> new MutableStructure(map),

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -87,6 +87,11 @@ public class OpenFeatureAPI {
         setProvider(DEFAULT_PROVIDER_KEY, provider);
     }
 
+    /**
+     * Add a provider for a named client.
+     * @param clientName The name of the client.
+     * @param provider The provider to set.
+     */
     public void setProvider(String clientName, FeatureProvider provider) {
         try (AutoCloseableLock __ = providerLock.writeLockAutoCloseable()) {
             this.providers.put(clientName, provider);
@@ -100,6 +105,11 @@ public class OpenFeatureAPI {
         return this.providers.get(DEFAULT_PROVIDER_KEY);
     }
 
+    /**
+     * Fetch a provider for a named client. If not found, return the default.
+     * @param name The client name to look for.
+     * @return A named {@link FeatureProvider}
+     */
     public FeatureProvider getProviderForClientOrDefault(String name) {
         try (AutoCloseableLock __ = providerLock.writeLockAutoCloseable()) {
             FeatureProvider val = this.providers.get(name);

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -84,7 +84,11 @@ public class OpenFeatureAPI {
      * {@inheritDoc}
      */
     public void setProvider(FeatureProvider provider) {
-        setProvider(DEFAULT_PROVIDER_KEY, provider);
+        if (provider == null) {
+            this.providers.remove(DEFAULT_PROVIDER_KEY);
+        } else {
+            setProvider(DEFAULT_PROVIDER_KEY, provider);
+        }
     }
 
     /**
@@ -112,9 +116,11 @@ public class OpenFeatureAPI {
      */
     public FeatureProvider getProviderForClientOrDefault(String name) {
         try (AutoCloseableLock __ = providerLock.writeLockAutoCloseable()) {
-            FeatureProvider val = this.providers.get(name);
-            if (val != null) {
-                return val;
+            if (name != null) { // this happens when a client name isn't set.
+                FeatureProvider val = this.providers.get(name);
+                if (val != null) {
+                    return val;
+                }
             }
             return this.providers.get(DEFAULT_PROVIDER_KEY);
         }

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -116,13 +116,11 @@ public class OpenFeatureAPI {
      */
     public FeatureProvider getProvider(String name) {
         try (AutoCloseableLock __ = providerLock.readLockAutoCloseable()) {
-            if (name != null) { // this happens when a client name isn't set.
-                FeatureProvider val = this.providers.get(name);
-                if (val != null) {
-                    return val;
-                }
+            if (name == null) {
+                return this.providers.get(DEFAULT_PROVIDER_KEY);
             }
-            return this.providers.get(DEFAULT_PROVIDER_KEY);
+            return this.providers.getOrDefault(name, this.providers.get(DEFAULT_PROVIDER_KEY));
+        }
         }
     }
 

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -114,8 +114,8 @@ public class OpenFeatureAPI {
      * @param name The client name to look for.
      * @return A named {@link FeatureProvider}
      */
-    public FeatureProvider getProviderForClientOrDefault(String name) {
-        try (AutoCloseableLock __ = providerLock.writeLockAutoCloseable()) {
+    public FeatureProvider getProvider(String name) {
+        try (AutoCloseableLock __ = providerLock.readLockAutoCloseable()) {
             if (name != null) { // this happens when a client name isn't set.
                 FeatureProvider val = this.providers.get(name);
                 if (val != null) {

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -106,7 +106,7 @@ public class OpenFeatureClient implements Client {
             final EvaluationContext clientContext;
 
             // openfeatureApi.getProvider() must be called once to maintain a consistent reference
-            provider = ObjectUtils.defaultIfNull(openfeatureApi.getProviderForClientOrDefault(this.name), () -> {
+            provider = ObjectUtils.defaultIfNull(openfeatureApi.getProvider(this.name), () -> {
                 log.debug("No provider configured, using no-op provider.");
                 return new NoOpProvider();
             });

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -99,17 +99,14 @@ public class OpenFeatureClient implements Client {
         FlagEvaluationDetails<T> details = null;
         List<Hook> mergedHooks = null;
         HookContext<T> hookCtx = null;
-        FeatureProvider provider = null;
+        FeatureProvider provider;
 
         try {
             final EvaluationContext apiContext;
             final EvaluationContext clientContext;
 
             // openfeatureApi.getProvider() must be called once to maintain a consistent reference
-            provider = ObjectUtils.defaultIfNull(openfeatureApi.getProvider(this.name), () -> {
-                log.debug("No provider configured, using no-op provider.");
-                return new NoOpProvider();
-            });
+            provider = openfeatureApi.getProvider(this.name);
 
             mergedHooks = ObjectUtils.merge(provider.getProviderHooks(), flagOptions.getHooks(), clientHooks,
                     openfeatureApi.getHooks());

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -106,7 +106,7 @@ public class OpenFeatureClient implements Client {
             final EvaluationContext clientContext;
 
             // openfeatureApi.getProvider() must be called once to maintain a consistent reference
-            provider = ObjectUtils.defaultIfNull(openfeatureApi.getProvider(), () -> {
+            provider = ObjectUtils.defaultIfNull(openfeatureApi.getProviderForClientOrDefault(this.name), () -> {
                 log.debug("No provider configured, using no-op provider.");
                 return new NoOpProvider();
             });

--- a/src/test/java/dev/openfeature/sdk/ClientProviderMappingTest.java
+++ b/src/test/java/dev/openfeature/sdk/ClientProviderMappingTest.java
@@ -1,0 +1,23 @@
+package dev.openfeature.sdk;
+
+import io.cucumber.java.eo.Do;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ClientProviderMappingTest {
+    @Test
+    void clientProviderTest() {
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+
+        api.setProvider("client1", new DoSomethingProvider());
+        api.setProvider("client2", new NoOpProvider());
+
+        Client c1 = api.getClient("client1");
+        Client c2 = api.getClient("client2");
+
+        assertTrue(c1.getBooleanValue("test", false));
+        assertFalse(c2.getBooleanValue("test", false));
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/DeveloperExperienceTest.java
+++ b/src/test/java/dev/openfeature/sdk/DeveloperExperienceTest.java
@@ -19,15 +19,6 @@ import dev.openfeature.sdk.fixtures.HookFixtures;
 class DeveloperExperienceTest implements HookFixtures {
     transient String flagKey = "mykey";
 
-    @Test void noProviderSet() {
-        final String noOp = "no-op";
-        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-        api.setProvider(null);
-        Client client = api.getClient();
-        String retval = client.getStringValue(flagKey, noOp);
-        assertEquals(noOp, retval);
-    }
-
     @Test void simpleBooleanFlag() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider());

--- a/src/test/java/dev/openfeature/sdk/EvalContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/EvalContextTest.java
@@ -162,6 +162,13 @@ public class EvalContextTest {
         assertEquals(key1, ctxMerged.getTargetingKey());
     }
 
+    @Test void merge_null_returns_value() {
+        MutableContext ctx1 = new MutableContext("key");
+        ctx1.add("mything", "value");
+        EvaluationContext result = ctx1.merge(null);
+        assertEquals(ctx1, result);
+    }
+
     @Test void merge_targeting_key() {
         String key1 = "key1";
         MutableContext ctx1 = new MutableContext(key1);

--- a/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
@@ -116,6 +116,10 @@ class ImmutableStructureTest {
         Map<String, Value> attrs = new HashMap<>();
         attrs.put("test", new Value(45));
         ImmutableStructure structure = new ImmutableStructure(attrs);
-        assertEquals(attrs, structure.asObjectMap());
+
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("test", 45);
+
+        assertEquals(expected, structure.asObjectMap());
     }
 }

--- a/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
@@ -111,4 +111,11 @@ class ImmutableStructureTest {
         Object value = structure.getValue("missing");
         assertNull(value);
     }
+
+    @Test void objectMapTest() {
+        Map<String, Value> attrs = new HashMap<>();
+        attrs.put("test", new Value(45));
+        ImmutableStructure structure = new ImmutableStructure(attrs);
+        assertEquals(attrs, structure.asObjectMap());
+    }
 }

--- a/src/test/java/dev/openfeature/sdk/LockingTest.java
+++ b/src/test/java/dev/openfeature/sdk/LockingTest.java
@@ -19,7 +19,6 @@ class LockingTest {
     private OpenFeatureClient client;
     private AutoCloseableReentrantReadWriteLock apiContextLock;
     private AutoCloseableReentrantReadWriteLock apiHooksLock;
-    private AutoCloseableReentrantReadWriteLock apiProviderLock;
     private AutoCloseableReentrantReadWriteLock clientContextLock;
     private AutoCloseableReentrantReadWriteLock clientHooksLock;
     
@@ -33,10 +32,8 @@ class LockingTest {
         client = (OpenFeatureClient) api.getClient();
         
         apiContextLock = setupLock(apiContextLock, mockInnerReadLock(), mockInnerWriteLock());
-        apiProviderLock = setupLock(apiProviderLock, mockInnerReadLock(), mockInnerWriteLock());
         apiHooksLock = setupLock(apiHooksLock, mockInnerReadLock(), mockInnerWriteLock());
         OpenFeatureAPI.contextLock = apiContextLock;
-        OpenFeatureAPI.providerLock = apiProviderLock;
         OpenFeatureAPI.hooksLock = apiHooksLock;
 
         clientContextLock = setupLock(clientContextLock, mockInnerReadLock(), mockInnerWriteLock());
@@ -91,12 +88,6 @@ class LockingTest {
         verify(apiContextLock.readLock()).unlock();
     }
 
-    @Test
-    void setProviderShouldWriteLockAndUnlock() {
-        api.setProvider(new DoSomethingProvider());
-        verify(apiProviderLock.writeLock()).lock();
-        verify(apiProviderLock.writeLock()).unlock();
-    }
 
     @Test
     void clearHooksShouldWriteLockAndUnlock() {

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -3,6 +3,7 @@ package dev.openfeature.sdk;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OpenFeatureAPITest {
     @Test
@@ -11,5 +12,15 @@ public class OpenFeatureAPITest {
         FeatureProvider provider = new NoOpProvider();
         api.setProvider("namedProviderTest", provider);
         assertEquals(provider.getMetadata().getName(), api.getProviderMetadata("namedProviderTest").getName());
+    }
+
+    @Test void settingDefaultProviderToNullErrors() {
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+        assertThrows(IllegalArgumentException.class, () -> api.setProvider(null));
+    }
+
+    @Test void settingNamedClientProviderToNullErrors() {
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+        assertThrows(IllegalArgumentException.class, () -> api.setProvider("client-name", null));
     }
 }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -8,8 +8,8 @@ public class OpenFeatureAPITest {
     @Test
     void namedProviderTest() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-        AlwaysBrokenProvider provider = new AlwaysBrokenProvider();
+        FeatureProvider provider = new NoOpProvider();
         api.setProvider("namedProviderTest", provider);
-        assertEquals(provider.getMetadata(), api.getProviderMetadata("namedProviderTest"));
+        assertEquals(provider.getMetadata().getName(), api.getProviderMetadata("namedProviderTest").getName());
     }
 }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -1,0 +1,15 @@
+package dev.openfeature.sdk;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenFeatureAPITest {
+    @Test
+    void namedProviderTest() {
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+        AlwaysBrokenProvider provider = new AlwaysBrokenProvider();
+        api.setProvider("namedProviderTest", provider);
+        assertEquals(provider.getMetadata(), api.getProviderMetadata("namedProviderTest"));
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -27,7 +27,7 @@ class OpenFeatureClientTest implements HookFixtures {
     @DisplayName("should not throw exception if hook has different type argument than hookContext")
     void shouldNotThrowExceptionIfHookHasDifferentTypeArgumentThanHookContext() {
         OpenFeatureAPI api = mock(OpenFeatureAPI.class);
-        when(api.getProviderForClientOrDefault(any())).thenReturn(new DoSomethingProvider());
+        when(api.getProvider(any())).thenReturn(new DoSomethingProvider());
         when(api.getHooks()).thenReturn(Arrays.asList(mockBooleanHook(), mockStringHook()));
 
         OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
@@ -57,7 +57,7 @@ class OpenFeatureClientTest implements HookFixtures {
             context -> context.getTargetingKey().equals(targetingKey)))).thenReturn(ProviderEvaluation.<Boolean>builder()
           .value(true).build());
         when(api.getProvider()).thenReturn(mockProvider);
-        when(api.getProviderForClientOrDefault(any())).thenReturn(mockProvider);
+        when(api.getProvider(any())).thenReturn(mockProvider);
 
 
         OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -27,7 +27,7 @@ class OpenFeatureClientTest implements HookFixtures {
     @DisplayName("should not throw exception if hook has different type argument than hookContext")
     void shouldNotThrowExceptionIfHookHasDifferentTypeArgumentThanHookContext() {
         OpenFeatureAPI api = mock(OpenFeatureAPI.class);
-        when(api.getProvider()).thenReturn(new DoSomethingProvider());
+        when(api.getProviderForClientOrDefault(any())).thenReturn(new DoSomethingProvider());
         when(api.getHooks()).thenReturn(Arrays.asList(mockBooleanHook(), mockStringHook()));
 
         OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
@@ -57,6 +57,8 @@ class OpenFeatureClientTest implements HookFixtures {
             context -> context.getTargetingKey().equals(targetingKey)))).thenReturn(ProviderEvaluation.<Boolean>builder()
           .value(true).build());
         when(api.getProvider()).thenReturn(mockProvider);
+        when(api.getProviderForClientOrDefault(any())).thenReturn(mockProvider);
+
 
         OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
         client.setEvaluationContext(ctx);


### PR DESCRIPTION
## This PR
This adds support for mapping a client name onto a given provider, while still providing backwards compatibility to existing clients.

### Related Issues
Refs https://github.com/open-feature/ofep/pull/56
Fixes: https://github.com/open-feature/java-sdk/issues/442

### Follow-up Tasks
I still need to clean up documentation around this to note the difference between a "default provider" and a client-specific provider.

### How to test
Not sure about testing, but I'd especially love eyes on the thread safety. I don't think ConcurrentHashMap is doing a lot of work here, given we have to use locks to support `getProviderForClientOrDefault`. If you have a better way, I'm all ears.