### PR TITLE
chore: rename integration tests e2e

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,8 +38,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify -P integration-test
+      - name: Verify with Maven
+        run: mvn --batch-mode --update-snapshots verify -P e2e-test
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@1dd0ce34be62fac4f3b714f860c0b0c520acd35d

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,16 @@ If you think we might be out of date with the spec, you can check that by invoki
 
 If you're adding tests to cover something in the spec, use the `@Specification` annotation like you see throughout the test suites.
 
-## Integration tests
+## End-to-End Tests
 
-The continuous integration runs a set of [gherkin integration tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests do not run with the default maven profile. If you'd like to run them locally, you can start the flagd testbed with
+The continuous integration runs a set of [gherkin e2e tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests do not run with the default maven profile. If you'd like to run them locally, you can start the flagd testbed with
 
 ```
 docker run -p 8013:8013 ghcr.io/open-feature/flagd-testbed:latest
 ```
 and then run 
 ```
-mvn test -P integration-test
+mvn test -P e2e-test
 ```
 
 ## Releasing

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
     <junit.jupiter.version>5.9.3</junit.jupiter.version>
     <!-- exclusion expression for integration tests -->
-    <testExclusions>**/integration/*.java</testExclusions>
+    <testExclusions>**/e2e/*.java</testExclusions>
     <module-name>${groupId}.${artifactId}</module-name>
   </properties>
 
@@ -495,10 +495,10 @@
 
   <profiles>
     <profile>
-      <!-- this profile handles running the flagd integration tests -->
-      <id>integration-test</id>
+      <!-- this profile handles running the flagd e2e tests -->
+      <id>e2e-test</id>
       <properties>
-        <!-- run the integration tests by clearing the exclusions -->
+        <!-- run the e2e tests by clearing the exclusions -->
         <testExclusions/>
       </properties>  
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
     <junit.jupiter.version>5.9.3</junit.jupiter.version>
-    <!-- exclusion expression for integration tests -->
+    <!-- exclusion expression for e2e tests -->
     <testExclusions>**/e2e/*.java</testExclusions>
     <module-name>${groupId}.${artifactId}</module-name>
   </properties>

--- a/src/test/java/dev/openfeature/sdk/e2e/RunCucumberTest.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/RunCucumberTest.java
@@ -1,4 +1,4 @@
-package dev.openfeature.sdk.integration;
+package dev.openfeature.sdk.e2e;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;

--- a/src/test/java/dev/openfeature/sdk/e2e/StepDefinitions.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/StepDefinitions.java
@@ -1,4 +1,4 @@
-package dev.openfeature.sdk.integration;
+package dev.openfeature.sdk.e2e;
 
 import dev.openfeature.contrib.providers.flagd.FlagdProvider;
 import dev.openfeature.sdk.Client;


### PR DESCRIPTION
As has been brought up a few times, "end-to-end" is probably a better term for these tests, since they startup multiple processes and do inter-process communication streams with real (not mocked) artifacts.

No functional changes. I did use git mv to try to preserve history as best as possible.