### PR TITLE
feat: add flag metadata

### DIFF
--- a/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
+++ b/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
@@ -7,23 +7,25 @@ import javax.annotation.Nullable;
 
 /**
  * Contains information about how the evaluation happened, including any resolved values.
+ *
  * @param <T> the type of the flag being evaluated.
  */
-@Data @Builder
-public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
+@Data @Builder public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
+
     private String flagKey;
     private T value;
     @Nullable private String variant;
     @Nullable private String reason;
     private ErrorCode errorCode;
     @Nullable private String errorMessage;
+    @Builder.Default private FlagMetadata flagMetadata = FlagMetadata.builder().build();
 
     /**
      * Generate detail payload from the provider response.
      *
      * @param providerEval provider response
-     * @param flagKey key for the flag being evaluated
-     * @param <T> type of flag being returned
+     * @param flagKey      key for the flag being evaluated
+     * @param <T>          type of flag being returned
      * @return detail payload
      */
     public static <T> FlagEvaluationDetails<T> from(ProviderEvaluation<T> providerEval, String flagKey) {
@@ -33,6 +35,7 @@ public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
                 .variant(providerEval.getVariant())
                 .reason(providerEval.getReason())
                 .errorCode(providerEval.getErrorCode())
+                .flagMetadata(providerEval.getFlagMetadata())
                 .build();
     }
 }

--- a/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
+++ b/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
@@ -10,7 +10,9 @@ import javax.annotation.Nullable;
  *
  * @param <T> the type of the flag being evaluated.
  */
-@Data @Builder public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
+@Data
+@Builder
+public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
 
     private String flagKey;
     private T value;

--- a/src/main/java/dev/openfeature/sdk/FlagMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/FlagMetadata.java
@@ -1,7 +1,6 @@
 package dev.openfeature.sdk;
 
-import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ParseError;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,6 +9,7 @@ import java.util.Map;
  * Immutable Flag Metadata representation. Implementation is backed by a {@link Map} and immutability is provided
  * through builder and accessors.
  */
+@Slf4j
 public class FlagMetadata {
     private final Map<String, Object> metadata;
 
@@ -18,8 +18,8 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve a {@link String} value for the given key. If a value is not found, {@link GeneralError} will be thrown.
-     * If value exist but of another type, {@link ParseError} will be thrown.
+     * Retrieve a {@link String} value for the given key. A {@code null} value is returned if the key does not exist
+     * or if the value is of a different type.
      *
      * @param key flag metadata key to retrieve
      */
@@ -28,9 +28,8 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve an {@link Integer} value for the given key.
-     * If a value is not found, {@link GeneralError} will be thrown.
-     * If value exist but of another type, {@link ParseError} will be thrown.
+     * Retrieve a {@link Integer} value for the given key. A {@code null} value is returned if the key does not exist
+     * or if the value is of a different type.
      *
      * @param key flag metadata key to retrieve
      */
@@ -39,8 +38,8 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve a {@link Float} value for the given key. If a value is not found, {@link GeneralError} will be thrown.
-     * If value exist but of another type, {@link ParseError} will be thrown.
+     * Retrieve a {@link Float} value for the given key. A {@code null} value is returned if the key does not exist
+     * or if the value is of a different type.
      *
      * @param key flag metadata key to retrieve
      */
@@ -49,9 +48,8 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve a {@link Double} value for the given key.
-     * If a value is not found, {@link GeneralError} will be thrown.
-     * If value exist but of another type, {@link ParseError} will be thrown.
+     * Retrieve a {@link Double} value for the given key. A {@code null} value is returned if the key does not exist
+     * or if the value is of a different type.
      *
      * @param key flag metadata key to retrieve
      */
@@ -60,9 +58,8 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve a {@link Boolean} value for the given key.
-     * If a value is not found, {@link GeneralError} will be thrown.
-     * If value exist but of another type, {@link ParseError} will be thrown.
+     * Retrieve a {@link Boolean} value for the given key. A {@code null} value is returned if the key does not exist
+     * or if the value is of a different type.
      *
      * @param key flag metadata key to retrieve
      */
@@ -74,15 +71,15 @@ public class FlagMetadata {
         final Object o = metadata.get(key);
 
         if (o == null) {
-            throw new GeneralError("key " + key + " does not exist in metadata");
+            log.debug("Metadata key "+ key+ "does not exist");
+            return null;
         }
 
         try {
             return type.cast(o);
         } catch (ClassCastException e) {
-            throw new ParseError(
-                    "wrong type for key " + key
-                            + ". Expected" + type.getSimpleName() + "but got " + o.getClass().getSimpleName(), e);
+            log.debug("Error retrieving value for key "+ key, e);
+            return null;
         }
     }
 

--- a/src/main/java/dev/openfeature/sdk/FlagMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/FlagMetadata.java
@@ -39,7 +39,7 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve an {@link Float} value for the given key. If a value is not found, {@link GeneralError} will be thrown.
+     * Retrieve a {@link Float} value for the given key. If a value is not found, {@link GeneralError} will be thrown.
      * If value exist but of another type, {@link ParseError} will be thrown.
      *
      * @param key flag metadata key to retrieve
@@ -49,7 +49,7 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve an {@link Double} value for the given key.
+     * Retrieve a {@link Double} value for the given key.
      * If a value is not found, {@link GeneralError} will be thrown.
      * If value exist but of another type, {@link ParseError} will be thrown.
      *
@@ -60,7 +60,7 @@ public class FlagMetadata {
     }
 
     /**
-     * Retrieve an {@link Boolean} value for the given key.
+     * Retrieve a {@link Boolean} value for the given key.
      * If a value is not found, {@link GeneralError} will be thrown.
      * If value exist but of another type, {@link ParseError} will be thrown.
      *

--- a/src/main/java/dev/openfeature/sdk/FlagMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/FlagMetadata.java
@@ -38,6 +38,16 @@ public class FlagMetadata {
     }
 
     /**
+     * Retrieve a {@link Long} value for the given key. A {@code null} value is returned if the key does not exist
+     * or if the value is of a different type.
+     *
+     * @param key flag metadata key to retrieve
+     */
+    public Long getLong(final String key) {
+        return getValue(key, Long.class);
+    }
+
+    /**
      * Retrieve a {@link Float} value for the given key. A {@code null} value is returned if the key does not exist
      * or if the value is of a different type.
      *
@@ -119,6 +129,17 @@ public class FlagMetadata {
          * @param value flag metadata value to add
          */
         public FlagMetadataBuilder addInteger(final String key, final Integer value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * Add Long value to the metadata.
+         *
+         * @param key   flag metadata key to add
+         * @param value flag metadata value to add
+         */
+        public FlagMetadataBuilder addLong(final String key, final Long value) {
             metadata.put(key, value);
             return this;
         }

--- a/src/main/java/dev/openfeature/sdk/FlagMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/FlagMetadata.java
@@ -71,14 +71,14 @@ public class FlagMetadata {
         final Object o = metadata.get(key);
 
         if (o == null) {
-            log.debug("Metadata key "+ key+ "does not exist");
+            log.debug("Metadata key " + key + "does not exist");
             return null;
         }
 
         try {
             return type.cast(o);
         } catch (ClassCastException e) {
-            log.debug("Error retrieving value for key "+ key, e);
+            log.debug("Error retrieving value for key " + key, e);
             return null;
         }
     }

--- a/src/main/java/dev/openfeature/sdk/FlagMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/FlagMetadata.java
@@ -1,0 +1,170 @@
+package dev.openfeature.sdk;
+
+import dev.openfeature.sdk.exceptions.GeneralError;
+import dev.openfeature.sdk.exceptions.ParseError;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Immutable Flag Metadata representation. Implementation is backed by a {@link Map} and immutability is provided
+ * through builder and accessors.
+ */
+public class FlagMetadata {
+    private final Map<String, Object> metadata;
+
+    private FlagMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Retrieve a {@link String} value for the given key. If a value is not found, {@link GeneralError} will be thrown.
+     * If value exist but of another type, {@link ParseError} will be thrown.
+     *
+     * @param key flag metadata key to retrieve
+     */
+    public String getString(final String key) {
+        return getValue(key, String.class);
+    }
+
+    /**
+     * Retrieve an {@link Integer} value for the given key.
+     * If a value is not found, {@link GeneralError} will be thrown.
+     * If value exist but of another type, {@link ParseError} will be thrown.
+     *
+     * @param key flag metadata key to retrieve
+     */
+    public Integer getInteger(final String key) {
+        return getValue(key, Integer.class);
+    }
+
+    /**
+     * Retrieve an {@link Float} value for the given key. If a value is not found, {@link GeneralError} will be thrown.
+     * If value exist but of another type, {@link ParseError} will be thrown.
+     *
+     * @param key flag metadata key to retrieve
+     */
+    public Float getFloat(final String key) {
+        return getValue(key, Float.class);
+    }
+
+    /**
+     * Retrieve an {@link Double} value for the given key.
+     * If a value is not found, {@link GeneralError} will be thrown.
+     * If value exist but of another type, {@link ParseError} will be thrown.
+     *
+     * @param key flag metadata key to retrieve
+     */
+    public Double getDouble(final String key) {
+        return getValue(key, Double.class);
+    }
+
+    /**
+     * Retrieve an {@link Boolean} value for the given key.
+     * If a value is not found, {@link GeneralError} will be thrown.
+     * If value exist but of another type, {@link ParseError} will be thrown.
+     *
+     * @param key flag metadata key to retrieve
+     */
+    public Boolean getBoolean(final String key) {
+        return getValue(key, Boolean.class);
+    }
+
+    private <T> T getValue(final String key, final Class<T> type) {
+        final Object o = metadata.get(key);
+
+        if (o == null) {
+            throw new GeneralError("key " + key + " does not exist in metadata");
+        }
+
+        try {
+            return type.cast(o);
+        } catch (ClassCastException e) {
+            throw new ParseError(
+                    "wrong type for key " + key
+                            + ". Expected" + type.getSimpleName() + "but got " + o.getClass().getSimpleName(), e);
+        }
+    }
+
+
+    /**
+     * Obtain a builder for {@link FlagMetadata}.
+     */
+    public static FlagMetadataBuilder builder() {
+        return new FlagMetadataBuilder();
+    }
+
+    /**
+     * Immutable builder for {@link FlagMetadata}.
+     */
+    public static class FlagMetadataBuilder {
+        private final Map<String, Object> metadata;
+
+        private FlagMetadataBuilder() {
+            metadata = new HashMap<>();
+        }
+
+        /**
+         * Add String value to the metadata.
+         *
+         * @param key   flag metadata key to add
+         * @param value flag metadata value to add
+         */
+        public FlagMetadataBuilder addString(final String key, final String value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * Add Integer value to the metadata.
+         *
+         * @param key   flag metadata key to add
+         * @param value flag metadata value to add
+         */
+        public FlagMetadataBuilder addInteger(final String key, final Integer value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * Add Float value to the metadata.
+         *
+         * @param key   flag metadata key to add
+         * @param value flag metadata value to add
+         */
+        public FlagMetadataBuilder addFloat(final String key, final Float value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * Add Double value to the metadata.
+         *
+         * @param key   flag metadata key to add
+         * @param value flag metadata value to add
+         */
+        public FlagMetadataBuilder addDouble(final String key, final Double value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * Add Boolean value to the metadata.
+         *
+         * @param key   flag metadata key to add
+         * @param value flag metadata value to add
+         */
+        public FlagMetadataBuilder addBoolean(final String key, final Boolean value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * Retrieve {@link FlagMetadata} with provided key,value pairs.
+         */
+        public FlagMetadata build() {
+            return new FlagMetadata(this.metadata);
+        }
+
+    }
+}

--- a/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
@@ -13,4 +13,6 @@ public class ProviderEvaluation<T> implements BaseEvaluation<T> {
     @Nullable private String reason;
     ErrorCode errorCode;
     @Nullable private String errorMessage;
+    @Builder.Default
+    private FlagMetadata flagMetadata = FlagMetadata.builder().build();
 }

--- a/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
+++ b/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
@@ -1,11 +1,14 @@
 package dev.openfeature.sdk;
 
-public class DoSomethingProvider implements FeatureProvider {
+class DoSomethingProvider implements FeatureProvider {
 
-    public static final String name = "Something";
+    static final String name = "Something";
+    // Flag evaluation metadata
+    static final FlagMetadata flagMetadata = FlagMetadata.builder().build();
+
     private EvaluationContext savedContext;
 
-    public EvaluationContext getMergedContext() {
+    EvaluationContext getMergedContext() {
         return savedContext;
     }
 
@@ -18,13 +21,16 @@ public class DoSomethingProvider implements FeatureProvider {
     public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
         savedContext = ctx;
         return ProviderEvaluation.<Boolean>builder()
-                .value(!defaultValue).build();
+                .value(!defaultValue)
+                .flagMetadata(flagMetadata)
+                .build();
     }
 
     @Override
     public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
         return ProviderEvaluation.<String>builder()
                 .value(new StringBuilder(defaultValue).reverse().toString())
+                .flagMetadata(flagMetadata)
                 .build();
     }
 
@@ -33,6 +39,7 @@ public class DoSomethingProvider implements FeatureProvider {
         savedContext = ctx;
         return ProviderEvaluation.<Integer>builder()
                 .value(defaultValue * 100)
+                .flagMetadata(flagMetadata)
                 .build();
     }
 
@@ -41,6 +48,7 @@ public class DoSomethingProvider implements FeatureProvider {
         savedContext = ctx;
         return ProviderEvaluation.<Double>builder()
                 .value(defaultValue * 100)
+                .flagMetadata(flagMetadata)
                 .build();
     }
 
@@ -49,6 +57,7 @@ public class DoSomethingProvider implements FeatureProvider {
         savedContext = invocationContext;
         return ProviderEvaluation.<Value>builder()
                 .value(null)
+                .flagMetadata(flagMetadata)
                 .build();
     }
 }

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -1,6 +1,8 @@
 package dev.openfeature.sdk;
 
-import static org.assertj.core.api.Assertions.*;
+import static dev.openfeature.sdk.DoSomethingProvider.flagMetadata;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -15,17 +17,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import dev.openfeature.sdk.exceptions.FlagNotFoundError;
-import dev.openfeature.sdk.testutils.FeatureProviderTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import dev.openfeature.sdk.fixtures.HookFixtures;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.simplify4u.slf4jmock.LoggerMock;
 import org.slf4j.Logger;
+
+import dev.openfeature.sdk.exceptions.FlagNotFoundError;
+import dev.openfeature.sdk.fixtures.HookFixtures;
+import dev.openfeature.sdk.testutils.FeatureProviderTestUtils;
 
 class FlagEvaluationSpecTest implements HookFixtures {
 
@@ -150,6 +152,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
                 .flagKey(key)
                 .value(false)
                 .variant(null)
+                .flagMetadata(flagMetadata)
                 .build();
         assertEquals(bd, c.getBooleanDetails(key, true));
         assertEquals(bd, c.getBooleanDetails(key, true, new ImmutableContext()));
@@ -159,6 +162,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
                 .flagKey(key)
                 .value("tset")
                 .variant(null)
+                .flagMetadata(flagMetadata)
                 .build();
         assertEquals(sd, c.getStringDetails(key, "test"));
         assertEquals(sd, c.getStringDetails(key, "test", new ImmutableContext()));
@@ -167,6 +171,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
         FlagEvaluationDetails<Integer> id = FlagEvaluationDetails.<Integer>builder()
                 .flagKey(key)
                 .value(400)
+                .flagMetadata(flagMetadata)
                 .build();
         assertEquals(id, c.getIntegerDetails(key, 4));
         assertEquals(id, c.getIntegerDetails(key, 4, new ImmutableContext()));
@@ -175,6 +180,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
         FlagEvaluationDetails<Double> dd = FlagEvaluationDetails.<Double>builder()
                 .flagKey(key)
                 .value(40.0)
+                .flagMetadata(flagMetadata)
                 .build();
         assertEquals(dd, c.getDoubleDetails(key, .4));
         assertEquals(dd, c.getDoubleDetails(key, .4, new ImmutableContext()));

--- a/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
@@ -14,6 +14,7 @@ class FlagMetadataTest {
         FlagMetadata flagMetadata = FlagMetadata.builder()
                 .addString("string", "string")
                 .addInteger("integer", 1)
+                .addLong("long", 1L)
                 .addFloat("float", 1.5f)
                 .addDouble("double", Double.MAX_VALUE)
                 .addBoolean("boolean", Boolean.FALSE)
@@ -22,6 +23,7 @@ class FlagMetadataTest {
         // then
         assertThat(flagMetadata.getString("string")).isEqualTo("string");
         assertThat(flagMetadata.getInteger("integer")).isEqualTo(1);
+        assertThat(flagMetadata.getLong("long")).isEqualTo(1L);
         assertThat(flagMetadata.getFloat("float")).isEqualTo(1.5f);
         assertThat(flagMetadata.getDouble("double")).isEqualTo(Double.MAX_VALUE);
         assertThat(flagMetadata.getBoolean("boolean")).isEqualTo(Boolean.FALSE);

--- a/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
@@ -1,15 +1,14 @@
 package dev.openfeature.sdk;
 
-import dev.openfeature.sdk.exceptions.GeneralError;
-import dev.openfeature.sdk.exceptions.ParseError;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FlagMetadataTest {
 
     @Test
+    @DisplayName("Test metadata payload construction and retrieval")
     public void builder_validation() {
         // given
         FlagMetadata flagMetadata = FlagMetadata.builder()
@@ -29,22 +28,24 @@ class FlagMetadataTest {
     }
 
     @Test
-    public void parse_error_validation() {
+    @DisplayName("Value type mismatch returns a null")
+    public void value_type_validation() {
         // given
         FlagMetadata flagMetadata = FlagMetadata.builder()
                 .addString("string", "string")
                 .build();
 
         // then
-        assertThatThrownBy(() -> flagMetadata.getBoolean("string")).isInstanceOf(ParseError.class);
+       assertThat(flagMetadata.getBoolean("string")).isNull();
     }
 
     @Test
+    @DisplayName("A null is returned if key does not exist")
     public void notfound_error_validation() {
         // given
         FlagMetadata flagMetadata = FlagMetadata.builder().build();
 
         // then
-        assertThatThrownBy(() -> flagMetadata.getBoolean("string")).isInstanceOf(GeneralError.class);
+        assertThat(flagMetadata.getBoolean("string")).isNull();
     }
 }

--- a/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
@@ -1,0 +1,50 @@
+package dev.openfeature.sdk;
+
+import dev.openfeature.sdk.exceptions.GeneralError;
+import dev.openfeature.sdk.exceptions.ParseError;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FlagMetadataTest {
+
+    @Test
+    public void builder_validation() {
+        // given
+        FlagMetadata flagMetadata = FlagMetadata.builder()
+                .addString("string", "string")
+                .addInteger("integer", 1)
+                .addFloat("float", 1.5f)
+                .addDouble("double", Double.MAX_VALUE)
+                .addBoolean("boolean", Boolean.FALSE)
+                .build();
+
+        // then
+        assertThat(flagMetadata.getString("string")).isEqualTo("string");
+        assertThat(flagMetadata.getInteger("integer")).isEqualTo(1);
+        assertThat(flagMetadata.getFloat("float")).isEqualTo(1.5f);
+        assertThat(flagMetadata.getDouble("double")).isEqualTo(Double.MAX_VALUE);
+        assertThat(flagMetadata.getBoolean("boolean")).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    public void parse_error_validation() {
+        // given
+        FlagMetadata flagMetadata = FlagMetadata.builder()
+                .addString("string", "string")
+                .build();
+
+        // then
+        assertThatThrownBy(() -> flagMetadata.getBoolean("string")).isInstanceOf(ParseError.class);
+    }
+
+    @Test
+    public void notfound_error_validation() {
+        // given
+        FlagMetadata flagMetadata = FlagMetadata.builder().build();
+
+        // then
+        assertThatThrownBy(() -> flagMetadata.getBoolean("string")).isInstanceOf(GeneralError.class);
+    }
+}


### PR DESCRIPTION
## This PR

Is connected to #437 & completes the implementation of flag metadata spec implementation [1]

The implementation is backed by immutable `FlagMetadata`. If present, metadata gets propagated from `ProviderEvaluation` to `FlagEvaluationDetails`

Tests were added to validate the construction as well as the propagation 


[1] - https://github.com/open-feature/spec/commit/74c373e089ad77bf8cac84f3d93c00c945ff3a8a