### PR TITLE
chore: expose get value for metadata

### DIFF
--- a/src/main/java/dev/openfeature/sdk/FlagMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/FlagMetadata.java
@@ -77,7 +77,10 @@ public class FlagMetadata {
         return getValue(key, Boolean.class);
     }
 
-    private <T> T getValue(final String key, final Class<T> type) {
+    /**
+     * Generic value retrieval for the given key.
+     */
+    public <T> T getValue(final String key, final Class<T> type) {
         final Object o = metadata.get(key);
 
         if (o == null) {

--- a/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
@@ -22,11 +22,22 @@ class FlagMetadataTest {
 
         // then
         assertThat(flagMetadata.getString("string")).isEqualTo("string");
+        assertThat(flagMetadata.getValue("string", String.class)).isEqualTo("string");
+
         assertThat(flagMetadata.getInteger("integer")).isEqualTo(1);
+        assertThat(flagMetadata.getValue("integer", Integer.class)).isEqualTo(1);
+
         assertThat(flagMetadata.getLong("long")).isEqualTo(1L);
+        assertThat(flagMetadata.getValue("long", Long.class)).isEqualTo(1L);
+
         assertThat(flagMetadata.getFloat("float")).isEqualTo(1.5f);
+        assertThat(flagMetadata.getValue("float", Float.class)).isEqualTo(1.5f);
+
         assertThat(flagMetadata.getDouble("double")).isEqualTo(Double.MAX_VALUE);
+        assertThat(flagMetadata.getValue("double", Double.class)).isEqualTo(Double.MAX_VALUE);
+
         assertThat(flagMetadata.getBoolean("boolean")).isEqualTo(Boolean.FALSE);
+        assertThat(flagMetadata.getValue("boolean", Boolean.class)).isEqualTo(Boolean.FALSE);
     }
 
     @Test
@@ -38,7 +49,7 @@ class FlagMetadataTest {
                 .build();
 
         // then
-       assertThat(flagMetadata.getBoolean("string")).isNull();
+        assertThat(flagMetadata.getBoolean("string")).isNull();
     }
 
     @Test


### PR DESCRIPTION
## This PR

Make the `getValue` method public for `FlagMetadata.java`. This allows generic value extractions where needed (ex:- Loop across <key, type> and extract them from flag metadata instead of checking for type and calling the exact method).

```
for (DimensionDescription description:dimensionDescriptions) {
        flagMetadata.getValue(description.getKey(), description.getType());
}

// where 

DimensionDescription is <key of String, type of Class>
```