### PR TITLE
chore: rename flag metadata

### DIFF
--- a/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
+++ b/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.java
@@ -20,7 +20,7 @@ public class FlagEvaluationDetails<T> implements BaseEvaluation<T> {
     @Nullable private String reason;
     private ErrorCode errorCode;
     @Nullable private String errorMessage;
-    @Builder.Default private FlagMetadata flagMetadata = FlagMetadata.builder().build();
+    @Builder.Default private ImmutableMetadata flagMetadata = ImmutableMetadata.builder().build();
 
     /**
      * Generate detail payload from the provider response.

--- a/src/main/java/dev/openfeature/sdk/ImmutableMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableMetadata.java
@@ -10,10 +10,10 @@ import java.util.Map;
  * through builder and accessors.
  */
 @Slf4j
-public class FlagMetadata {
+public class ImmutableMetadata {
     private final Map<String, Object> metadata;
 
-    private FlagMetadata(Map<String, Object> metadata) {
+    private ImmutableMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
     }
 
@@ -98,19 +98,19 @@ public class FlagMetadata {
 
 
     /**
-     * Obtain a builder for {@link FlagMetadata}.
+     * Obtain a builder for {@link ImmutableMetadata}.
      */
-    public static FlagMetadataBuilder builder() {
-        return new FlagMetadataBuilder();
+    public static ImmutableMetadataBuilder builder() {
+        return new ImmutableMetadataBuilder();
     }
 
     /**
-     * Immutable builder for {@link FlagMetadata}.
+     * Immutable builder for {@link ImmutableMetadata}.
      */
-    public static class FlagMetadataBuilder {
+    public static class ImmutableMetadataBuilder {
         private final Map<String, Object> metadata;
 
-        private FlagMetadataBuilder() {
+        private ImmutableMetadataBuilder() {
             metadata = new HashMap<>();
         }
 
@@ -120,7 +120,7 @@ public class FlagMetadata {
          * @param key   flag metadata key to add
          * @param value flag metadata value to add
          */
-        public FlagMetadataBuilder addString(final String key, final String value) {
+        public ImmutableMetadataBuilder addString(final String key, final String value) {
             metadata.put(key, value);
             return this;
         }
@@ -131,7 +131,7 @@ public class FlagMetadata {
          * @param key   flag metadata key to add
          * @param value flag metadata value to add
          */
-        public FlagMetadataBuilder addInteger(final String key, final Integer value) {
+        public ImmutableMetadataBuilder addInteger(final String key, final Integer value) {
             metadata.put(key, value);
             return this;
         }
@@ -142,7 +142,7 @@ public class FlagMetadata {
          * @param key   flag metadata key to add
          * @param value flag metadata value to add
          */
-        public FlagMetadataBuilder addLong(final String key, final Long value) {
+        public ImmutableMetadataBuilder addLong(final String key, final Long value) {
             metadata.put(key, value);
             return this;
         }
@@ -153,7 +153,7 @@ public class FlagMetadata {
          * @param key   flag metadata key to add
          * @param value flag metadata value to add
          */
-        public FlagMetadataBuilder addFloat(final String key, final Float value) {
+        public ImmutableMetadataBuilder addFloat(final String key, final Float value) {
             metadata.put(key, value);
             return this;
         }
@@ -164,7 +164,7 @@ public class FlagMetadata {
          * @param key   flag metadata key to add
          * @param value flag metadata value to add
          */
-        public FlagMetadataBuilder addDouble(final String key, final Double value) {
+        public ImmutableMetadataBuilder addDouble(final String key, final Double value) {
             metadata.put(key, value);
             return this;
         }
@@ -175,16 +175,16 @@ public class FlagMetadata {
          * @param key   flag metadata key to add
          * @param value flag metadata value to add
          */
-        public FlagMetadataBuilder addBoolean(final String key, final Boolean value) {
+        public ImmutableMetadataBuilder addBoolean(final String key, final Boolean value) {
             metadata.put(key, value);
             return this;
         }
 
         /**
-         * Retrieve {@link FlagMetadata} with provided key,value pairs.
+         * Retrieve {@link ImmutableMetadata} with provided key,value pairs.
          */
-        public FlagMetadata build() {
-            return new FlagMetadata(this.metadata);
+        public ImmutableMetadata build() {
+            return new ImmutableMetadata(this.metadata);
         }
 
     }

--- a/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
@@ -14,5 +14,5 @@ public class ProviderEvaluation<T> implements BaseEvaluation<T> {
     ErrorCode errorCode;
     @Nullable private String errorMessage;
     @Builder.Default
-    private FlagMetadata flagMetadata = FlagMetadata.builder().build();
+    private ImmutableMetadata flagMetadata = ImmutableMetadata.builder().build();
 }

--- a/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
+++ b/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
@@ -4,7 +4,7 @@ class DoSomethingProvider implements FeatureProvider {
 
     static final String name = "Something";
     // Flag evaluation metadata
-    static final FlagMetadata flagMetadata = FlagMetadata.builder().build();
+    static final ImmutableMetadata flagMetadata = ImmutableMetadata.builder().build();
 
     private EvaluationContext savedContext;
 

--- a/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagMetadataTest.java
@@ -11,7 +11,7 @@ class FlagMetadataTest {
     @DisplayName("Test metadata payload construction and retrieval")
     public void builder_validation() {
         // given
-        FlagMetadata flagMetadata = FlagMetadata.builder()
+        ImmutableMetadata flagMetadata = ImmutableMetadata.builder()
                 .addString("string", "string")
                 .addInteger("integer", 1)
                 .addLong("long", 1L)
@@ -44,7 +44,7 @@ class FlagMetadataTest {
     @DisplayName("Value type mismatch returns a null")
     public void value_type_validation() {
         // given
-        FlagMetadata flagMetadata = FlagMetadata.builder()
+        ImmutableMetadata flagMetadata = ImmutableMetadata.builder()
                 .addString("string", "string")
                 .build();
 
@@ -56,7 +56,7 @@ class FlagMetadataTest {
     @DisplayName("A null is returned if key does not exist")
     public void notfound_error_validation() {
         // given
-        FlagMetadata flagMetadata = FlagMetadata.builder().build();
+        ImmutableMetadata flagMetadata = ImmutableMetadata.builder().build();
 
         // then
         assertThat(flagMetadata.getBoolean("string")).isNull();


### PR DESCRIPTION
Renames the `FlagMetadata` class (it can be used for event metadata as well). Talked with @Kavindu-Dodan (the implementer) about this. This is not yet released, so there's no breaking change to worry about.