### PR TITLE
fix:  Implement equals for the ImmutableMetadata object

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableMetadata.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -10,6 +11,7 @@ import java.util.Map;
  * through builder and accessors.
  */
 @Slf4j
+@EqualsAndHashCode
 public class ImmutableMetadata {
     private final Map<String, Object> metadata;
 

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationDetailsTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationDetailsTest.java
@@ -53,7 +53,7 @@ class FlagEvaluationDetailsTest {
                 .reason(Reason.ERROR.toString())
                 .value(false)
                 .errorCode(ErrorCode.GENERAL)
-                .errorMessage("impossible to contact GO Feature Flag relay proxy instance")
+                .errorMessage("error XXX")
                 .flagMetadata(ImmutableMetadata.builder().addString("metadata","1").build())
                 .build();
 
@@ -61,7 +61,7 @@ class FlagEvaluationDetailsTest {
                 .reason(Reason.ERROR.toString())
                 .value(false)
                 .errorCode(ErrorCode.GENERAL)
-                .errorMessage("impossible to contact GO Feature Flag relay proxy instance")
+                .errorMessage("error XXX")
                 .flagMetadata(ImmutableMetadata.builder().addString("metadata","1").build())
                 .build();
 

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationDetailsTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationDetailsTest.java
@@ -45,4 +45,26 @@ class FlagEvaluationDetailsTest {
         assertEquals(errorMessage, details.getErrorMessage());
         assertEquals(metadata, details.getFlagMetadata());
     }
+
+    @Test
+    @DisplayName("should be able to compare 2 FlagEvaluationDetails")
+    public void compareFlagEvaluationDetails(){
+        FlagEvaluationDetails fed1 = FlagEvaluationDetails.builder()
+                .reason(Reason.ERROR.toString())
+                .value(false)
+                .errorCode(ErrorCode.GENERAL)
+                .errorMessage("impossible to contact GO Feature Flag relay proxy instance")
+                .flagMetadata(ImmutableMetadata.builder().addString("metadata","1").build())
+                .build();
+
+        FlagEvaluationDetails fed2 = FlagEvaluationDetails.builder()
+                .reason(Reason.ERROR.toString())
+                .value(false)
+                .errorCode(ErrorCode.GENERAL)
+                .errorMessage("impossible to contact GO Feature Flag relay proxy instance")
+                .flagMetadata(ImmutableMetadata.builder().addString("metadata","1").build())
+                .build();
+
+        assertEquals(fed1,fed2);
+    }
 }


### PR DESCRIPTION
## This PR
- Implement the `equals` method to be able to compare 2 `FlagEvaluationDetails`.

### Related Issues
Fixes #511