### PR TITLE
fix: getState mandatory on EventProvider

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EventProvider.java
+++ b/src/main/java/dev/openfeature/sdk/EventProvider.java
@@ -16,6 +16,12 @@ import dev.openfeature.sdk.internal.TriConsumer;
  */
 public abstract class EventProvider implements FeatureProvider {
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public abstract ProviderState getState();
+
     private TriConsumer<EventProvider, ProviderEvent, ProviderEventDetails> onEmit = null;
 
     /**

--- a/src/main/java/dev/openfeature/sdk/FeatureProvider.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProvider.java
@@ -31,7 +31,7 @@ public interface FeatureProvider {
      * if they have special initialization needed prior being called for flag
      * evaluation.
      * <p>
-     * It is ok, if the method is expensive as it is executed in the background. All
+     * It is ok if the method is expensive as it is executed in the background. All
      * runtime exceptions will be
      * caught and logged.
      * </p>
@@ -46,7 +46,7 @@ public interface FeatureProvider {
      * Providers can overwrite this method, if they have special shutdown actions
      * needed.
      * <p>
-     * It is ok, if the method is expensive as it is executed in the background. All
+     * It is ok if the method is expensive as it is executed in the background. All
      * runtime exceptions will be
      * caught and logged.
      * </p>
@@ -57,7 +57,11 @@ public interface FeatureProvider {
 
     /**
      * Returns a representation of the current readiness of the provider.
-     * Providers which do not implement this method are assumed to be ready immediately.
+     * If the provider needs to be initialized, it should return {@link ProviderState#NOT_READY}.
+     * If the provider is in an error state, it should return {@link ProviderState#ERROR}.
+     * If the provider is functioning normally, it should return {@link ProviderState#READY}.
+     * 
+     * <p><i>Providers which do not implement this method are assumed to be ready immediately.</i></p>
      * 
      * @return ProviderState
      */

--- a/src/test/java/dev/openfeature/sdk/EventProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/EventProviderTest.java
@@ -121,6 +121,11 @@ class EventProviderTest {
             // TODO Auto-generated method stub
             throw new UnsupportedOperationException("Unimplemented method 'getObjectEvaluation'");
         }
+
+        @Override
+        public ProviderState getState() {
+            return ProviderState.READY;            
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/dev/openfeature/sdk/EventProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/EventProviderTest.java
@@ -124,7 +124,7 @@ class EventProviderTest {
 
         @Override
         public ProviderState getState() {
-            return ProviderState.READY;            
+            return ProviderState.READY;
         }
     }
 


### PR DESCRIPTION
In 3 event provider implementations, [flagd-java](https://github.com/open-feature/java-sdk-contrib/pull/361#pullrequestreview-1541468446), [go-feature-flag-web](https://github.com/open-feature/js-sdk-contrib/pull/474#discussion_r1274012627), and even my own implementation of flagd-js, authors have forgotten to properly implement `getState` (which means the SDK assumes the provider is already `READY` and doesn't run `initialize()`.)

This is an easy pitfall. To help with this, I'm making the implementation of `getState` required in the abstract `EventProvider` class, and will do similarly in the JS-SDK. I think this is a reasonable proposal because the `EventProvider` class is very new, and in the majority of cases a provider that can fire async events requires some kind of remote connection, so it will need initialization. This is technically a breaking change, but it would only impact the experimental events API, specifically the `EventProvider` implementations which could only be a few days old at this point, and which (due to my previous point) likely should have implemented this anyway.

It also adds some more doc about the importance of this method.

Relates to: https://github.com/open-feature/js-sdk/pull/506