### PR TITLE
chore: add todos, fix submodule pull

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # TODO: this can be removed with https://github.com/open-feature/java-sdk/issues/523
     services:
       flagd:
         image: ghcr.io/open-feature/flagd-testbed:latest
@@ -39,7 +40,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Verify with Maven
-        run: mvn --batch-mode --update-snapshots verify -P e2e-test
+        run: mvn --batch-mode --update-snapshots --activate-profiles e2e-test verify
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e1dd05cde2ed37d100f658b34ea423728ba1812e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ If you're adding tests to cover something in the spec, use the `@Specification` 
 
 ## End-to-End Tests
 
+<!-- TODO: this section should be updated with https://github.com/open-feature/java-sdk/issues/523 -->
+
 The continuous integration runs a set of [gherkin e2e tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests do not run with the default maven profile. If you'd like to run them locally, you can start the flagd testbed with
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,8 @@
 
     <profile>
       <!-- this profile handles running the flagd e2e tests -->
+      <!-- TODO: this profile can likely be removed with TODO: this section should be updated with https://github.com/open-feature/java-sdk/issues/523 -->
+      <!-- TODO: we should pull the submodule and run these tests unconditionall once flagd isn't required -->
       <id>e2e-test</id>
       <properties>
         <!-- run the e2e tests by clearing the exclusions -->
@@ -523,7 +525,7 @@
                     <argument>submodule</argument>
                     <argument>update</argument>
                     <argument>--init</argument>
-                    <argument>--recursive</argument>
+                    <argument>test-harness</argument>
                   </arguments>
                 </configuration>
               </execution>


### PR DESCRIPTION
Adds some TODOs related to https://github.com/open-feature/java-sdk/issues/523.

Also pulls a _specific_ submodule instead of all of them via recursive, since this can cause failures when multiple jobs pull submodules at the same time.