### PR TITLE
chore: fix race with events tests

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EventSupport.java
+++ b/src/main/java/dev/openfeature/sdk/EventSupport.java
@@ -23,7 +23,7 @@ class EventSupport {
     // we use a v4 uuid as a "placeholder" for anonymous clients, since
     // ConcurrentHashMap doesn't support nulls
     private static final String defaultClientUuid = UUID.randomUUID().toString();
-    private static final ExecutorService taskExecutor = Executors.newCachedThreadPool();
+    private final ExecutorService taskExecutor = Executors.newCachedThreadPool();
     private final Map<String, HandlerStore> handlerStores = new ConcurrentHashMap<>();
     private final HandlerStore globalHandlerStore = new HandlerStore();
 


### PR DESCRIPTION
I believe this was causing intermittent failures with tests. This static field on a package private member meant that the instance we created for testing (which we shutdown) was shared with the "real" API instance (see [here](https://github.com/open-feature/java-sdk/actions/runs/5765050607/job/15630249339#step:7:753) for an example failure).

I don't think this constitutes a production bug, but it should make our tests more reliable.

Edit: I ran this suite locally 10+ times and in GH 5 times and it seems to run reliably now.