### PR TITLE
fix: ability to set provider after shutdown

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EventSupport.java
+++ b/src/main/java/dev/openfeature/sdk/EventSupport.java
@@ -145,7 +145,11 @@ class EventSupport {
      * Stop the event handler task executor.
      */
     public void shutdown() {
-        taskExecutor.shutdown();
+        try {
+            taskExecutor.shutdown();
+        } catch (Exception e) {
+            log.warn("Exception while attempting to shutdown task executor", e);
+        }
     }
 
     // Handler store maintains a set of handlers for each event type.

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -21,13 +21,15 @@ import lombok.extern.slf4j.Slf4j;
 public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
     // package-private multi-read/single-write lock
     static AutoCloseableReentrantReadWriteLock lock = new AutoCloseableReentrantReadWriteLock();
-    private EvaluationContext evaluationContext;
     private final List<Hook> apiHooks;
-    private ProviderRepository providerRepository = new ProviderRepository();
-    private EventSupport eventSupport = new EventSupport();
+    private ProviderRepository providerRepository;
+    private EventSupport eventSupport;
+    private EvaluationContext evaluationContext;
 
     protected OpenFeatureAPI() {
         apiHooks = new ArrayList<>();
+        providerRepository = new ProviderRepository();
+        eventSupport = new EventSupport();
     }
 
     private static class SingletonHolder {
@@ -190,9 +192,19 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
         }
     }
 
+    /**
+     * Shutdown and reset the current status of OpenFeature API.
+     * This call cleans up all active providers and attempt to shut down internal event handling mechanisms.
+     * Once shutdown is complete, API is reset and ready to use again.
+     * */
     public void shutdown() {
-        providerRepository.shutdown();
-        eventSupport.shutdown();
+        try (AutoCloseableLock __ = lock.writeLockAutoCloseable()) {
+            providerRepository.shutdown();
+            eventSupport.shutdown();
+
+            providerRepository = new ProviderRepository();
+            eventSupport = new EventSupport();
+        }
     }
 
     /**
@@ -262,15 +274,6 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
             }
             eventSupport.addClientHandler(clientName, event, handler);
         }
-    }
-
-    /**
-     * This method is only here for testing as otherwise all tests after the API
-     * shutdown test would fail.
-     */
-    final void reset() {
-        providerRepository = new ProviderRepository();
-        eventSupport = new EventSupport();
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -193,9 +193,9 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
     }
 
     /**
-     * Shutdown and reset the current status of OpenFeature API.
-     * This call cleans up all active providers and attempt to shut down internal event handling mechanisms.
-     * Once shutdown is complete, API is reset and ready to use again.
+     * Shut down and reset the current status of OpenFeature API.
+     * This call cleans up all active providers and attempts to shut down internal event handling mechanisms.
+     * Once shut down is complete, API is reset and ready to use again.
      * */
     public void shutdown() {
         try (AutoCloseableLock __ = lock.writeLockAutoCloseable()) {

--- a/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
@@ -109,9 +109,22 @@ class ShutdownBehaviorSpecTest {
                             verify(defaultProvider).shutdown();
                             verify(namedProvider).shutdown();
                         });
-
-                api.reset();
             }
+        }
+
+
+        @Test
+        @DisplayName("once shutdown is complete, api must be ready to use again")
+        void apiIsReadyToUseAfterShutdown() {
+            final OpenFeatureAPI openFeatureAPI = OpenFeatureAPI.getInstance();
+
+            NoOpProvider p1 = new NoOpProvider();
+            openFeatureAPI.setProvider(p1);
+
+            openFeatureAPI.shutdown();
+
+            NoOpProvider p2 = new NoOpProvider();
+            openFeatureAPI.setProvider(p2);
         }
     }
 }


### PR DESCRIPTION
## This PR

Fix #552 

Since API is a singleton, we must re-initialize all cleaned-up resources. 