### PR TITLE
chore: fix jacoco coverage minimum, throw in memory provider

### DIFF
--- a/src/main/java/dev/openfeature/sdk/exceptions/ProviderNotReadyError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/ProviderNotReadyError.java
@@ -1,0 +1,12 @@
+package dev.openfeature.sdk.exceptions;
+
+import dev.openfeature.sdk.ErrorCode;
+import lombok.Getter;
+import lombok.experimental.StandardException;
+
+@SuppressWarnings("checkstyle:MissingJavadocType")
+@StandardException
+public class ProviderNotReadyError extends OpenFeatureError {
+    private static final long serialVersionUID = 1L;
+    @Getter private final ErrorCode errorCode = ErrorCode.PROVIDER_NOT_READY;
+}

--- a/src/test/java/dev/openfeature/sdk/e2e/StepDefinitions.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/StepDefinitions.java
@@ -271,7 +271,6 @@ public class StepDefinitions {
     @Then("the reason should indicate an error and the error code should indicate a missing flag with {string}")
     public void the_reason_should_indicate_an_error_and_the_error_code_should_be_flag_not_found(String errorCode) {
         assertEquals(Reason.ERROR.toString(), notFoundDetails.getReason());
-        assertTrue(notFoundDetails.getErrorMessage().contains(errorCode));
         assertTrue(notFoundDetails.getErrorCode().name().equals(errorCode));
     }
 
@@ -292,7 +291,6 @@ public class StepDefinitions {
     @Then("the reason should indicate an error and the error code should indicate a type mismatch with {string}")
     public void the_reason_should_indicate_an_error_and_the_error_code_should_be_type_mismatch(String errorCode) {
         assertEquals(Reason.ERROR.toString(), typeErrorDetails.getReason());
-        assertTrue(typeErrorDetails.getErrorMessage().contains(errorCode));
         assertTrue(typeErrorDetails.getErrorCode().name().equals(errorCode));
     }
 

--- a/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
@@ -2,17 +2,22 @@ package dev.openfeature.sdk.providers.memory;
 
 import com.google.common.collect.ImmutableMap;
 import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.Value;
+import dev.openfeature.sdk.exceptions.FlagNotFoundError;
+import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.omg.CORBA.DynAnyPackage.TypeMismatch;
 
 import java.util.Map;
 
 import static dev.openfeature.sdk.Structure.mapToStructure;
 import static dev.openfeature.sdk.testutils.TestFlagsUtils.buildFlags;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
@@ -81,4 +86,17 @@ class InMemoryProviderTest {
         assertEquals(expectedObject, client.getObjectValue("object-flag", new Value(true)));
     }
 
+    @Test
+    void notFound() {
+        assertThrows(FlagNotFoundError.class, () -> {
+            provider.getBooleanEvaluation("not-found-flag", false, new ImmutableContext());
+        });
+    }
+
+    @Test
+    void typeMismatch() {
+        assertThrows(TypeMismatchError.class, () -> {
+            provider.getBooleanEvaluation("string-flag", false, new ImmutableContext());
+        });
+    }
 }


### PR DESCRIPTION
Small changes to satisfy jacoco coverage failing in main (bring above 80%).

Also throwing in the new in-memory provider instead of returning error resolutions.

cc @liran2000 I missed these small things on your PR. I hope they make sense.