### PR TITLE
fix: NPE on named provider init/shutdown

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -135,7 +135,7 @@ class ProviderRepository {
     }
 
     private void shutDownOld(FeatureProvider oldProvider,Consumer<FeatureProvider> afterShutdown) {
-        if (!isProviderRegistered(oldProvider)) {
+        if (oldProvider != null && !isProviderRegistered(oldProvider)) {
             shutdownProvider(oldProvider);
             afterShutdown.accept(oldProvider);
         }

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -142,7 +142,8 @@ class ProviderRepository {
     }
 
     private boolean isProviderRegistered(FeatureProvider oldProvider) {
-        return this.providers.containsValue(oldProvider) || this.defaultProvider.get().equals(oldProvider);
+        return oldProvider != null && (this.providers.containsValue(oldProvider)
+            || this.defaultProvider.get().equals(oldProvider));
     }
 
     private void shutdownProvider(FeatureProvider provider) {


### PR DESCRIPTION
fix NPE on named provider initialization.

### Problem

When initializing named provider first time, NPE is thrown.  
This may cause old provider to not shutdown properly.

### Solution

Add null check on _isProviderRegistered_.

### Steps to reproduce

1. Add dependency at pom.xml to see logs on console:
```
<dependency>
      <groupId>org.apache.logging.log4j</groupId>
      <artifactId>log4j-slf4j2-impl</artifactId>
      <version>2.20.0</version>
      <scope>test</scope>
</dependency>
```
2. Run relevant individual unit test, e.g. _dev.openfeature.sdk.EventsTest.ApiEvents.NamedProvider.Initialization_.
3. Observe console log. Without this fix, the following error appears:
```
java.lang.NullPointerException: null
	at java.util.concurrent.ConcurrentHashMap.containsValue(ConcurrentHashMap.java:979) ~[?:?]
	at dev.openfeature.sdk.ProviderRepository.isProviderRegistered(ProviderRepository.java:145) ~[classes/:?]
	at dev.openfeature.sdk.ProviderRepository.shutDownOld(ProviderRepository.java:138) ~[classes/:?]
	at dev.openfeature.sdk.ProviderRepository.initializeProvider(ProviderRepository.java:130) ~[classes/:?]
	at dev.openfeature.sdk.ProviderRepository.lambda$prepareAndInitializeProvider$2(ProviderRepository.java:115) ~[classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```