### PR TITLE
feat: provider state check

### DIFF
--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 
 import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
+import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import dev.openfeature.sdk.internal.AutoCloseableLock;
 import dev.openfeature.sdk.internal.AutoCloseableReentrantReadWriteLock;
 import dev.openfeature.sdk.internal.ObjectUtils;
@@ -163,6 +164,14 @@ public class OpenFeatureClient implements Client {
             T defaultValue,
             FeatureProvider provider,
             EvaluationContext invocationContext) {
+
+        if (!ProviderState.READY.equals(provider.getState())) {
+            if (ProviderState.NOT_READY.equals(provider.getState())) {
+                throw new ProviderNotReadyError("provider not yet initialized");
+            }
+            throw new GeneralError("unknown error");
+        }
+
         switch (type) {
             case BOOLEAN:
                 return provider.getBooleanEvaluation(key, (Boolean) defaultValue, invocationContext);

--- a/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
@@ -16,9 +16,7 @@ import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
-import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -121,12 +119,6 @@ public class InMemoryProvider extends EventProvider {
     private <T> ProviderEvaluation<T> getEvaluation(
             String key, EvaluationContext evaluationContext, Class<?> expectedType
     ) throws OpenFeatureError {
-        if (!ProviderState.READY.equals(state)) {
-            if (ProviderState.NOT_READY.equals(state)) {
-                throw new ProviderNotReadyError("provider not yet initialized");
-            }
-            throw new GeneralError("unknown error");
-        }
         Flag<?> flag = flags.get(key);
         if (flag == null) {
             throw new FlagNotFoundError("flag " + key + "not found");

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -254,9 +254,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
 
         assertEquals(Reason.ERROR.toString(), result.getReason());
         Mockito.verify(logger).error(
-                ArgumentMatchers.contains("Unable to correctly evaluate flag with key"),
-                any(),
-                ArgumentMatchers.isA(FlagNotFoundError.class));
+            ArgumentMatchers.contains("Unable to correctly evaluate flag with key"),
+            any(),
+            ArgumentMatchers.isA(FlagNotFoundError.class));
     }
 
     @Specification(number="1.2.2", text="The client interface MUST define a metadata member or accessor, containing an immutable name field or accessor of type string, which corresponds to the name value supplied during client creation.")

--- a/src/test/java/dev/openfeature/sdk/HookSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSpecTest.java
@@ -190,6 +190,10 @@ class HookSpecTest implements HookFixtures {
         List<String> evalOrder = new ArrayList<>();
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider() {
+            @Override
+            public ProviderState getState() {
+                return ProviderState.READY;
+            }
             public List<Hook> getProviderHooks() {
                 return Collections.singletonList(new BooleanHook() {
 
@@ -387,6 +391,7 @@ class HookSpecTest implements HookFixtures {
                 .thenReturn(ProviderEvaluation.<Boolean>builder()
                         .value(true)
                         .build());
+        when(provider.getState()).thenReturn(ProviderState.READY);
         InOrder order = inOrder(hook, provider);
 
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
@@ -491,6 +496,7 @@ class HookSpecTest implements HookFixtures {
         when(provider.getBooleanEvaluation(any(), any(), any())).thenReturn(ProviderEvaluation.<Boolean>builder()
                 .value(true)
                 .build());
+        when(provider.getState()).thenReturn(ProviderState.READY);
 
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         FeatureProviderTestUtils.setFeatureProvider(provider);
@@ -551,7 +557,12 @@ class HookSpecTest implements HookFixtures {
     private Client getClient(FeatureProvider provider) {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         if (provider == null) {
-            FeatureProviderTestUtils.setFeatureProvider(new NoOpProvider());
+            FeatureProviderTestUtils.setFeatureProvider(new NoOpProvider() {
+                @Override
+                public ProviderState getState() {
+                    return ProviderState.READY;
+                }
+            });
         } else {
             FeatureProviderTestUtils.setFeatureProvider(provider);
         }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -58,7 +58,7 @@ class OpenFeatureClientTest implements HookFixtures {
           .value(true).build());
         when(api.getProvider()).thenReturn(mockProvider);
         when(api.getProvider(any())).thenReturn(mockProvider);
-
+        when(mockProvider.getState()).thenReturn(ProviderState.READY);
 
         OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
         client.setEvaluationContext(ctx);

--- a/src/test/java/dev/openfeature/sdk/TestConstants.java
+++ b/src/test/java/dev/openfeature/sdk/TestConstants.java
@@ -1,5 +1,5 @@
 package dev.openfeature.sdk;
 
 public class TestConstants {
-    public static final String BROKEN_MESSAGE = "This is borked.";
+    public static final String BROKEN_MESSAGE = "This is broken.";
 }

--- a/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
@@ -6,7 +6,7 @@ import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
-import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
+import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeAll;
@@ -103,6 +103,6 @@ class InMemoryProviderTest {
         InMemoryProvider inMemoryProvider = new InMemoryProvider(new HashMap<>());
 
         // ErrorCode.PROVIDER_NOT_READY should be returned when evaluated via the client
-        assertThrows(ProviderNotReadyError.class, ()-> inMemoryProvider.getBooleanEvaluation("fail_not_initialized", false, new ImmutableContext()));
+        assertThrows(OpenFeatureError.class, ()-> inMemoryProvider.getBooleanEvaluation("fail_not_initialized", false, new ImmutableContext()));
     }
 }


### PR DESCRIPTION
According to the [spec](https://github.com/open-feature/spec/blob/main/specification/sections/02-providers.md#requirement-245):
>Requirement 2.4.5
The provider SHOULD indicate an error if flag resolution is attempted before the provider is ready.
It's recommended to set an informative error code, such as PROVIDER_NOT_READY if evaluation in attempted before the provider is initialized.

Problem:
Provider state check is implemented per provider.
Solution:
Provider state check is implemented at core SDK.

### Notes

- Hooks:
May be considered as some "behavior change", as in case of provider not ready, error is thrown, and hooks are not called, which is similar behavior to other errors handling.
- This is raised by several developers when implementing a provider, and suggested [here](https://github.com/open-feature/java-sdk-contrib/pull/424#discussion_r1321295710) by @ivarconr.
- Some providers implementation may have to adjust implementation and test for this. If implementation is not adopted, this is not expected to break something.

@toddbaert @Kavindu-Dodan @thomaspoignant 

