### PR TITLE
fix: RejectedExecutionException on shutdown

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -171,16 +171,6 @@ class ProviderRepository {
                 .concat(Stream.of(this.defaultProvider.get()), this.providers.values().stream())
                 .distinct()
                 .forEach(this::shutdownProvider);
-        setProvider(new NoOpProvider(),
-                (FeatureProvider fp) -> {
-                },
-                (FeatureProvider fp) -> {
-                },
-                (FeatureProvider fp) -> {
-                },
-                (FeatureProvider fp,
-                        String message) -> {
-                }, false);
         this.providers.clear();
         taskExecutor.shutdown();
     }

--- a/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
@@ -296,15 +296,6 @@ class ProviderRepositoryTest {
         setFeatureProvider(ANOTHER_CLIENT_NAME, featureProvider2);
 
         providerRepository.shutdown();
-
-        await()
-                .pollDelay(Duration.ofMillis(1))
-                .atMost(Duration.ofSeconds(TIMEOUT))
-                .untilAsserted(() -> {
-                    assertThat(providerRepository.getProvider()).isInstanceOf(NoOpProvider.class);
-                    assertThat(providerRepository.getProvider(CLIENT_NAME)).isInstanceOf(NoOpProvider.class);
-                    assertThat(providerRepository.getProvider(ANOTHER_CLIENT_NAME)).isInstanceOf(NoOpProvider.class);
-                });
         verify(featureProvider1, timeout(TIMEOUT)).shutdown();
         verify(featureProvider2, timeout(TIMEOUT)).shutdown();
     }


### PR DESCRIPTION
- don't reset noop provider on `ProviderRepository` shutdown, not necessary anyway since we create a whole new `ProviderRepository` on shutdown
- updated related tests

@Kavindu-Dodan you were exactly right on the cause.

Fixes: https://github.com/open-feature/java-sdk/issues/647