### PR TITLE
fix: tolerate duplicate provider registrations

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -63,7 +63,8 @@
                         default="checkstyle-xpath-suppressions.xml" />
             <property name="optional" value="true"/>
         </module>
-    
+
+        <module name="UnusedImports"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/src/main/java/dev/openfeature/sdk/EventProvider.java
+++ b/src/main/java/dev/openfeature/sdk/EventProvider.java
@@ -28,7 +28,9 @@ public abstract class EventProvider implements FeatureProvider {
      * "Attach" this EventProvider to an SDK, which allows events to propagate from this provider.
      * No-op if the same onEmit is already attached. 
      *
-     *  @param onEmit the function to run when a provider emits events.
+     * @param onEmit the function to run when a provider emits events.
+     * @throws IllegalStateException if attempted to bind a new emitter for already bound provider
+     *
      */
     void attach(TriConsumer<EventProvider, ProviderEvent, ProviderEventDetails> onEmit) {
         if (this.onEmit != null && this.onEmit != onEmit) {

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -106,15 +106,15 @@ class ProviderRepository {
               BiConsumer<FeatureProvider, String> afterError,
               boolean waitForInit) {
 
-        // provider is set immediately, on this thread
-        FeatureProvider oldProvider = clientName != null
-                ? this.providers.put(clientName, newProvider)
-                : this.defaultProvider.getAndSet(newProvider);
-
         if (!isProviderRegistered(newProvider)) {
             // only run afterSet if new provider is not already attached
             afterSet.accept(newProvider);
         }
+
+        // provider is set immediately, on this thread
+        FeatureProvider oldProvider = clientName != null
+                ? this.providers.put(clientName, newProvider)
+                : this.defaultProvider.getAndSet(newProvider);
 
         if (waitForInit) {
             initializeProvider(newProvider, afterInit, afterShutdown, afterError, oldProvider);

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -151,13 +151,13 @@ class ProviderRepository {
     }
 
     /**
-     * Helper to check if provider is already known (registered)
+     * Helper to check if provider is already known (registered).
      * @param provider provider to check for registration
      * @return boolean true if already registered, false otherwise
      */
     private boolean isProviderRegistered(FeatureProvider provider) {
-        return provider != null &&
-                (this.providers.containsValue(provider) || this.defaultProvider.get().equals(provider));
+        return provider != null
+                && (this.providers.containsValue(provider) || this.defaultProvider.get().equals(provider));
     }
 
     private void shutdownProvider(FeatureProvider provider) {

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -1,11 +1,15 @@
 package dev.openfeature.sdk;
 
+import dev.openfeature.sdk.providers.memory.InMemoryProvider;
 import dev.openfeature.sdk.testutils.FeatureProviderTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OpenFeatureAPITest {
 
@@ -38,6 +42,20 @@ class OpenFeatureAPITest {
 
         assertThat(OpenFeatureAPI.getInstance().getProvider(name).getMetadata().getName())
                 .isEqualTo(DoSomethingProvider.name);
+    }
+
+    @Test
+    void providerToMultipleNames() {
+        FeatureProvider provider = new InMemoryProvider(Collections.EMPTY_MAP);
+
+        // register same provider for multiple names & as default provider
+        OpenFeatureAPI.getInstance().setProviderAndWait(provider);
+        OpenFeatureAPI.getInstance().setProviderAndWait("clientA", provider);
+        OpenFeatureAPI.getInstance().setProviderAndWait("clientB", provider);
+
+        assertEquals(provider, OpenFeatureAPI.getInstance().getProvider());
+        assertEquals(provider, OpenFeatureAPI.getInstance().getProvider("clientA"));
+        assertEquals(provider, OpenFeatureAPI.getInstance().getProvider("clientB"));
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -46,16 +46,21 @@ class OpenFeatureAPITest {
 
     @Test
     void providerToMultipleNames() {
-        FeatureProvider provider = new InMemoryProvider(Collections.EMPTY_MAP);
+        FeatureProvider inMemAsEventingProvider = new InMemoryProvider(Collections.EMPTY_MAP);
+        FeatureProvider noOpAsNonEventingProvider = new NoOpProvider();
 
         // register same provider for multiple names & as default provider
-        OpenFeatureAPI.getInstance().setProviderAndWait(provider);
-        OpenFeatureAPI.getInstance().setProviderAndWait("clientA", provider);
-        OpenFeatureAPI.getInstance().setProviderAndWait("clientB", provider);
+        OpenFeatureAPI.getInstance().setProviderAndWait(inMemAsEventingProvider);
+        OpenFeatureAPI.getInstance().setProviderAndWait("clientA", inMemAsEventingProvider);
+        OpenFeatureAPI.getInstance().setProviderAndWait("clientB", inMemAsEventingProvider);
+        OpenFeatureAPI.getInstance().setProviderAndWait("clientC", noOpAsNonEventingProvider);
+        OpenFeatureAPI.getInstance().setProviderAndWait("clientD", noOpAsNonEventingProvider);
 
-        assertEquals(provider, OpenFeatureAPI.getInstance().getProvider());
-        assertEquals(provider, OpenFeatureAPI.getInstance().getProvider("clientA"));
-        assertEquals(provider, OpenFeatureAPI.getInstance().getProvider("clientB"));
+        assertEquals(inMemAsEventingProvider, OpenFeatureAPI.getInstance().getProvider());
+        assertEquals(inMemAsEventingProvider, OpenFeatureAPI.getInstance().getProvider("clientA"));
+        assertEquals(inMemAsEventingProvider, OpenFeatureAPI.getInstance().getProvider("clientB"));
+        assertEquals(noOpAsNonEventingProvider, OpenFeatureAPI.getInstance().getProvider("clientC"));
+        assertEquals(noOpAsNonEventingProvider, OpenFeatureAPI.getInstance().getProvider("clientD"));
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
@@ -141,17 +141,6 @@ class ProviderRepositoryTest {
 
                 verify(provider, never()).initialize(any());
             }
-
-            @Test
-            @DisplayName("Should allow same provider to be registered with multiple names")
-            void allowSameProviderOnMultipleNames() throws Exception {
-                FeatureProvider provider = createMockedProvider();
-
-                setFeatureProvider(CLIENT_NAME, provider);
-                setFeatureProvider(ANOTHER_CLIENT_NAME, provider);
-
-                verify(provider, atMostOnce()).initialize(any());
-            }
         }
     }
 

--- a/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -139,6 +140,17 @@ class ProviderRepositoryTest {
                 setFeatureProvider(CLIENT_NAME, provider);
 
                 verify(provider, never()).initialize(any());
+            }
+
+            @Test
+            @DisplayName("Should allow same provider to be registered with multiple names")
+            void allowSameProviderOnMultipleNames() throws Exception {
+                FeatureProvider provider = createMockedProvider();
+
+                setFeatureProvider(CLIENT_NAME, provider);
+                setFeatureProvider(ANOTHER_CLIENT_NAME, provider);
+
+                verify(provider, atMostOnce()).initialize(any());
             }
         }
     }

--- a/src/test/java/dev/openfeature/sdk/testutils/FeatureProviderTestUtils.java
+++ b/src/test/java/dev/openfeature/sdk/testutils/FeatureProviderTestUtils.java
@@ -8,6 +8,7 @@ import lombok.experimental.UtilityClass;
 
 import static org.awaitility.Awaitility.await;
 
+// todo check the need of this utility class as we now have setProviderAndWait capability
 @UtilityClass
 public class FeatureProviderTestUtils {
 


### PR DESCRIPTION
## This PR

Fixes a bug that prevented the same provider from being registered with multiple names (or the same provider as default and with another name).

Note that I have not changed the behavior of `EventProvider.java` where it throws if multiple eventing attachments were attempted be to registered.  