### PR TITLE
perf: improve error handling

### DIFF
--- a/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
@@ -11,7 +11,7 @@ public class FlagNotFoundError extends OpenFeatureError {
     @Getter private final ErrorCode errorCode = ErrorCode.FLAG_NOT_FOUND;
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         return this;
     }
 }

--- a/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
@@ -9,4 +9,9 @@ import lombok.experimental.StandardException;
 public class FlagNotFoundError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
     @Getter private final ErrorCode errorCode = ErrorCode.FLAG_NOT_FOUND;
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

While working with OF, I noticed that in case a flag is not found, the whole stack trace is attached to the exception.
I think this info is not necessary for this type of exception since it is hidden from the end user, and the SDK only requires the `ErrorCode` field. 

I quickly configured some JMH tests that use the InMemory FlagD provider to test the performance gains in evaluating a flag that doesn't exist. The Score value represents the amount of FF evaluations done in a single millisecond. 
In a single thread case, the performance gain is >60%. 

### Before

```
"Benchmark","Mode","Threads","Samples","Score","Score Error (99,9%)","Unit"
"booleanNotFound_01Thread","thrpt",1,10,"459,324808","8,254488","ops/ms"
"booleanNotFound_02Thread","thrpt",2,10,"791,244898","8,644711","ops/ms"
"booleanNotFound_05Thread","thrpt",5,10,"1465,736432","17,059916","ops/ms"
```

### After

```
"Benchmark","Mode","Threads","Samples","Score","Score Error (99,9%)","Unit"
"booleanNotFound_01Thread","thrpt",1,10,"765,474969","17,161956","ops/ms"
"booleanNotFound_02Thread","thrpt",2,10,"1159,854112","23,483354","ops/ms"
"booleanNotFound_05Thread","thrpt",5,10,"1828,460599","45,932954","ops/ms"
```

