### PR TITLE
fix: setProviderAndWait must throw

### DIFF
--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -18,9 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import dev.openfeature.sdk.providers.memory.InMemoryProvider;
-import dev.openfeature.sdk.testutils.TestEventsProvider;
-import lombok.SneakyThrows;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,8 +29,12 @@ import org.simplify4u.slf4jmock.LoggerMock;
 import org.slf4j.Logger;
 
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
+import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.fixtures.HookFixtures;
+import dev.openfeature.sdk.providers.memory.InMemoryProvider;
 import dev.openfeature.sdk.testutils.FeatureProviderTestUtils;
+import dev.openfeature.sdk.testutils.TestEventsProvider;
+import lombok.SneakyThrows;
 
 class FlagEvaluationSpecTest implements HookFixtures {
 
@@ -85,6 +87,17 @@ class FlagEvaluationSpecTest implements HookFixtures {
         String providerName = "providerAndWait";
         OpenFeatureAPI.getInstance().setProviderAndWait(providerName, provider);
         assertThat(api.getProvider(providerName).getState()).isEqualTo(ProviderState.READY);
+    }
+
+    @SneakyThrows
+    @Specification(number="1.1.8", text="The API SHOULD provide functions to set a provider and wait for the initialize function to return or throw.")
+    @Test void providerAndWaitError() {
+        FeatureProvider provider1 = new TestEventsProvider(500, true, "fake error");
+        assertThrows(GeneralError.class, () -> api.setProviderAndWait(provider1));
+
+        FeatureProvider provider2 = new TestEventsProvider(500, true, "fake error");
+        String providerName = "providerAndWaitError";
+        assertThrows(GeneralError.class, () -> api.setProviderAndWait(providerName, provider2));
     }
 
     @Specification(number="2.4.5", text="The provider SHOULD indicate an error if flag resolution is attempted before the provider is ready.")

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -1,15 +1,16 @@
 package dev.openfeature.sdk;
 
-import dev.openfeature.sdk.providers.memory.InMemoryProvider;
-import dev.openfeature.sdk.testutils.FeatureProviderTestUtils;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.openfeature.sdk.providers.memory.InMemoryProvider;
+import dev.openfeature.sdk.testutils.FeatureProviderTestUtils;
 
 class OpenFeatureAPITest {
 
@@ -45,7 +46,7 @@ class OpenFeatureAPITest {
     }
 
     @Test
-    void providerToMultipleNames() {
+    void providerToMultipleNames() throws Exception {
         FeatureProvider inMemAsEventingProvider = new InMemoryProvider(Collections.EMPTY_MAP);
         FeatureProvider noOpAsNonEventingProvider = new NoOpProvider();
 

--- a/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -29,6 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.testutils.exception.TestException;
 
 class ProviderRepositoryTest {
@@ -253,7 +253,7 @@ class ProviderRepositoryTest {
                 Consumer<FeatureProvider> afterSet = mock(Consumer.class);
                 Consumer<FeatureProvider> afterInit = mock(Consumer.class);
                 Consumer<FeatureProvider> afterShutdown = mock(Consumer.class);
-                BiConsumer<FeatureProvider, String> afterError = mock(BiConsumer.class);
+                BiConsumer<FeatureProvider, OpenFeatureError> afterError = mock(BiConsumer.class);
         
                 FeatureProvider oldProvider = providerRepository.getProvider();
                 FeatureProvider featureProvider1 = createMockedProvider();
@@ -274,7 +274,7 @@ class ProviderRepositoryTest {
                 Consumer<FeatureProvider> afterSet = mock(Consumer.class);
                 Consumer<FeatureProvider> afterInit = mock(Consumer.class);
                 Consumer<FeatureProvider> afterShutdown = mock(Consumer.class);
-                BiConsumer<FeatureProvider, String> afterError = mock(BiConsumer.class);
+                BiConsumer<FeatureProvider, OpenFeatureError> afterError = mock(BiConsumer.class);
         
                 FeatureProvider errorFeatureProvider = createMockedErrorProvider();
         
@@ -310,7 +310,7 @@ class ProviderRepositoryTest {
 
     private void setFeatureProvider(FeatureProvider provider, Consumer<FeatureProvider> afterSet,
             Consumer<FeatureProvider> afterInit, Consumer<FeatureProvider> afterShutdown,
-            BiConsumer<FeatureProvider, String> afterError) {
+            BiConsumer<FeatureProvider, OpenFeatureError> afterError) {
         providerRepository.setProvider(provider, afterSet, afterInit, afterShutdown,
                 afterError, false);
         waitForSettingProviderHasBeenCompleted(ProviderRepository::getProvider, provider);
@@ -348,8 +348,8 @@ class ProviderRepositoryTest {
         };
     }
 
-    private BiConsumer<FeatureProvider, String> mockAfterError() {
-        return (fp, message) -> {
+    private BiConsumer<FeatureProvider, OpenFeatureError> mockAfterError() {
+        return (fp, ex) -> {
         };
     }
 

--- a/src/test/java/dev/openfeature/sdk/testutils/TestEventsProvider.java
+++ b/src/test/java/dev/openfeature/sdk/testutils/TestEventsProvider.java
@@ -8,6 +8,7 @@ import dev.openfeature.sdk.ProviderEvent;
 import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
+import dev.openfeature.sdk.exceptions.GeneralError;
 
 public class TestEventsProvider extends EventProvider {
 
@@ -63,7 +64,7 @@ public class TestEventsProvider extends EventProvider {
             Thread.sleep(initTimeoutMs);
             if (this.initError) {
                 this.state = ProviderState.ERROR;
-                throw new Exception(initErrorMessage);
+                throw new GeneralError(initErrorMessage);
             }
             this.state = ProviderState.READY;
         }


### PR DESCRIPTION
As per [1.1.2.4](https://openfeature.dev/specification/sections/flag-evaluation#requirement-1124), the blocking provider setter must throw if init fails, so that application integrators can easily understand if their provider is working without attaching event handlers.

We implemented the wait functionality of this method, but we swallow the exception.

This PR fixes that.