### PR TITLE
fix: improve targetingKey handling in the context

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EvaluationContext.java
+++ b/src/main/java/dev/openfeature/sdk/EvaluationContext.java
@@ -6,6 +6,9 @@ package dev.openfeature.sdk;
  */
 @SuppressWarnings("PMD.BeanMembersShouldSerialize")
 public interface EvaluationContext extends Structure {
+
+    String TARGETING_KEY = "targetingKey";
+
     String getTargetingKey();
 
     /**

--- a/src/main/java/dev/openfeature/sdk/Structure.java
+++ b/src/main/java/dev/openfeature/sdk/Structure.java
@@ -113,9 +113,8 @@ public interface Structure {
     default <T extends Structure> Map<String, Value> merge(Function<Map<String, Value>, Structure> newStructure,
                                                            Map<String, Value> base,
                                                            Map<String, Value> overriding) {
-        Map<String, Value> merged = new HashMap<>();
 
-        merged.putAll(base);
+        final Map<String, Value> merged = new HashMap<>(base);
         for (Entry<String, Value> overridingEntry : overriding.entrySet()) {
             String key = overridingEntry.getKey();
             if (overridingEntry.getValue().isStructure() && merged.containsKey(key) && merged.get(key).isStructure()) {

--- a/src/test/java/dev/openfeature/sdk/EvalContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/EvalContextTest.java
@@ -1,17 +1,16 @@
 package dev.openfeature.sdk;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.cucumber.java.hu.Ha;
-import org.junit.jupiter.api.Test;
+import static dev.openfeature.sdk.EvaluationContext.TARGETING_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EvalContextTest {
     @Specification(number="3.1.1",
@@ -184,7 +183,7 @@ public class EvalContextTest {
 
         ctx2.setTargetingKey("  ");
         ctxMerged = ctx1.merge(ctx2);
-        assertEquals(key1, ctxMerged.getTargetingKey());
+        assertEquals(key2, ctxMerged.getTargetingKey());
     }
 
     @Test void asObjectMap() {
@@ -214,6 +213,7 @@ public class EvalContextTest {
 
 
         Map<String, Object> want = new HashMap<>();
+        want.put(TARGETING_KEY, key1);
         want.put("stringItem", "stringValue");
         want.put("boolItem", false);
         want.put("integerItem", 1);

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static dev.openfeature.sdk.EvaluationContext.TARGETING_KEY;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,7 +21,7 @@ class ImmutableContextTest {
         attributes.put("key2", new Value("val2"));
         EvaluationContext ctx = new ImmutableContext("targeting key", attributes);
         attributes.put("key3", new Value("val3"));
-        assertArrayEquals(new Object[]{"key1", "key2"}, ctx.keySet().toArray());
+        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, ctx.keySet().toArray());
     }
 
     @DisplayName("targeting key should be changed from the overriding context")
@@ -56,7 +57,7 @@ class ImmutableContextTest {
         EvaluationContext ctx = new ImmutableContext("targeting_key", attributes);
         EvaluationContext merge = ctx.merge(null);
         assertEquals("targeting_key", merge.getTargetingKey());
-        assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
+        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
     }
 
     @DisplayName("Merge should retain subkeys from the existing context when the overriding context has the same targeting key")
@@ -77,7 +78,7 @@ class ImmutableContextTest {
         EvaluationContext overriding = new ImmutableContext("targeting_key", overridingAttributes);
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());
-        assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
+        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
         
         Value key1 = merge.getValue("key1");
         assertTrue(key1.isStructure());


### PR DESCRIPTION
## This PR

Fixes #801. 

**What's changed?** 

I have changed how we store the targetingKey internally (in both mutable and immutable contexts). Instead of storing in a field, we now store targetingKey as a property of the delegated Structure implemementation. 

**Why** 

Both mutable and immutable contexts use a Structure implementation instance and delegate operations onto this instance. For example, `asObjectMap` and `asMap()` are exposed through this delegation. With this change, we keep the same delegation and expose targetingKey from the above-mentioned attribute exporters. 

**Impact**

There are no behaviour change other than for avoiding storing of empty string (`""`) for targetingKey.   