### PR TITLE
feat: context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,17 @@ See [here](https://javadoc.io/doc/dev.openfeature/sdk/latest/) for the Javadocs.
 
 ## 🌟 Features
 
-| Status | Features                        | Description                                                                                                                        |
-| ------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| ✅     | [Providers](#providers)         | Integrate with a commercial, open source, or in-house feature management tool.                                                     |
-| ✅     | [Targeting](#targeting)         | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
-| ✅     | [Hooks](#hooks)                 | Add functionality to various stages of the flag evaluation life-cycle.                                                             |
-| ✅     | [Logging](#logging)             | Integrate with popular logging packages.                                                                                           |
-| ✅     | [Named clients](#named-clients) | Utilize multiple providers in a single application.                                                                                |
-| ✅     | [Eventing](#eventing)           | React to state changes in the provider or flag management system.                                                                  |
-| ✅     | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                        |
-| ✅     | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                |
+| Status | Features                                                              | Description                                                                                                                                                   |
+| ------ |-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅     | [Providers](#providers)                                               | Integrate with a commercial, open source, or in-house feature management tool.                                                                                |
+| ✅     | [Targeting](#targeting)                                               | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).                            |
+| ✅     | [Hooks](#hooks)                                                       | Add functionality to various stages of the flag evaluation life-cycle.                                                                                        |
+| ✅     | [Logging](#logging)                                                   | Integrate with popular logging packages.                                                                                                                      |
+| ✅     | [Named clients](#named-clients)                                       | Utilize multiple providers in a single application.                                                                                                           |
+| ✅     | [Eventing](#eventing)                                                 | React to state changes in the provider or flag management system.                                                                                             |
+| ✅     | [Shutdown](#shutdown)                                                 | Gracefully clean up a provider during application shutdown.                                                                                                   |
+| ✅     | [Transaction Context Propagation](#transaction-context-propagation)   | Set a specific [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context) for a transaction (e.g. an HTTP request or a thread). |   
+| ✅     | [Extending](#extending)                                               | Extend OpenFeature with custom providers and hooks.                                                                                                           |
 
 <sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ OpenFeatureAPI.getInstance().shutdown();
 Transaction context is a container for transaction-specific evaluation context (e.g. user id, user agent, IP).
 Transaction context can be set where specific data is available (e.g. an auth service or request handler) and by using the transaction context propagator it will automatically be applied to all flag evaluations within a transaction (e.g. a request or thread).
 By default, the `NoOpTransactionContextPropagator` is used, which doesn't store anything.
-To register a `ThreadLocal` context propagator, you can use the `setTransactionContextPropagator` method as shown below:
+To register a `ThreadLocal` context propagator, you can use the `setTransactionContextPropagator` method as shown below.
 ```java
 // registering the ThreadLocalTransactionContextPropagator
 OpenFeatureAPI.getInstance().setTransactionContextPropagator(new ThreadLocalTransactionContextPropagator());

--- a/README.md
+++ b/README.md
@@ -273,6 +273,27 @@ This should only be called when your application is in the process of shutting d
 OpenFeatureAPI.getInstance().shutdown();
 ```
 
+### Transaction Context Propagation
+Transaction context is a container for transaction-specific evaluation context (e.g. user id, user agent, IP).
+Transaction context can be set where specific data is available (e.g. an auth service or request handler) and by using the transaction context propagator it will automatically be applied to all flag evaluations within a transaction (e.g. a request or thread).
+By default, the `NoOpTransactionContextPropagator` is used, which doesn't store anything.
+To register a `ThreadLocal` context propagator, you can use the `setTransactionContextPropagator` method as shown below:
+```java
+// registering the ThreadLocalTransactionContextPropagator
+OpenFeatureAPI.getInstance().setTransactionContextPropagator(new ThreadLocalTransactionContextPropagator());
+```
+Once you've registered a transaction context propagator, you can propagate the data into request scoped transaction context.
+
+```java
+// adding userId to transaction context
+OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+Map<String, Value> transactionAttrs = new HashMap<>();
+transactionAttrs.put("userId", new Value("userId"));
+EvaluationContext transactionCtx = new ImmutableContext(transactionAttrs);
+api.setTransactionContext(apiCtx);
+```
+Additionally, you can develop a custom transaction context propagator by implementing the `TransactionContextPropagator` interface and registering it as shown above.
+
 ## Extending
 
 ### Develop a provider

--- a/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
+++ b/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
@@ -1,0 +1,24 @@
+package dev.openfeature.sdk;
+
+/**
+ * A {@link TransactionContextPropagator} that simply returns null.
+ */
+public class NoOpTransactionContextPropagator implements TransactionContextPropagator {
+
+    /**
+     * {@inheritDoc}
+     * @return null
+     */
+    @Override
+    public EvaluationContext getTransactionContext() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTransactionContext(EvaluationContext evaluationContext) {
+
+    }
+}

--- a/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
+++ b/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
@@ -1,17 +1,17 @@
 package dev.openfeature.sdk;
 
 /**
- * A {@link TransactionContextPropagator} that simply returns null.
+ * A {@link TransactionContextPropagator} that simply returns empty context.
  */
 public class NoOpTransactionContextPropagator implements TransactionContextPropagator {
 
     /**
      * {@inheritDoc}
-     * @return null
+     * @return empty immutable context
      */
     @Override
     public EvaluationContext getTransactionContext() {
-        return null;
+        return new ImmutableContext();
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -127,14 +127,14 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
      *
      * @return {@link EvaluationContext} The current transaction context
      */
-    public EvaluationContext getTransactionContext() {
+    EvaluationContext getTransactionContext() {
         return this.transactionContextPropagator.getTransactionContext();
     }
 
     /**
      * Sets the transaction context using the registered transaction context propagator.
      */
-    void setTransactionContext(EvaluationContext evaluationContext) {
+    public void setTransactionContext(EvaluationContext evaluationContext) {
         this.transactionContextPropagator.setTransactionContext(evaluationContext);
     }
 

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -164,9 +164,7 @@ public class OpenFeatureClient implements Client {
                 ? openfeatureApi.getTransactionContext()
                 : new ImmutableContext();
 
-        EvaluationContext mergedInvocationCtx = invocationContext.merge(hookContext);
-
-        return apiContext.merge(transactionContext.merge(clientContext.merge(mergedInvocationCtx)));
+        return apiContext.merge(transactionContext.merge(clientContext.merge(invocationContext.merge(hookContext))));
     }
 
     private <T> ProviderEvaluation<?> createProviderEvaluation(

--- a/src/main/java/dev/openfeature/sdk/ThreadLocalTransactionContextPropagator.java
+++ b/src/main/java/dev/openfeature/sdk/ThreadLocalTransactionContextPropagator.java
@@ -1,0 +1,28 @@
+package dev.openfeature.sdk;
+
+/**
+ * A {@link ThreadLocalTransactionContextPropagator} is a transactional context propagator
+ * that uses a ThreadLocal to persist a transactional context for the duration of a single thread.
+ *
+ * @see TransactionContextPropagator
+ */
+public class ThreadLocalTransactionContextPropagator implements TransactionContextPropagator {
+
+    private final ThreadLocal<EvaluationContext> evaluationContextThreadLocal = new ThreadLocal<>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EvaluationContext getTransactionContext() {
+        return this.evaluationContextThreadLocal.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTransactionContext(EvaluationContext evaluationContext) {
+        this.evaluationContextThreadLocal.set(evaluationContext);
+    }
+}

--- a/src/main/java/dev/openfeature/sdk/TransactionContextPropagator.java
+++ b/src/main/java/dev/openfeature/sdk/TransactionContextPropagator.java
@@ -1,0 +1,27 @@
+package dev.openfeature.sdk;
+
+/**
+ * {@link TransactionContextPropagator} is responsible for persisting a transactional context
+ * for the duration of a single transaction.
+ * Examples of potential transaction specific context include: a user id, user agent, IP.
+ * Transaction context is merged with evaluation context prior to flag evaluation.
+ * <p>
+ * The precedence of merging context can be seen in
+ * <a href=https://openfeature.dev/specification/sections/evaluation-context#requirement-323>the specification</a>.
+ * </p>
+ */
+public interface TransactionContextPropagator {
+
+    /**
+     * Returns the currently defined transaction context using the registered transaction
+     * context propagator.
+     *
+     * @return {@link EvaluationContext} The current transaction context
+     */
+    EvaluationContext getTransactionContext();
+
+    /**
+     * Sets the transaction context.
+     */
+    void setTransactionContext(EvaluationContext evaluationContext);
+}

--- a/src/test/java/dev/openfeature/sdk/LockingTest.java
+++ b/src/test/java/dev/openfeature/sdk/LockingTest.java
@@ -185,6 +185,20 @@ class LockingTest {
         verify(apiLock.readLock()).unlock();
     }
 
+    @Test
+    void setTransactionalContextPropagatorShouldWriteLockAndUnlock() {
+        api.setTransactionContextPropagator(new NoOpTransactionContextPropagator());
+        verify(apiLock.writeLock()).lock();
+        verify(apiLock.writeLock()).unlock();
+    }
+
+    @Test
+    void getTransactionalContextPropagatorShouldReadLockAndUnlock() {
+        api.getTransactionContextPropagator();
+        verify(apiLock.readLock()).lock();
+        verify(apiLock.readLock()).unlock();
+    }
+
 
     @Test
     void clearHooksShouldWriteLockAndUnlock() {

--- a/src/test/java/dev/openfeature/sdk/NoOpTransactionContextPropagatorTest.java
+++ b/src/test/java/dev/openfeature/sdk/NoOpTransactionContextPropagatorTest.java
@@ -1,0 +1,23 @@
+package dev.openfeature.sdk;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NoOpTransactionContextPropagatorTest {
+
+    NoOpTransactionContextPropagator contextPropagator = new NoOpTransactionContextPropagator();
+
+    @Test
+    public void emptyTransactionContext() {
+        EvaluationContext result = contextPropagator.getTransactionContext();
+        assertNull(result);
+    }
+
+    @Test
+    public void setTransactionContext() {
+        EvaluationContext firstContext = new ImmutableContext();
+        contextPropagator.setTransactionContext(firstContext);
+        assertNull(contextPropagator.getTransactionContext());
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/NoOpTransactionContextPropagatorTest.java
+++ b/src/test/java/dev/openfeature/sdk/NoOpTransactionContextPropagatorTest.java
@@ -2,6 +2,9 @@ package dev.openfeature.sdk;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class NoOpTransactionContextPropagatorTest {
@@ -11,13 +14,16 @@ class NoOpTransactionContextPropagatorTest {
     @Test
     public void emptyTransactionContext() {
         EvaluationContext result = contextPropagator.getTransactionContext();
-        assertNull(result);
+        assertTrue(result.asMap().isEmpty());
     }
 
     @Test
     public void setTransactionContext() {
-        EvaluationContext firstContext = new ImmutableContext();
-        contextPropagator.setTransactionContext(firstContext);
-        assertNull(contextPropagator.getTransactionContext());
+        Map<String, Value> transactionAttrs = new HashMap<>();
+        transactionAttrs.put("userId", new Value("userId"));
+        EvaluationContext transactionCtx = new ImmutableContext(transactionAttrs);
+        contextPropagator.setTransactionContext(transactionCtx);
+        EvaluationContext result = contextPropagator.getTransactionContext();
+        assertTrue(result.asMap().isEmpty());
     }
 }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -73,4 +73,9 @@ class OpenFeatureAPITest {
     void settingNamedClientProviderToNullErrors() {
         assertThatCode(() -> api.setProvider(CLIENT_NAME, null)).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void settingTransactionalContextPropagatorToNullErrors() {
+        assertThatCode(() -> api.setTransactionContextPropagator(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/src/test/java/dev/openfeature/sdk/ThreadLocalTransactionContextPropagatorTest.java
+++ b/src/test/java/dev/openfeature/sdk/ThreadLocalTransactionContextPropagatorTest.java
@@ -1,0 +1,57 @@
+package dev.openfeature.sdk;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ThreadLocalTransactionContextPropagatorTest {
+
+    ThreadLocalTransactionContextPropagator contextPropagator = new ThreadLocalTransactionContextPropagator();
+
+    @Test
+    public void setTransactionContextOneThread() {
+        EvaluationContext firstContext = new ImmutableContext();
+        contextPropagator.setTransactionContext(firstContext);
+        assertSame(firstContext, contextPropagator.getTransactionContext());
+        EvaluationContext secondContext = new ImmutableContext();
+        contextPropagator.setTransactionContext(secondContext);
+        assertNotSame(firstContext, contextPropagator.getTransactionContext());
+        assertSame(secondContext, contextPropagator.getTransactionContext());
+    }
+
+    @Test
+    public void emptyTransactionContext() {
+        EvaluationContext result = contextPropagator.getTransactionContext();
+        assertNull(result);
+    }
+
+    @SneakyThrows
+    @Test
+    public void setTransactionContextTwoThreads() {
+        EvaluationContext firstContext = new ImmutableContext();
+        EvaluationContext secondContext = new ImmutableContext();
+
+        Callable<EvaluationContext> callable = () -> {
+            assertNull(contextPropagator.getTransactionContext());
+            contextPropagator.setTransactionContext(secondContext);
+            EvaluationContext transactionContext = contextPropagator.getTransactionContext();
+            assertSame(secondContext, transactionContext);
+            return transactionContext;
+        };
+        contextPropagator.setTransactionContext(firstContext);
+        EvaluationContext firstThreadContext = contextPropagator.getTransactionContext();
+        assertSame(firstContext, firstThreadContext);
+
+        FutureTask<EvaluationContext> futureTask = new FutureTask<>(callable);
+        Thread thread = new Thread(futureTask);
+        thread.start();
+        EvaluationContext secondThreadContext = futureTask.get();
+
+        assertSame(secondContext, secondThreadContext);
+        assertSame(firstContext, firstThreadContext);
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/ThreadLocalTransactionContextPropagatorTest.java
+++ b/src/test/java/dev/openfeature/sdk/ThreadLocalTransactionContextPropagatorTest.java
@@ -52,6 +52,6 @@ public class ThreadLocalTransactionContextPropagatorTest {
         EvaluationContext secondThreadContext = futureTask.get();
 
         assertSame(secondContext, secondThreadContext);
-        assertSame(firstContext, firstThreadContext);
+        assertSame(firstContext, contextPropagator.getTransactionContext());
     }
 }


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->
- adds transactional context support

### Related Issues
Fixes #819

### Notes
- This is my first PR here, so I'll appreciate any feedback you can provide!
- I'm not sure if `OpenFeatureAPI` should use `NoOpTransactionContextPropagator` as a default `TransactionContextPropagator`, or if it can simply be `null`.
- I assume there was a mistake in the test `FlagEvaluationSpecTest.multi_layer_context_merges_correctly()` - attributes were put in the same `HashMap` twice. Have a look at it, please, and if I'm mistaken, I'll revert the changes.
