### PR TITLE
fix: missing targeting key should return null

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -62,7 +62,8 @@ public final class ImmutableContext implements EvaluationContext {
      */
     @Override
     public String getTargetingKey() {
-        return this.getValue(TARGETING_KEY).asString();
+        Value value = this.getValue(TARGETING_KEY);
+        return value == null ? null : value.asString();
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -99,7 +99,8 @@ public class MutableContext implements EvaluationContext {
      */
     @Override
     public String getTargetingKey() {
-        return this.getValue(TARGETING_KEY).asString();
+        Value value = this.getValue(TARGETING_KEY);
+        return value == null ? null : value.asString();
     }
 
     /**

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -47,6 +47,12 @@ class ImmutableContextTest {
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());
     }
+    @DisplayName("missing targeting key should return null")
+    @Test
+    void missingTargetingKeyShould() {
+        EvaluationContext ctx = new ImmutableContext();
+        assertEquals(null, ctx.getTargetingKey());
+    }
 
     @DisplayName("Merge should retain all the attributes from the existing context when overriding context is null")
     @Test

--- a/src/test/java/dev/openfeature/sdk/MutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/MutableContextTest.java
@@ -1,0 +1,105 @@
+package dev.openfeature.sdk;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static dev.openfeature.sdk.EvaluationContext.TARGETING_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MutableContextTest {
+
+    @DisplayName("targeting key should be changed from the overriding context")
+    @Test
+    void shouldChangeTargetingKeyFromOverridingContext() {
+        HashMap<String, Value> attributes = new HashMap<>();
+        attributes.put("key1", new Value("val1"));
+        attributes.put("key2", new Value("val2"));
+        EvaluationContext ctx = new MutableContext("targeting key", attributes);
+        EvaluationContext overriding = new MutableContext("overriding_key");
+        EvaluationContext merge = ctx.merge(overriding);
+        assertEquals("overriding_key", merge.getTargetingKey());
+    }
+
+    @DisplayName("targeting key should not changed from the overriding context if missing")
+    @Test
+    void shouldRetainTargetingKeyWhenOverridingContextTargetingKeyValueIsEmpty() {
+        HashMap<String, Value> attributes = new HashMap<>();
+        attributes.put("key1", new Value("val1"));
+        attributes.put("key2", new Value("val2"));
+        EvaluationContext ctx = new MutableContext("targeting_key", attributes);
+        EvaluationContext overriding = new MutableContext("");
+        EvaluationContext merge = ctx.merge(overriding);
+        assertEquals("targeting_key", merge.getTargetingKey());
+    }
+    @DisplayName("missing targeting key should return null")
+    @Test
+    void missingTargetingKeyShould() {
+        EvaluationContext ctx = new MutableContext();
+        assertEquals(null, ctx.getTargetingKey());
+    }
+
+    @DisplayName("Merge should retain all the attributes from the existing context when overriding context is null")
+    @Test
+    void mergeShouldReturnAllTheValuesFromTheContextWhenOverridingContextIsNull() {
+        HashMap<String, Value> attributes = new HashMap<>();
+        attributes.put("key1", new Value("val1"));
+        attributes.put("key2", new Value("val2"));
+        EvaluationContext ctx = new MutableContext("targeting_key", attributes);
+        EvaluationContext merge = ctx.merge(null);
+        assertEquals("targeting_key", merge.getTargetingKey());
+        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
+    }
+
+    @DisplayName("Merge should retain subkeys from the existing context when the overriding context has the same targeting key")
+    @Test
+    void mergeShouldRetainItsSubkeysWhenOverridingContextHasTheSameKey() {
+        HashMap<String, Value> attributes = new HashMap<>();
+        HashMap<String, Value> overridingAttributes = new HashMap<>();
+        HashMap<String, Value> key1Attributes = new HashMap<>();
+        HashMap<String, Value> ovKey1Attributes = new HashMap<>();
+
+        key1Attributes.put("key1_1", new Value("val1_1"));
+        attributes.put("key1", new Value(new ImmutableStructure(key1Attributes)));
+        attributes.put("key2", new Value("val2"));
+        ovKey1Attributes.put("overriding_key1_1", new Value("overriding_val_1_1"));
+        overridingAttributes.put("key1", new Value(new ImmutableStructure(ovKey1Attributes)));
+        
+        EvaluationContext ctx = new MutableContext("targeting_key", attributes);
+        EvaluationContext overriding = new MutableContext("targeting_key", overridingAttributes);
+        EvaluationContext merge = ctx.merge(overriding);
+        assertEquals("targeting_key", merge.getTargetingKey());
+        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
+        
+        Value key1 = merge.getValue("key1");
+        assertTrue(key1.isStructure());
+        
+        Structure value = key1.asStructure();
+        assertArrayEquals(new Object[]{"key1_1","overriding_key1_1"}, value.keySet().toArray());
+    }
+    
+    @DisplayName("Merge should retain subkeys from the existing context when the overriding context doesn't have targeting key")
+    @Test
+    void mergeShouldRetainItsSubkeysWhenOverridingContextHasNoTargetingKey() {
+        HashMap<String, Value> attributes = new HashMap<>();
+        HashMap<String, Value> key1Attributes = new HashMap<>();
+
+        key1Attributes.put("key1_1", new Value("val1_1"));
+        attributes.put("key1", new Value(new ImmutableStructure(key1Attributes)));
+        attributes.put("key2", new Value("val2"));
+        
+        EvaluationContext ctx = new MutableContext(attributes);
+        EvaluationContext overriding = new MutableContext();
+        EvaluationContext merge = ctx.merge(overriding);
+        assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
+        
+        Value key1 = merge.getValue("key1");
+        assertTrue(key1.isStructure());
+        
+        Structure value = key1.asStructure();
+        assertArrayEquals(new Object[]{"key1_1"}, value.keySet().toArray());
+    }
+}


### PR DESCRIPTION
Problem:
getTargetingKey of missing targeting key causing NullPointerException.
Solution:
getTargetingKey of missing targeting key returns null.

failing _java-sdk-contrib_ [CI](https://github.com/open-feature/java-sdk-contrib/actions/runs/8314110946/job/22750876680?pr=722):
```
Error:  dev.openfeature.contrib.providers.flagd.resolver.process.targeting.OperatorTest.timestampPresent -- Time elapsed: 0.006 s <<< ERROR!
java.lang.NullPointerException
	at dev.openfeature.sdk.ImmutableContext.getTargetingKey(ImmutableContext.java:65)
	at dev.openfeature.contrib.providers.flagd.resolver.process.targeting.Operator.apply(Operator.java:52)
```


When adopting #805, saw an issue when [checking missing targeting](https://github.com/open-feature/java-sdk-contrib/blob/main/providers/statsig/src/main/java/dev/openfeature/contrib/providers/statsig/ContextTransformer.java#L25) key when it is required, causing the check to not work properly:
```
if (ctx.getTargetingKey() == null) {
    throw new TargetingKeyMissingError("targeting key is required.");
}
```

Related [test](https://github.com/open-feature/java-sdk-contrib/pull/722/files#diff-8c58451457555d525c75ac688495b1b2543885582f14a6d8e1a43bbd2cf845e6R122) check can be updated after this fix.
