### PR TITLE
fix: shutdown method blocks until task executor shutdown completes

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EventSupport.java
+++ b/src/main/java/dev/openfeature/sdk/EventSupport.java
@@ -152,13 +152,15 @@ class EventSupport {
      * or timeout period has elapsed.
      */
     public void shutdown() {
+        taskExecutor.shutdown();
         try {
-            taskExecutor.shutdown();
             if (!taskExecutor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 log.warn("Task executor did not terminate before the timeout period had elapsed");
+                taskExecutor.shutdownNow();
             }
-        } catch (Exception e) {
-            log.warn("Exception while attempting to shutdown task executor", e);
+        } catch (InterruptedException e) {
+            taskExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/main/java/dev/openfeature/sdk/EventSupport.java
+++ b/src/main/java/dev/openfeature/sdk/EventSupport.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /**
@@ -23,6 +24,7 @@ class EventSupport {
     // we use a v4 uuid as a "placeholder" for anonymous clients, since
     // ConcurrentHashMap doesn't support nulls
     private static final String defaultClientUuid = UUID.randomUUID().toString();
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 3;
     private final Map<String, HandlerStore> handlerStores = new ConcurrentHashMap<>();
     private final HandlerStore globalHandlerStore = new HandlerStore();
     private final ExecutorService taskExecutor = Executors.newCachedThreadPool(runnable -> {
@@ -146,11 +148,15 @@ class EventSupport {
     }
 
     /**
-     * Stop the event handler task executor.
+     * Stop the event handler task executor and block until either termination has completed
+     * or timeout period has elapsed.
      */
     public void shutdown() {
         try {
             taskExecutor.shutdown();
+            if (!taskExecutor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                log.warn("Task executor did not terminate before the timeout period had elapsed");
+            }
         } catch (Exception e) {
             log.warn("Exception while attempting to shutdown task executor", e);
         }


### PR DESCRIPTION
## This PR
is to ensure the shutdown method waits until the task executor (which is a daemon thread) has either completed shutdown or the timeout period elapses.

### Related Issues

Fixes #683

### Notes
I set the period to wait for completion to 3 seconds

### Follow-up Tasks
n/a

### How to test
n/a

