### PR TITLE
fix: consistent method chainability

### DIFF
--- a/src/main/java/dev/openfeature/sdk/Client.java
+++ b/src/main/java/dev/openfeature/sdk/Client.java
@@ -18,7 +18,7 @@ public interface Client extends Features, EventBus<Client> {
      * Set the client-level evaluation context.
      * @param ctx Client level context.
      */
-    void setEvaluationContext(EvaluationContext ctx);
+    Client setEvaluationContext(EvaluationContext ctx);
 
     /**
      * Adds hooks for evaluation.
@@ -26,7 +26,7 @@ public interface Client extends Features, EventBus<Client> {
      *
      * @param hooks The hook to add.
      */
-    void addHooks(Hook... hooks);
+    Client addHooks(Hook... hooks);
 
     /**
      * Fetch the hooks associated to this client.

--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -87,10 +87,11 @@ public class MutableContext implements EvaluationContext {
     /**
      * Override or set targeting key for this mutable context. Value should be non-null and non-empty to be accepted.
      */
-    public void setTargetingKey(String targetingKey) {
+    public MutableContext setTargetingKey(String targetingKey) {
         if (targetingKey != null && !targetingKey.trim().isEmpty()) {
             this.add(TARGETING_KEY, targetingKey);
         }
+        return this;
     }
 
 

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -83,10 +83,11 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
     /**
      * {@inheritDoc}
      */
-    public void setEvaluationContext(EvaluationContext evaluationContext) {
+    public OpenFeatureAPI setEvaluationContext(EvaluationContext evaluationContext) {
         try (AutoCloseableLock __ = lock.writeLockAutoCloseable()) {
             this.evaluationContext = evaluationContext;
         }
+        return this;
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -56,10 +56,11 @@ public class OpenFeatureClient implements Client {
      * {@inheritDoc}
      */
     @Override
-    public void addHooks(Hook... hooks) {
+    public OpenFeatureClient addHooks(Hook... hooks) {
         try (AutoCloseableLock __ = this.hooksLock.writeLockAutoCloseable()) {
             this.clientHooks.addAll(Arrays.asList(hooks));
         }
+        return this;
     }
 
     /**
@@ -76,10 +77,11 @@ public class OpenFeatureClient implements Client {
      * {@inheritDoc}
      */
     @Override
-    public void setEvaluationContext(EvaluationContext evaluationContext) {
+    public OpenFeatureClient setEvaluationContext(EvaluationContext evaluationContext) {
         try (AutoCloseableLock __ = contextLock.writeLockAutoCloseable()) {
             this.evaluationContext = evaluationContext;
         }
+        return this;
     }
 
     /**

--- a/src/test/java/dev/openfeature/sdk/MutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/MutableContextTest.java
@@ -116,4 +116,19 @@ class MutableContextTest {
         Structure value = key1.asStructure();
         assertArrayEquals(new Object[]{"key1_1"}, value.keySet().toArray());
     }
+
+    @DisplayName("Ensuring mutations are chainable")
+    @Test
+    void shouldAllowChainingOfMutations() {
+        MutableContext context = new MutableContext();
+        context.add("key1", "val1")
+                .add("key2", 2)
+                .setTargetingKey("TARGETING_KEY")
+                .add("key3", 3.0);
+
+        assertEquals("TARGETING_KEY", context.getTargetingKey());
+        assertEquals("val1", context.getValue("key1").asString());
+        assertEquals(2, context.getValue("key2").asInteger());
+        assertEquals(3.0, context.getValue("key3").asDouble());        
+    }
 }

--- a/src/test/java/dev/openfeature/sdk/MutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/MutableContextTest.java
@@ -117,7 +117,7 @@ class MutableContextTest {
         assertArrayEquals(new Object[]{"key1_1"}, value.keySet().toArray());
     }
 
-    @DisplayName("Ensuring mutations are chainable")
+    @DisplayName("Ensure mutations are chainable")
     @Test
     void shouldAllowChainingOfMutations() {
         MutableContext context = new MutableContext();

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,5 +78,13 @@ class OpenFeatureAPITest {
     @Test
     void settingTransactionalContextPropagatorToNullErrors() {
         assertThatCode(() -> api.setTransactionContextPropagator(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void setEvaluationContextShouldAllowChaining() {
+        OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
+        EvaluationContext ctx = new ImmutableContext("targeting key", new HashMap<>());
+        OpenFeatureClient result = client.setEvaluationContext(ctx);
+        assertEquals(client, result);
     }
 }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -3,12 +3,21 @@ package dev.openfeature.sdk;
 import java.util.*;
 
 import dev.openfeature.sdk.fixtures.HookFixtures;
+import net.sf.saxon.expr.Component.M;
+
+import org.checkerframework.checker.units.qual.m;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.simplify4u.slf4jmock.LoggerMock;
 import org.slf4j.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class OpenFeatureClientTest implements HookFixtures {
@@ -67,4 +76,28 @@ class OpenFeatureClientTest implements HookFixtures {
 
         assertThat(result.getValue()).isTrue();
     }
+
+    @Test
+    @DisplayName("addHooks should allow chaining by returning the same client instance")
+    void addHooksShouldAllowChaining() {
+        OpenFeatureAPI api = mock(OpenFeatureAPI.class);
+        OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
+        Hook<?> hook1 = Mockito.mock(Hook.class);
+        Hook<?> hook2 = Mockito.mock(Hook.class);
+
+        OpenFeatureClient result = client.addHooks(hook1, hook2);
+        assertSame(client, result, "addHooks method should be chainable");    
+    }
+
+    @Test
+    @DisplayName("setEvaluationContext should allow chaining by returning the same client instance")
+    void setEvaluationContextShouldAllowChaining() {
+        OpenFeatureAPI api = mock(OpenFeatureAPI.class);
+        OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
+        EvaluationContext ctx = new ImmutableContext("targeting key", new HashMap<>());
+
+        OpenFeatureClient result = client.setEvaluationContext(ctx);
+        assertSame(client, result, "setEvaluationContext method should be chainable");
+    }
+        
 }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -3,9 +3,7 @@ package dev.openfeature.sdk;
 import java.util.*;
 
 import dev.openfeature.sdk.fixtures.HookFixtures;
-import net.sf.saxon.expr.Component.M;
 
-import org.checkerframework.checker.units.qual.m;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.simplify4u.slf4jmock.LoggerMock;
@@ -13,7 +11,6 @@ import org.slf4j.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -86,7 +83,7 @@ class OpenFeatureClientTest implements HookFixtures {
         Hook<?> hook2 = Mockito.mock(Hook.class);
 
         OpenFeatureClient result = client.addHooks(hook1, hook2);
-        assertSame(client, result, "addHooks method should be chainable");    
+        assertEquals(client, result);  
     }
 
     @Test
@@ -97,7 +94,7 @@ class OpenFeatureClientTest implements HookFixtures {
         EvaluationContext ctx = new ImmutableContext("targeting key", new HashMap<>());
 
         OpenFeatureClient result = client.setEvaluationContext(ctx);
-        assertSame(client, result, "setEvaluationContext method should be chainable");
+        assertEquals(client, result);
     }
-        
+   
 }


### PR DESCRIPTION
-Client Interface: Modified `setEvaluationContext` and `addHooks` to return `Client` instances, enabling chaining.
-MutableContext: Updated `setTargetingKey` to return a `MutableContext` instance.
-OpenFeatureAPI: Altered `setEvaluationContext` to return `OpenFeatureAPI` instances.
-OpenFeatureClient: Updated both `addHooks` and `setEvaluationContext` to return `OpenFeatureClient` instances.
-Added unit tests to verify chainability for each updated method.

Fixes: https://github.com/open-feature/java-sdk/issues/906