### PR TITLE
fix: PMD warnings with new version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.21.2</version>
+        <version>3.22.0</version>
         <executions>
           <execution>
             <id>run-pmd</id>

--- a/src/main/java/dev/openfeature/sdk/EventDetails.java
+++ b/src/main/java/dev/openfeature/sdk/EventDetails.java
@@ -13,14 +13,14 @@ public class EventDetails extends ProviderEventDetails {
     private String providerName;
 
     static EventDetails fromProviderEventDetails(ProviderEventDetails providerEventDetails, String providerName) {
-        return EventDetails.fromProviderEventDetails(providerEventDetails, providerName, null);
+        return fromProviderEventDetails(providerEventDetails, providerName, null);
     }
 
     static EventDetails fromProviderEventDetails(
             ProviderEventDetails providerEventDetails,
             String providerName,
             String clientName) {
-        return EventDetails.builder()
+        return builder()
                 .clientName(clientName)
                 .providerName(providerName)
                 .flagsChanged(providerEventDetails.getFlagsChanged())

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
  * Configuration here will be shared across all {@link Client}s.
  */
 @Slf4j
+@SuppressWarnings("PMD.UnusedLocalVariable")
 public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
     // package-private multi-read/single-write lock
     static AutoCloseableReentrantReadWriteLock lock = new AutoCloseableReentrantReadWriteLock();

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -19,7 +19,8 @@ import lombok.extern.slf4j.Slf4j;
  * {@inheritDoc}
  */
 @Slf4j
-@SuppressWarnings({ "PMD.DataflowAnomalyAnalysis", "PMD.BeanMembersShouldSerialize", "unchecked", "rawtypes" })
+@SuppressWarnings({ "PMD.DataflowAnomalyAnalysis", "PMD.BeanMembersShouldSerialize",
+                    "PMD.UnusedLocalVariable", "unchecked", "rawtypes" })
 public class OpenFeatureClient implements Client {
 
     private final OpenFeatureAPI openfeatureApi;
@@ -107,7 +108,8 @@ public class OpenFeatureClient implements Client {
         FeatureProvider provider;
 
         try {
-            // openfeatureApi.getProvider() must be called once to maintain a consistent reference
+            // openfeatureApi.getProvider() must be called once to maintain a consistent
+            // reference
             provider = openfeatureApi.getProvider(this.name);
 
             mergedHooks = ObjectUtils.merge(provider.getProviderHooks(), flagOptions.getHooks(), clientHooks,

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -108,8 +108,7 @@ public class OpenFeatureClient implements Client {
         FeatureProvider provider;
 
         try {
-            // openfeatureApi.getProvider() must be called once to maintain a consistent
-            // reference
+            // openfeatureApi.getProvider() must be called once to maintain a consistent reference
             provider = openfeatureApi.getProvider(this.name);
 
             mergedHooks = ObjectUtils.merge(provider.getProviderHooks(), flagOptions.getHooks(), clientHooks,


### PR DESCRIPTION
Was getting an unused local variable error due to "__" not being a named variable within try-with-resources blocks. Warnings have been suppressed.

https://stackoverflow.com/questions/16588843/why-does-try-with-resource-require-a-local-variable

#910 