### PR TITLE
fix: updated context not passed to all hooks

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -73,7 +73,7 @@ public final class ImmutableContext implements EvaluationContext {
      * Merges this EvaluationContext object with the passed EvaluationContext, overriding in case of conflict.
      *
      * @param overridingContext overriding context
-     * @return resulting merged context
+     * @return new, resulting merged context
      */
     @Override
     public EvaluationContext merge(EvaluationContext overridingContext) {

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -116,7 +116,7 @@ public class OpenFeatureClient implements Client {
                     openfeatureApi.getHooks());
 
             EvaluationContext mergedCtx = hookSupport.beforeHooks(type, HookContext.from(key, type, this.getMetadata(),
-            provider.getMetadata(), mergeEvaluationContext(ctx), defaultValue), mergedHooks, hints);
+                    provider.getMetadata(), mergeEvaluationContext(ctx), defaultValue), mergedHooks, hints);
 
             afterHookContext = HookContext.from(key, type, this.getMetadata(),
                     provider.getMetadata(), mergedCtx, defaultValue);

--- a/src/test/java/dev/openfeature/sdk/HookSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSpecTest.java
@@ -484,10 +484,11 @@ class HookSpecTest implements HookFixtures {
     @Specification(number = "4.1.4", text = "The evaluation context MUST be mutable only within the before hook.")
     @Specification(number = "4.3.4", text = "Any `evaluation context` returned from a `before` hook MUST be passed to subsequent `before` hooks (via `HookContext`).")
     @Test void beforeContextUpdated() {
-        EvaluationContext ctx = new ImmutableContext();
-        Hook hook = mockBooleanHook();
+        String targetingKey = "test-key";
+        EvaluationContext ctx = new ImmutableContext(targetingKey);
+        Hook<Boolean> hook = mockBooleanHook();
         when(hook.before(any(), any())).thenReturn(Optional.of(ctx));
-        Hook hook2 = mockBooleanHook();
+        Hook<Boolean> hook2 = mockBooleanHook();
         when(hook.before(any(), any())).thenReturn(Optional.empty());
         InOrder order = inOrder(hook, hook2);
 
@@ -499,11 +500,11 @@ class HookSpecTest implements HookFixtures {
                         .build());
 
         order.verify(hook).before(any(), any());
-        ArgumentCaptor<HookContext> captor = ArgumentCaptor.forClass(HookContext.class);
+        ArgumentCaptor<HookContext<Boolean>> captor = ArgumentCaptor.forClass(HookContext.class);
         order.verify(hook2).before(captor.capture(), any());
 
-        HookContext hc = captor.getValue();
-        assertEquals(hc.getCtx(), ctx);
+        HookContext<Boolean> hc = captor.getValue();
+        assertEquals(hc.getCtx().getTargetingKey(), targetingKey);
 
     }
 


### PR DESCRIPTION
Fixes an issue where the fully merged and updated context was used in the evaluation, but not in all hooks.

Fixes: https://github.com/open-feature/java-sdk/issues/1047