### PR TITLE
fix: Use ConcurrentHashMap for InMemoryProvider

### DIFF
--- a/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
@@ -67,7 +67,6 @@ public class InMemoryProvider extends EventProvider {
      */
     public void updateFlags(Map<String, Flag<?>> newFlags) {
         Set<String> flagsChanged = new HashSet<>(newFlags.keySet());
-        flagsChanged.removeAll(this.flags.keySet());
         this.flags.putAll(newFlags);
 
         ProviderEventDetails details = ProviderEventDetails.builder()

--- a/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
@@ -2,10 +2,10 @@ package dev.openfeature.sdk.providers.memory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
@@ -44,7 +44,7 @@ public class InMemoryProvider extends EventProvider {
     }
 
     public InMemoryProvider(Map<String, Flag<?>> flags) {
-        this.flags = new HashMap<>(flags);
+        this.flags = new ConcurrentHashMap<>(flags);
     }
 
     /**
@@ -67,7 +67,7 @@ public class InMemoryProvider extends EventProvider {
         Set<String> flagsChanged = new HashSet<>();
         flagsChanged.addAll(this.flags.keySet());
         flagsChanged.addAll(flags.keySet());
-        this.flags = new HashMap<>(flags);
+        this.flags = new ConcurrentHashMap<>(flags);
         ProviderEventDetails details = ProviderEventDetails.builder()
             .flagsChanged(new ArrayList<>(flagsChanged))
             .message("flags changed")

--- a/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
@@ -33,7 +33,7 @@ public class InMemoryProvider extends EventProvider {
     @Getter
     private static final String NAME = "InMemoryProvider";
 
-    private Map<String, Flag<?>> flags;
+    private final Map<String, Flag<?>> flags;
 
     @Getter
     private ProviderState state = ProviderState.NOT_READY;
@@ -61,13 +61,13 @@ public class InMemoryProvider extends EventProvider {
 
     /**
      * Updating provider flags configuration, replacing existing flags.
-     * @param flags the flags to use instead of the previous flags.
+     * @param newFlags the flags to use instead of the previous flags.
      */
-    public void updateFlags(Map<String, Flag<?>> flags) {
-        Set<String> flagsChanged = new HashSet<>();
-        flagsChanged.addAll(this.flags.keySet());
-        flagsChanged.addAll(flags.keySet());
-        this.flags = new ConcurrentHashMap<>(flags);
+    public void updateFlags(Map<String, Flag<?>> newFlags) {
+        Set<String> flagsChanged = new HashSet<>(newFlags.keySet());
+        flagsChanged.removeAll(this.flags.keySet());
+        this.flags.putAll(newFlags);
+
         ProviderEventDetails details = ProviderEventDetails.builder()
             .flagsChanged(new ArrayList<>(flagsChanged))
             .message("flags changed")

--- a/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
@@ -48,7 +48,7 @@ public class InMemoryProvider extends EventProvider {
     }
 
     /**
-     * Initialize the provider.
+     * Initializes the provider.
      * @param evaluationContext evaluation context
      * @throws Exception on error
      */
@@ -60,8 +60,10 @@ public class InMemoryProvider extends EventProvider {
     }
 
     /**
-     * Updating provider flags configuration, replacing existing flags.
-     * @param newFlags the flags to use instead of the previous flags.
+     * Updates the provider flags configuration.
+     * For existing flags, the new configurations replace the old one.
+     * For new flags, they are added to the configuration.
+     * @param newFlags the new flag configurations
      */
     public void updateFlags(Map<String, Flag<?>> newFlags) {
         Set<String> flagsChanged = new HashSet<>(newFlags.keySet());
@@ -76,11 +78,13 @@ public class InMemoryProvider extends EventProvider {
     }
 
     /**
-     * Updating provider flags configuration with adding or updating a flag.
-     * @param flag the flag to update. If a flag with this key already exists, new flag replaces it.
+     * Updates a single provider flag configuration.
+     * For existing flag, the new configuration replaces the old one.
+     * For new flag, they are added to the configuration.
+     * @param newFlag the flag to update
      */
-    public void updateFlag(String flagKey, Flag<?> flag) {
-        this.flags.put(flagKey, flag);
+    public void updateFlag(String flagKey, Flag<?> newFlag) {
+        this.flags.put(flagKey, newFlag);
         ProviderEventDetails details = ProviderEventDetails.builder()
             .flagsChanged(Collections.singletonList(flagKey))
             .message("flag added/updated")

--- a/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
@@ -1,12 +1,5 @@
 package dev.openfeature.sdk.providers.memory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.Metadata;
@@ -23,6 +16,13 @@ import dev.openfeature.sdk.exceptions.TypeMismatchError;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * In-memory provider.
@@ -82,7 +82,7 @@ public class InMemoryProvider extends EventProvider {
     public void updateFlag(String flagKey, Flag<?> flag) {
         this.flags.put(flagKey, flag);
         ProviderEventDetails details = ProviderEventDetails.builder()
-            .flagsChanged(Arrays.asList(flagKey))
+            .flagsChanged(Collections.singletonList(flagKey))
             .message("flag added/updated")
             .build();
         emitProviderConfigurationChanged(details);

--- a/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
@@ -13,13 +13,8 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 import static dev.openfeature.sdk.Structure.mapToStructure;
@@ -128,29 +123,6 @@ class InMemoryProviderTest {
         provider.updateFlags(flags);
 
         await().untilAsserted(() -> verify(handler, times(1))
-                .accept(argThat(details -> details.getFlagsChanged().isEmpty())));
-    }
-
-    @Test
-    void multithreadedTest() throws InterruptedException {
-        ExecutorService executorService = Executors.newFixedThreadPool(100);
-        List<Callable<Void>> updates = new ArrayList<>();
-        for (int i = 0; i < 10000; i++) {
-            String flagKey = "multithreadedFlag" + i;
-            updates.add(() -> {
-                provider.updateFlag(flagKey, Flag.builder()
-                        .variant("on", true)
-                        .variant("off", false)
-                        .defaultVariant("on")
-                        .build());
-                return null;
-            });
-        }
-
-        executorService.invokeAll(updates);
-
-        for (int i = 0; i < 10000; i++) {
-            assertTrue(client.getBooleanValue("multithreadedFlag" + i, false));
-        }
+                .accept(argThat(details -> details.getFlagsChanged().size() == buildFlags().size())));
     }
 }

--- a/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
@@ -27,6 +27,7 @@ import static dev.openfeature.sdk.testutils.TestFlagsUtils.buildFlags;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -126,8 +127,8 @@ class InMemoryProviderTest {
 
         provider.updateFlags(flags);
 
-        verify(handler, times(1))
-                .accept(argThat(details -> details.getFlagsChanged().isEmpty()));
+        await().untilAsserted(() -> verify(handler, times(1))
+                .accept(argThat(details -> details.getFlagsChanged().isEmpty())));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## Use ConcurrentHashMap for InMemoryProvider
<!-- add the description of the PR here -->

- Use `ConcurrentHashMap` for `flags` in `InMemoryProvider` to make it thread-safe

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1054 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

