### PR TITLE
fix: Pin byte-buddy(-agent) version to 1.14.19 to workaround Mockito issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,8 @@
   <dependencyManagement>
     <dependencies>
 
+      <!-- Start mockito workaround -->
+      <!-- https://github.com/mockito/mockito/issues/3121 -->
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
@@ -164,6 +166,7 @@
         <version>1.14.19</version>
         <scope>test</scope>
       </dependency>
+      <!-- End mockito workaround-->
 
       <dependency>
         <groupId>io.cucumber</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,9 @@
         <configuration>
           <argLine>
             ${surefireArgLine}
+            <!-- workaround for Mockito issue under Java 21
+             https://github.com/mockito/mockito/issues/3121 -->
+            -Dnet.bytebuddy.experimental=true
           </argLine>
           <excludes>
             <!-- tests to exclude -->

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,20 @@
     <dependencies>
 
       <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.14.19</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>1.14.19</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-bom</artifactId>
         <version>7.18.1</version>
@@ -239,9 +253,6 @@
         <configuration>
           <argLine>
             ${surefireArgLine}
-            <!-- workaround for Mockito issue under Java 21
-             https://github.com/mockito/mockito/issues/3121 -->
-            -Dnet.bytebuddy.experimental=true
           </argLine>
           <excludes>
             <!-- tests to exclude -->

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <junit.jupiter.version>5.11.0</junit.jupiter.version>
      <!-- exclusion expression for e2e tests -->
     <testExclusions>**/e2e/*.java</testExclusions>
-    <module-name>${groupId}.${artifactId}</module-name>
+    <module-name>${project.groupId}.${project.artifactId}</module-name>
   </properties>
 
   <name>OpenFeature Java SDK</name>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
 
       <!-- Start mockito workaround -->
       <!-- https://github.com/mockito/mockito/issues/3121 -->
+      <!-- These are transitive dependencies of mockito we are forcing -->
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## Pin byte-buddy(-agent) version to 1.14.19 to workaround Mockito issue
<!-- add the description of the PR here -->
Workaround to make Mockito tests to pass under Java 21 due to this [open Mockito bug](https://github.com/mockito/mockito/issues/3121)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1059 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

