### PR TITLE
feat: error resolution flow control without exceptions

### DIFF
--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -135,7 +135,7 @@ public class OpenFeatureClient implements Client {
                 OpenFeatureError error = ExceptionUtils.instantiateErrorByErrorCode(
                         details.getErrorCode(),
                         details.getErrorMessage());
-                details.setValue(defaultValue);
+                enrichDetailsWithErrorDefaults(defaultValue, details);
                 hookSupport.errorHooks(type, afterHookContext, error, mergedHooks, hints);
             } else {
                 hookSupport.afterHooks(type, afterHookContext, details, mergedHooks, hints);
@@ -150,14 +150,18 @@ public class OpenFeatureClient implements Client {
                 details.setErrorCode(ErrorCode.GENERAL);
             }
             details.setErrorMessage(e.getMessage());
-            details.setValue(defaultValue);
-            details.setReason(Reason.ERROR.toString());
+            enrichDetailsWithErrorDefaults(defaultValue, details);
             hookSupport.errorHooks(type, afterHookContext, e, mergedHooks, hints);
         } finally {
             hookSupport.afterAllHooks(type, afterHookContext, mergedHooks, hints);
         }
 
         return details;
+    }
+
+    private static <T> void enrichDetailsWithErrorDefaults(T defaultValue, FlagEvaluationDetails<T> details) {
+        details.setValue(defaultValue);
+        details.setReason(Reason.ERROR.toString());
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
  * You should not instantiate this or reference this class.
  * Use the dev.openfeature.sdk.Client interface instead.
  * @see Client
- * 
+ *
  * @deprecated // TODO: eventually we will make this non-public. See issue #872
  */
 @Slf4j
@@ -132,7 +132,11 @@ public class OpenFeatureClient implements Client {
 
             details = FlagEvaluationDetails.from(providerEval, key);
             if (details.getErrorCode() != null) {
-                throw ExceptionUtils.instantiateErrorByErrorCode(details.getErrorCode(), details.getErrorMessage());
+                OpenFeatureError error = ExceptionUtils.instantiateErrorByErrorCode(
+                        details.getErrorCode(),
+                        details.getErrorMessage());
+                details.setValue(defaultValue);
+                hookSupport.errorHooks(type, afterHookContext, error, mergedHooks, hints);
             } else {
                 hookSupport.afterHooks(type, afterHookContext, details, mergedHooks, hints);
             }

--- a/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
@@ -4,14 +4,11 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
-@SuppressWarnings("checkstyle:MissingJavadocType")
+@SuppressWarnings({"checkstyle:MissingJavadocType", "squid:S110"})
 @StandardException
-public class FlagNotFoundError extends OpenFeatureError {
+public class FlagNotFoundError extends OpenFeatureErrorWithoutStacktrace {
     private static final long serialVersionUID = 1L;
-    @Getter private final ErrorCode errorCode = ErrorCode.FLAG_NOT_FOUND;
+    @Getter
+    private final ErrorCode errorCode = ErrorCode.FLAG_NOT_FOUND;
 
-    @Override
-    public synchronized Throwable fillInStackTrace() {
-        return this;
-    }
 }

--- a/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureErrorWithoutStacktrace.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureErrorWithoutStacktrace.java
@@ -1,0 +1,14 @@
+package dev.openfeature.sdk.exceptions;
+
+import lombok.experimental.StandardException;
+
+@SuppressWarnings("checkstyle:MissingJavadocType")
+@StandardException
+public abstract class OpenFeatureErrorWithoutStacktrace extends OpenFeatureError {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/dev/openfeature/sdk/exceptions/ProviderNotReadyError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/ProviderNotReadyError.java
@@ -4,9 +4,9 @@ import dev.openfeature.sdk.ErrorCode;
 import lombok.Getter;
 import lombok.experimental.StandardException;
 
-@SuppressWarnings("checkstyle:MissingJavadocType")
+@SuppressWarnings({"checkstyle:MissingJavadocType", "squid:S110"})
 @StandardException
-public class ProviderNotReadyError extends OpenFeatureError {
+public class ProviderNotReadyError extends OpenFeatureErrorWithoutStacktrace {
     private static final long serialVersionUID = 1L;
     @Getter private final ErrorCode errorCode = ErrorCode.PROVIDER_NOT_READY;
 }

--- a/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
@@ -7,8 +7,9 @@ import lombok.experimental.StandardException;
 /**
  * The type of the flag value does not match the expected type.
  */
+@SuppressWarnings({"checkstyle:MissingJavadocType", "squid:S110"})
 @StandardException
-public class TypeMismatchError extends OpenFeatureError {
+public class TypeMismatchError extends OpenFeatureErrorWithoutStacktrace {
     private static final long serialVersionUID = 1L;
 
     @Getter private final ErrorCode errorCode = ErrorCode.TYPE_MISMATCH;

--- a/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
@@ -9,7 +9,7 @@ import lombok.experimental.StandardException;
  */
 @SuppressWarnings({"checkstyle:MissingJavadocType", "squid:S110"})
 @StandardException
-public class TypeMismatchError extends OpenFeatureErrorWithoutStacktrace {
+public class TypeMismatchError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
 
     @Getter private final ErrorCode errorCode = ErrorCode.TYPE_MISMATCH;

--- a/src/test/java/dev/openfeature/sdk/AlwaysBrokenWithDetailsProvider.java
+++ b/src/test/java/dev/openfeature/sdk/AlwaysBrokenWithDetailsProvider.java
@@ -1,0 +1,53 @@
+package dev.openfeature.sdk;
+
+import dev.openfeature.sdk.exceptions.FlagNotFoundError;
+
+public class AlwaysBrokenWithDetailsProvider implements FeatureProvider {
+
+    @Override
+    public Metadata getMetadata() {
+        return () -> {
+            throw new FlagNotFoundError(TestConstants.BROKEN_MESSAGE);
+        };
+    }
+
+    @Override
+    public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
+        return ProviderEvaluation.<Boolean>builder()
+                .errorMessage(TestConstants.BROKEN_MESSAGE)
+                .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                .build();
+    }
+
+    @Override
+    public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
+        return ProviderEvaluation.<String>builder()
+                .errorMessage(TestConstants.BROKEN_MESSAGE)
+                .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                .build();
+    }
+
+    @Override
+    public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
+        return ProviderEvaluation.<Integer>builder()
+                .errorMessage(TestConstants.BROKEN_MESSAGE)
+                .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                .build();
+    }
+
+    @Override
+    public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
+        return ProviderEvaluation.<Double>builder()
+                .errorMessage(TestConstants.BROKEN_MESSAGE)
+                .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                .build();
+    }
+
+    @Override
+    public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext invocationContext) {
+        return ProviderEvaluation.<Value>builder()
+                .errorMessage(TestConstants.BROKEN_MESSAGE)
+                .errorCode(ErrorCode.FLAG_NOT_FOUND)
+                .build();
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -259,10 +259,27 @@ class FlagEvaluationSpecTest implements HookFixtures {
     @Test void broken_provider() {
         FeatureProviderTestUtils.setFeatureProvider(new AlwaysBrokenProvider());
         Client c = api.getClient();
-        assertFalse(c.getBooleanValue("key", false));
-        FlagEvaluationDetails<Boolean> details = c.getBooleanDetails("key", false);
+        boolean defaultValue = false;
+        assertFalse(c.getBooleanValue("key", defaultValue));
+        FlagEvaluationDetails<Boolean> details = c.getBooleanDetails("key", defaultValue);
         assertEquals(ErrorCode.FLAG_NOT_FOUND, details.getErrorCode());
         assertEquals(TestConstants.BROKEN_MESSAGE, details.getErrorMessage());
+        assertEquals(defaultValue, details.getValue());
+    }
+
+    @Specification(number="1.4.8", text="In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain an `error code`.")
+    @Specification(number="1.4.9", text="In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` SHOULD indicate an error.")
+    @Specification(number="1.4.10", text="Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.")
+    @Specification(number="1.4.13", text="In cases of abnormal execution, the `evaluation details` structure's `error message` field **MAY** contain a string containing additional details about the nature of the error.")
+    @Test void broken_provider_withDetails() {
+        FeatureProviderTestUtils.setFeatureProvider(new AlwaysBrokenWithDetailsProvider());
+        Client c = api.getClient();
+        boolean defaultValue = false;
+        assertFalse(c.getBooleanValue("key", defaultValue));
+        FlagEvaluationDetails<Boolean> details = c.getBooleanDetails("key", defaultValue);
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, details.getErrorCode());
+        assertEquals(TestConstants.BROKEN_MESSAGE, details.getErrorMessage());
+        assertEquals(defaultValue, details.getValue());
     }
 
     @Specification(number="1.4.11", text="Methods, functions, or operations on the client SHOULD NOT write log messages.")

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -113,7 +113,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
         OpenFeatureAPI.getInstance().setProvider(providerName, provider);
         assertThat(api.getProvider(providerName).getState()).isEqualTo(ProviderState.NOT_READY);
         Client client = OpenFeatureAPI.getInstance().getClient(providerName);
-        assertEquals(ErrorCode.PROVIDER_NOT_READY, client.getBooleanDetails("return_error_when_not_initialized", false).getErrorCode());
+        FlagEvaluationDetails<Boolean> details = client.getBooleanDetails("return_error_when_not_initialized", false);
+        assertEquals(ErrorCode.PROVIDER_NOT_READY, details.getErrorCode());
+        assertEquals(Reason.ERROR.toString(), details.getReason());
     }
 
     @Specification(number="1.1.5", text="The API MUST provide a function for retrieving the metadata field of the configured provider.")
@@ -264,6 +266,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
         FlagEvaluationDetails<Boolean> details = c.getBooleanDetails("key", defaultValue);
         assertEquals(ErrorCode.FLAG_NOT_FOUND, details.getErrorCode());
         assertEquals(TestConstants.BROKEN_MESSAGE, details.getErrorMessage());
+        assertEquals(Reason.ERROR.toString(), details.getReason());
         assertEquals(defaultValue, details.getValue());
     }
 
@@ -279,6 +282,7 @@ class FlagEvaluationSpecTest implements HookFixtures {
         FlagEvaluationDetails<Boolean> details = c.getBooleanDetails("key", defaultValue);
         assertEquals(ErrorCode.FLAG_NOT_FOUND, details.getErrorCode());
         assertEquals(TestConstants.BROKEN_MESSAGE, details.getErrorMessage());
+        assertEquals(Reason.ERROR.toString(), details.getReason());
         assertEquals(defaultValue, details.getValue());
     }
 


### PR DESCRIPTION
So far, we used exceptions to handle our flow control, but Exceptions are costly. In the end, we enriched our
evaluation Details with errorCode and errorMessage. If desired, the providers can also handle this to reduce the execution footprint in erroneous cases, which don't have to be exceptions. Till now, we also converted those into exceptions and threw them, with this little code change, we would return already the details, and call the hooks, without exceptions being thrown.

For example, FlagNotFound is such a case; it can be expected and not exceptional. Hence, the exception flow might add too much overhead to performance-critical environments.

This implementation now allows the prover implementors to decide whether to support either or both.


### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

Most likely this is something we also want to do in all other sdks.

### How to test
<!-- if applicable, add testing instructions under this section -->

