### PR TITLE
chore(style): add editorconfig for easier configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,72 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+tab_width = 4
+trim_trailing_whitespace = true
+
+ij_continuation_indent_size = 8
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+# Following the rules of the Google Java Style Guide.
+# See https://google.github.io/styleguide/javaguide.html
+[*.java]
+max_line_length = 120
+
+ij_java_do_not_wrap_after_single_annotation_in_parameter = true
+ij_java_insert_inner_class_imports = false
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_packages_to_use_import_on_demand = unset
+ij_java_imports_layout = $*,|,*
+ij_java_doc_align_param_comments = true
+ij_java_doc_align_exception_comments = true
+ij_java_doc_add_p_tag_on_empty_lines = false
+ij_java_doc_do_not_wrap_if_one_line = true
+ij_java_doc_keep_empty_parameter_tag = false
+ij_java_doc_keep_empty_throws_tag = false
+ij_java_doc_keep_empty_return_tag = false
+ij_java_doc_preserve_line_breaks = true
+ij_java_doc_indent_on_continuation = true
+ij_java_keep_control_statement_in_one_line = false
+ij_java_keep_blank_lines_in_code = 1
+ij_java_align_multiline_parameters = false
+ij_java_align_multiline_resources = false
+ij_java_align_multiline_for = true
+ij_java_space_before_array_initializer_left_brace = true
+ij_java_call_parameters_wrap = normal
+ij_java_method_parameters_wrap = normal
+ij_java_extends_list_wrap = normal
+ij_java_throws_keyword_wrap = normal
+ij_java_method_call_chain_wrap = normal
+ij_java_binary_operation_wrap = normal
+ij_java_binary_operation_sign_on_next_line = true
+ij_java_ternary_operation_wrap = normal
+ij_java_ternary_operation_signs_on_next_line = true
+ij_java_keep_simple_methods_in_one_line = true
+ij_java_keep_simple_lambdas_in_one_line = true
+ij_java_keep_simple_classes_in_one_line = true
+ij_java_for_statement_wrap = normal
+ij_java_array_initializer_wrap = normal
+ij_java_wrap_comments = true
+ij_java_if_brace_force = always
+ij_java_do_while_brace_force = always
+ij_java_while_brace_force = always
+ij_java_for_brace_force = always
+ij_java_space_after_closing_angle_bracket_in_type_argument = false
+
+[{*.json,*.json5}]
+indent_size = 2
+tab_width = 2
+ij_smart_tabs = false
+
+[*.yaml]
+indent_size = 2
+tab_width = 2

--- a/src/main/java/dev/openfeature/sdk/AbstractStructure.java
+++ b/src/main/java/dev/openfeature/sdk/AbstractStructure.java
@@ -3,7 +3,7 @@ package dev.openfeature.sdk;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings({ "PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType" })
+@SuppressWarnings({"PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType"})
 abstract class AbstractStructure implements Structure {
 
     protected final Map<String, Value> attributes;

--- a/src/main/java/dev/openfeature/sdk/BaseEvaluation.java
+++ b/src/main/java/dev/openfeature/sdk/BaseEvaluation.java
@@ -2,29 +2,34 @@ package dev.openfeature.sdk;
 
 /**
  * This is a common interface between the evaluation results that providers return and what is given to the end users.
+ *
  * @param <T> The type of flag being evaluated.
  */
 public interface BaseEvaluation<T> {
     /**
      * Returns the resolved value of the evaluation.
+     *
      * @return {T} the resolve value
      */
     T getValue();
 
     /**
      * Returns an identifier for this value, if applicable.
+     *
      * @return {String} value identifier
      */
     String getVariant();
 
     /**
      * Describes how we came to the value that we're returning.
+     *
      * @return {Reason}
      */
     String getReason();
 
     /**
      * The error code, if applicable. Should only be set when the Reason is ERROR.
+     *
      * @return {ErrorCode}
      */
     ErrorCode getErrorCode();
@@ -32,6 +37,7 @@ public interface BaseEvaluation<T> {
     /**
      * The error message (usually from exception.getMessage()), if applicable.
      * Should only be set when the Reason is ERROR.
+     *
      * @return {String}
      */
     String getErrorMessage();

--- a/src/main/java/dev/openfeature/sdk/BooleanHook.java
+++ b/src/main/java/dev/openfeature/sdk/BooleanHook.java
@@ -3,7 +3,7 @@ package dev.openfeature.sdk;
 /**
  * An extension point which can run around flag resolution. They are intended to be used as a way to add custom logic
  * to the lifecycle of flag evaluation.
- * 
+ *
  * @see Hook
  */
 public interface BooleanHook extends Hook<Boolean> {

--- a/src/main/java/dev/openfeature/sdk/Client.java
+++ b/src/main/java/dev/openfeature/sdk/Client.java
@@ -10,12 +10,14 @@ public interface Client extends Features, EventBus<Client> {
 
     /**
      * Return an optional client-level evaluation context.
+     *
      * @return {@link EvaluationContext}
      */
     EvaluationContext getEvaluationContext();
 
     /**
      * Set the client-level evaluation context.
+     *
      * @param ctx Client level context.
      */
     Client setEvaluationContext(EvaluationContext ctx);
@@ -30,6 +32,7 @@ public interface Client extends Features, EventBus<Client> {
 
     /**
      * Fetch the hooks associated to this client.
+     *
      * @return A list of {@link Hook}s.
      */
     List<Hook> getHooks();

--- a/src/main/java/dev/openfeature/sdk/DoubleHook.java
+++ b/src/main/java/dev/openfeature/sdk/DoubleHook.java
@@ -3,7 +3,7 @@ package dev.openfeature.sdk;
 /**
  * An extension point which can run around flag resolution. They are intended to be used as a way to add custom logic
  * to the lifecycle of flag evaluation.
- * 
+ *
  * @see Hook
  */
 public interface DoubleHook extends Hook<Double> {

--- a/src/main/java/dev/openfeature/sdk/EventBus.java
+++ b/src/main/java/dev/openfeature/sdk/EventBus.java
@@ -6,38 +6,38 @@ import java.util.function.Consumer;
  * Interface for attaching event handlers.
  */
 public interface EventBus<T> {
-    
+
     /**
      * Add a handler for the {@link ProviderEvent#PROVIDER_READY} event.
      * Shorthand for {@link #on(ProviderEvent, Consumer)}
-     * 
+     *
      * @param handler behavior to add with this event
      * @return this
      */
     T onProviderReady(Consumer<EventDetails> handler);
-    
+
     /**
      * Add a handler for the {@link ProviderEvent#PROVIDER_CONFIGURATION_CHANGED} event.
      * Shorthand for {@link #on(ProviderEvent, Consumer)}
-     * 
+     *
      * @param handler behavior to add with this event
      * @return this
      */
     T onProviderConfigurationChanged(Consumer<EventDetails> handler);
-    
+
     /**
      * Add a handler for the {@link ProviderEvent#PROVIDER_STALE} event.
      * Shorthand for {@link #on(ProviderEvent, Consumer)}
-     * 
+     *
      * @param handler behavior to add with this event
      * @return this
      */
     T onProviderError(Consumer<EventDetails> handler);
-    
+
     /**
      * Add a handler for the {@link ProviderEvent#PROVIDER_ERROR} event.
      * Shorthand for {@link #on(ProviderEvent, Consumer)}
-     * 
+     *
      * @param handler behavior to add with this event
      * @return this
      */
@@ -45,18 +45,18 @@ public interface EventBus<T> {
 
     /**
      * Add a handler for the specified {@link ProviderEvent}.
-     * 
-     * @param event event type
+     *
+     * @param event   event type
      * @param handler behavior to add with this event
      * @return this
      */
     T on(ProviderEvent event, Consumer<EventDetails> handler);
-    
+
     /**
      * Remove the previously attached handler by reference.
      * If the handler doesn't exists, no-op.
-     * 
-     * @param event event type
+     *
+     * @param event   event type
      * @param handler to be removed
      * @return this
      */

--- a/src/main/java/dev/openfeature/sdk/EventProvider.java
+++ b/src/main/java/dev/openfeature/sdk/EventProvider.java
@@ -26,11 +26,10 @@ public abstract class EventProvider implements FeatureProvider {
 
     /**
      * "Attach" this EventProvider to an SDK, which allows events to propagate from this provider.
-     * No-op if the same onEmit is already attached. 
+     * No-op if the same onEmit is already attached.
      *
      * @param onEmit the function to run when a provider emits events.
      * @throws IllegalStateException if attempted to bind a new emitter for already bound provider
-     *
      */
     void attach(TriConsumer<EventProvider, ProviderEvent, ProviderEventDetails> onEmit) {
         if (this.onEmit != null && this.onEmit != onEmit) {
@@ -50,7 +49,7 @@ public abstract class EventProvider implements FeatureProvider {
 
     /**
      * Emit the specified {@link ProviderEvent}.
-     * 
+     *
      * @param event   The event type
      * @param details The details of the event
      */
@@ -63,7 +62,7 @@ public abstract class EventProvider implements FeatureProvider {
     /**
      * Emit a {@link ProviderEvent#PROVIDER_READY} event.
      * Shorthand for {@link #emit(ProviderEvent, ProviderEventDetails)}
-     * 
+     *
      * @param details The details of the event
      */
     public void emitProviderReady(ProviderEventDetails details) {
@@ -74,7 +73,7 @@ public abstract class EventProvider implements FeatureProvider {
      * Emit a
      * {@link ProviderEvent#PROVIDER_CONFIGURATION_CHANGED}
      * event. Shorthand for {@link #emit(ProviderEvent, ProviderEventDetails)}
-     * 
+     *
      * @param details The details of the event
      */
     public void emitProviderConfigurationChanged(ProviderEventDetails details) {
@@ -84,7 +83,7 @@ public abstract class EventProvider implements FeatureProvider {
     /**
      * Emit a {@link ProviderEvent#PROVIDER_STALE} event.
      * Shorthand for {@link #emit(ProviderEvent, ProviderEventDetails)}
-     * 
+     *
      * @param details The details of the event
      */
     public void emitProviderStale(ProviderEventDetails details) {
@@ -94,7 +93,7 @@ public abstract class EventProvider implements FeatureProvider {
     /**
      * Emit a {@link ProviderEvent#PROVIDER_ERROR} event.
      * Shorthand for {@link #emit(ProviderEvent, ProviderEventDetails)}
-     * 
+     *
      * @param details The details of the event
      */
     public void emitProviderError(ProviderEventDetails details) {

--- a/src/main/java/dev/openfeature/sdk/EventSupport.java
+++ b/src/main/java/dev/openfeature/sdk/EventSupport.java
@@ -35,7 +35,7 @@ class EventSupport {
     /**
      * Run all the event handlers associated with this domain.
      * If the domain is null, handlers attached to unnamed clients will run.
-     * 
+     *
      * @param domain       the domain to run event handlers for, or null
      * @param event        the event type
      * @param eventDetails the event details
@@ -54,7 +54,7 @@ class EventSupport {
 
     /**
      * Run all the API (global) event handlers.
-     * 
+     *
      * @param event        the event type
      * @param eventDetails the event details
      */
@@ -67,10 +67,10 @@ class EventSupport {
 
     /**
      * Add a handler for the specified domain, or all unnamed clients.
-     * 
-     * @param domain     the domain to add handlers for, or else unnamed
-     * @param event      the event type
-     * @param handler    the handler function to run
+     *
+     * @param domain  the domain to add handlers for, or else unnamed
+     * @param event   the event type
+     * @param handler the handler function to run
      */
     public void addClientHandler(String domain, ProviderEvent event, Consumer<EventDetails> handler) {
         final String name = Optional.ofNullable(domain)
@@ -88,11 +88,11 @@ class EventSupport {
 
     /**
      * Remove a client event handler for the specified event type.
-     * 
-     * @param domain     the domain of the client handler to remove, or null to remove
-     *                   from unnamed clients
-     * @param event      the event type
-     * @param handler    the handler ref to be removed
+     *
+     * @param domain  the domain of the client handler to remove, or null to remove
+     *                from unnamed clients
+     * @param event   the event type
+     * @param handler the handler ref to be removed
      */
     public void removeClientHandler(String domain, ProviderEvent event, Consumer<EventDetails> handler) {
         domain = Optional.ofNullable(domain)
@@ -102,7 +102,7 @@ class EventSupport {
 
     /**
      * Add a global event handler of the specified event type.
-     * 
+     *
      * @param event   the event type
      * @param handler the handler to be added
      */
@@ -112,7 +112,7 @@ class EventSupport {
 
     /**
      * Remove a global event handler for the specified event type.
-     * 
+     *
      * @param event   the event type
      * @param handler the handler ref to be removed
      */
@@ -122,7 +122,7 @@ class EventSupport {
 
     /**
      * Get all domain names for which we have event handlers registered.
-     * 
+     *
      * @return set of domain names
      */
     public Set<String> getAllDomainNames() {
@@ -131,7 +131,7 @@ class EventSupport {
 
     /**
      * Run the passed handler on the taskExecutor.
-     * 
+     *
      * @param handler      the handler to run
      * @param eventDetails the event details
      */

--- a/src/main/java/dev/openfeature/sdk/FeatureProvider.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProvider.java
@@ -60,9 +60,9 @@ public interface FeatureProvider {
      * If the provider needs to be initialized, it should return {@link ProviderState#NOT_READY}.
      * If the provider is in an error state, it should return {@link ProviderState#ERROR}.
      * If the provider is functioning normally, it should return {@link ProviderState#READY}.
-     * 
+     *
      * <p><i>Providers which do not implement this method are assumed to be ready immediately.</i></p>
-     * 
+     *
      * @return ProviderState
      */
     default ProviderState getState() {

--- a/src/main/java/dev/openfeature/sdk/Features.java
+++ b/src/main/java/dev/openfeature/sdk/Features.java
@@ -16,7 +16,7 @@ public interface Features {
     FlagEvaluationDetails<Boolean> getBooleanDetails(String key, Boolean defaultValue, EvaluationContext ctx);
 
     FlagEvaluationDetails<Boolean> getBooleanDetails(String key, Boolean defaultValue, EvaluationContext ctx,
-                                                     FlagEvaluationOptions options);
+            FlagEvaluationOptions options);
 
     String getStringValue(String key, String defaultValue);
 
@@ -29,7 +29,7 @@ public interface Features {
     FlagEvaluationDetails<String> getStringDetails(String key, String defaultValue, EvaluationContext ctx);
 
     FlagEvaluationDetails<String> getStringDetails(String key, String defaultValue, EvaluationContext ctx,
-                                                   FlagEvaluationOptions options);
+            FlagEvaluationOptions options);
 
     Integer getIntegerValue(String key, Integer defaultValue);
 
@@ -42,7 +42,7 @@ public interface Features {
     FlagEvaluationDetails<Integer> getIntegerDetails(String key, Integer defaultValue, EvaluationContext ctx);
 
     FlagEvaluationDetails<Integer> getIntegerDetails(String key, Integer defaultValue, EvaluationContext ctx,
-                                                     FlagEvaluationOptions options);
+            FlagEvaluationOptions options);
 
     Double getDoubleValue(String key, Double defaultValue);
 
@@ -55,7 +55,7 @@ public interface Features {
     FlagEvaluationDetails<Double> getDoubleDetails(String key, Double defaultValue, EvaluationContext ctx);
 
     FlagEvaluationDetails<Double> getDoubleDetails(String key, Double defaultValue, EvaluationContext ctx,
-                                                   FlagEvaluationOptions options);
+            FlagEvaluationOptions options);
 
     Value getObjectValue(String key, Value defaultValue);
 

--- a/src/main/java/dev/openfeature/sdk/HookContext.java
+++ b/src/main/java/dev/openfeature/sdk/HookContext.java
@@ -10,28 +10,35 @@ import lombok.With;
  *
  * @param <T> the type for the flag being evaluated
  */
-@Value @Builder @With
+@Value
+@Builder
+@With
 public class HookContext<T> {
-    @NonNull String flagKey;
-    @NonNull FlagValueType type;
-    @NonNull T defaultValue;
-    @NonNull EvaluationContext ctx;
+    @NonNull
+    String flagKey;
+    @NonNull
+    FlagValueType type;
+    @NonNull
+    T defaultValue;
+    @NonNull
+    EvaluationContext ctx;
     ClientMetadata clientMetadata;
     Metadata providerMetadata;
 
     /**
      * Builds a {@link HookContext} instances from request data.
-     * @param key feature flag key
-     * @param type flag value type
-     * @param clientMetadata info on which client is calling
+     *
+     * @param key              feature flag key
+     * @param type             flag value type
+     * @param clientMetadata   info on which client is calling
      * @param providerMetadata info on the provider
-     * @param ctx Evaluation Context for the request
-     * @param defaultValue Fallback value
-     * @param <T> type that the flag is evaluating against
+     * @param ctx              Evaluation Context for the request
+     * @param defaultValue     Fallback value
+     * @param <T>              type that the flag is evaluating against
      * @return resulting context for hook
      */
     public static <T> HookContext<T> from(String key, FlagValueType type, ClientMetadata clientMetadata,
-                                          Metadata providerMetadata, EvaluationContext ctx, T defaultValue) {
+            Metadata providerMetadata, EvaluationContext ctx, T defaultValue) {
         return HookContext.<T>builder()
                 .flagKey(key)
                 .type(type)

--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@SuppressWarnings({ "unchecked", "rawtypes" })
+@SuppressWarnings({"unchecked", "rawtypes"})
 class HookSupport {
 
     public EvaluationContext beforeHooks(FlagValueType flagValueType, HookContext hookCtx, List<Hook> hooks,

--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -89,10 +89,10 @@ public final class ImmutableContext implements EvaluationContext {
     @SuppressWarnings("all")
     private static class DelegateExclusions {
         @ExcludeFromGeneratedCoverageReport
-        public <T extends Structure> Map<String, Value> merge(Function<Map<String, Value>, Structure> newStructure, 
+        public <T extends Structure> Map<String, Value> merge(Function<Map<String, Value>, Structure> newStructure,
                 Map<String, Value> base,
                 Map<String, Value> overriding) {
- 
+
             return null;
         }
     }

--- a/src/main/java/dev/openfeature/sdk/ImmutableStructure.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableStructure.java
@@ -19,7 +19,7 @@ import lombok.ToString;
  */
 @ToString
 @EqualsAndHashCode
-@SuppressWarnings({ "PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType" })
+@SuppressWarnings({"PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType"})
 public final class ImmutableStructure extends AbstractStructure {
 
     /**
@@ -40,8 +40,8 @@ public final class ImmutableStructure extends AbstractStructure {
                 .collect(HashMap::new,
                         (accumulated, entry) -> accumulated.put(entry.getKey(),
                                 Optional.ofNullable(entry.getValue())
-                                    .map(Value::clone)
-                                    .orElse(null)),
+                                        .map(Value::clone)
+                                        .orElse(null)),
                         HashMap::putAll)));
     }
 
@@ -70,8 +70,8 @@ public final class ImmutableStructure extends AbstractStructure {
                 .collect(HashMap::new,
                         (accumulated, entry) -> accumulated.put(entry.getKey(),
                                 Optional.ofNullable(entry.getValue())
-                                .map(Value::clone)
-                                .orElse(null)),
+                                        .map(Value::clone)
+                                        .orElse(null)),
                         HashMap::putAll);
     }
 }

--- a/src/main/java/dev/openfeature/sdk/IntegerHook.java
+++ b/src/main/java/dev/openfeature/sdk/IntegerHook.java
@@ -3,7 +3,7 @@ package dev.openfeature.sdk;
 /**
  * An extension point which can run around flag resolution. They are intended to be used as a way to add custom logic
  * to the lifecycle of flag evaluation.
- * 
+ *
  * @see Hook
  */
 public interface IntegerHook extends Hook<Integer> {

--- a/src/main/java/dev/openfeature/sdk/MutableStructure.java
+++ b/src/main/java/dev/openfeature/sdk/MutableStructure.java
@@ -10,9 +10,9 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * {@link MutableStructure} represents a potentially nested object type which is used to represent 
+ * {@link MutableStructure} represents a potentially nested object type which is used to represent
  * structured data.
- * The MutableStructure is a Structure implementation which is not threadsafe, and whose attributes can 
+ * The MutableStructure is a Structure implementation which is not threadsafe, and whose attributes can
  * be modified after instantiation.
  */
 @ToString

--- a/src/main/java/dev/openfeature/sdk/NoOpProvider.java
+++ b/src/main/java/dev/openfeature/sdk/NoOpProvider.java
@@ -59,7 +59,7 @@ public class NoOpProvider implements FeatureProvider {
 
     @Override
     public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue,
-        EvaluationContext invocationContext) {
+            EvaluationContext invocationContext) {
         return ProviderEvaluation.<Value>builder()
                 .value(defaultValue)
                 .variant(PASSED_IN_DEFAULT)

--- a/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
+++ b/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
@@ -7,6 +7,7 @@ public class NoOpTransactionContextPropagator implements TransactionContextPropa
 
     /**
      * {@inheritDoc}
+     *
      * @return empty immutable context
      */
     @Override

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -86,7 +86,7 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
      * Multiple clients can be used to segment feature flag configuration.
      * If there is already a provider bound to this domain, this provider will be used.
      * Otherwise, the default provider is used until a provider is assigned to that domain.
-     * 
+     *
      * @param domain an identifier which logically binds clients with providers
      * @return a new client instance
      */
@@ -100,8 +100,8 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
      * Multiple clients can be used to segment feature flag configuration.
      * If there is already a provider bound to this domain, this provider will be used.
      * Otherwise, the default provider is used until a provider is assigned to that domain.
-     * 
-     * @param domain a identifier which logically binds clients with providers
+     *
+     * @param domain  a identifier which logically binds clients with providers
      * @param version a version identifier
      * @return a new client instance
      */
@@ -193,8 +193,8 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
     /**
      * Add a provider for a domain.
      *
-     * @param domain     The domain to bind the provider to.
-     * @param provider   The provider to set.
+     * @param domain   The domain to bind the provider to.
+     * @param provider The provider to set.
      */
     public void setProvider(String domain, FeatureProvider provider) {
         try (AutoCloseableLock __ = lock.writeLockAutoCloseable()) {
@@ -226,8 +226,8 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
     /**
      * Add a provider for a domain and wait for initialization to finish.
      *
-     * @param domain     The domain to bind the provider to.
-     * @param provider   The provider to set.
+     * @param domain   The domain to bind the provider to.
+     * @param provider The provider to set.
      */
     public void setProviderAndWait(String domain, FeatureProvider provider) throws OpenFeatureError {
         try (AutoCloseableLock __ = lock.writeLockAutoCloseable()) {
@@ -300,6 +300,7 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
 
     /**
      * Fetch the hooks associated to this client.
+     *
      * @return A list of {@link Hook}s.
      */
     public List<Hook> getHooks() {
@@ -404,7 +405,7 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
 
     /**
      * Runs the handlers associated with a particular provider.
-     * 
+     *
      * @param provider the provider from where this event originated
      * @param event    the event type
      * @param details  the event details

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -20,8 +20,8 @@ import lombok.extern.slf4j.Slf4j;
  * OpenFeature Client implementation.
  * You should not instantiate this or reference this class.
  * Use the dev.openfeature.sdk.Client interface instead.
+ *
  * @see Client
- * 
  * @deprecated // TODO: eventually we will make this non-public. See issue #872
  */
 @Slf4j
@@ -48,8 +48,8 @@ public class OpenFeatureClient implements Client {
      * @param domain         An identifier which logically binds clients with providers (used by observability tools).
      * @param version        Version of the client (used by observability tools).
      * @deprecated Do not use this constructor. It's for internal use only.
-     *             Clients created using it will not run event handlers.
-     *             Use the OpenFeatureAPI's getClient factory method instead.
+     *         Clients created using it will not run event handlers.
+     *         Use the OpenFeatureAPI's getClient factory method instead.
      */
     @Deprecated() // TODO: eventually we will make this non-public. See issue #872
     public OpenFeatureClient(OpenFeatureAPI openFeatureAPI, String domain, String version) {

--- a/src/main/java/dev/openfeature/sdk/ProviderEventDetails.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderEventDetails.java
@@ -8,7 +8,8 @@ import lombok.experimental.SuperBuilder;
 /**
  * The details of a particular event.
  */
-@Data @SuperBuilder(toBuilder = true)
+@Data
+@SuperBuilder(toBuilder = true)
 public class ProviderEventDetails {
     private List<String> flagsChanged;
     private String message;

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -47,8 +47,8 @@ class ProviderRepository {
 
     public List<String> getDomainsForProvider(FeatureProvider provider) {
         return providers.entrySet().stream()
-            .filter(entry -> entry.getValue().equals(provider))
-            .map(entry -> entry.getKey()).collect(Collectors.toList());
+                .filter(entry -> entry.getValue().equals(provider))
+                .map(entry -> entry.getKey()).collect(Collectors.toList());
     }
 
     public Set<String> getAllBoundDomains() {
@@ -99,12 +99,12 @@ class ProviderRepository {
     }
 
     private void prepareAndInitializeProvider(String domain,
-              FeatureProvider newProvider,
-              Consumer<FeatureProvider> afterSet,
-              Consumer<FeatureProvider> afterInit,
-              Consumer<FeatureProvider> afterShutdown,
-              BiConsumer<FeatureProvider, OpenFeatureError> afterError,
-              boolean waitForInit) {
+            FeatureProvider newProvider,
+            Consumer<FeatureProvider> afterSet,
+            Consumer<FeatureProvider> afterInit,
+            Consumer<FeatureProvider> afterShutdown,
+            BiConsumer<FeatureProvider, OpenFeatureError> afterError,
+            boolean waitForInit) {
 
         if (!isProviderRegistered(newProvider)) {
             // only run afterSet if new provider is not already attached
@@ -155,6 +155,7 @@ class ProviderRepository {
 
     /**
      * Helper to check if provider is already known (registered).
+     *
      * @param provider provider to check for registration
      * @return boolean true if already registered, false otherwise
      */

--- a/src/main/java/dev/openfeature/sdk/ProviderState.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderState.java
@@ -8,7 +8,7 @@ public enum ProviderState {
 
     /**
      * Returns true if the passed ProviderEvent maps to this ProviderState.
-     * 
+     *
      * @param event event to compare
      * @return boolean if matches.
      */

--- a/src/main/java/dev/openfeature/sdk/StringHook.java
+++ b/src/main/java/dev/openfeature/sdk/StringHook.java
@@ -3,7 +3,7 @@ package dev.openfeature.sdk;
 /**
  * An extension point which can run around flag resolution. They are intended to be used as a way to add custom logic
  * to the lifecycle of flag evaluation.
- * 
+ *
  * @see Hook
  */
 public interface StringHook extends Hook<String> {

--- a/src/main/java/dev/openfeature/sdk/Structure.java
+++ b/src/main/java/dev/openfeature/sdk/Structure.java
@@ -12,12 +12,12 @@ import java.util.stream.Collectors;
 import static dev.openfeature.sdk.Value.objectToValue;
 
 /**
- * {@link Structure} represents a potentially nested object type which is used to represent 
+ * {@link Structure} represents a potentially nested object type which is used to represent
  * structured data.
  */
 @SuppressWarnings("PMD.BeanMembersShouldSerialize")
 public interface Structure {
-    
+
     /**
      * Get all keys.
      *
@@ -103,16 +103,16 @@ public interface Structure {
 
     /**
      * Recursively merges the base map with the overriding map.
-     * 
-     * @param <T> Structure type
+     *
+     * @param <T>          Structure type
      * @param newStructure function to create the right structure
-     * @param base base map to merge
-     * @param overriding overriding map to merge
+     * @param base         base map to merge
+     * @param overriding   overriding map to merge
      * @return resulting merged map
      */
     default <T extends Structure> Map<String, Value> merge(Function<Map<String, Value>, Structure> newStructure,
-                                                           Map<String, Value> base,
-                                                           Map<String, Value> overriding) {
+            Map<String, Value> base,
+            Map<String, Value> overriding) {
 
         final Map<String, Value> merged = new HashMap<>(base);
         for (Entry<String, Value> overridingEntry : overriding.entrySet()) {
@@ -137,9 +137,9 @@ public interface Structure {
      */
     static Structure mapToStructure(Map<String, Object> map) {
         return new MutableStructure(map.entrySet().stream()
-            .collect(HashMap::new,
+                .collect(HashMap::new,
                         (accumulated, entry) -> accumulated.put(entry.getKey(),
-                        objectToValue(entry.getValue())),
+                                objectToValue(entry.getValue())),
                         HashMap::putAll));
     }
 }

--- a/src/main/java/dev/openfeature/sdk/Value.java
+++ b/src/main/java/dev/openfeature/sdk/Value.java
@@ -37,33 +37,34 @@ public class Value implements Cloneable {
 
     /**
      * Construct a new Value with an Object.
+     *
      * @param value to be wrapped.
      * @throws InstantiationException if value is not a valid type
-     *      (boolean, string, int, double, list, structure, instant)
+     *         (boolean, string, int, double, list, structure, instant)
      */
     public Value(Object value) throws InstantiationException {
         this.innerObject = value;
         if (!this.isNull()
-            && !this.isBoolean()
-            && !this.isString()
-            && !this.isNumber()
-            && !this.isStructure()
-            && !this.isList()
-            && !this.isInstant()) {
+                && !this.isBoolean()
+                && !this.isString()
+                && !this.isNumber()
+                && !this.isStructure()
+                && !this.isList()
+                && !this.isInstant()) {
             throw new InstantiationException("Invalid value type: " + value.getClass());
         }
     }
 
     public Value(Value value) {
-        this.innerObject = value.innerObject; 
+        this.innerObject = value.innerObject;
     }
 
     public Value(Boolean value) {
-        this.innerObject = value; 
+        this.innerObject = value;
     }
 
     public Value(String value) {
-        this.innerObject = value; 
+        this.innerObject = value;
     }
 
     public Value(Integer value) {
@@ -71,69 +72,69 @@ public class Value implements Cloneable {
     }
 
     public Value(Double value) {
-        this.innerObject = value; 
+        this.innerObject = value;
     }
 
     public Value(Structure value) {
-        this.innerObject = value; 
+        this.innerObject = value;
     }
 
     public Value(List<Value> value) {
-        this.innerObject = value; 
+        this.innerObject = value;
     }
 
     public Value(Instant value) {
         this.innerObject = value;
     }
 
-    /** 
+    /**
      * Check if this Value represents null.
-     * 
+     *
      * @return boolean
      */
     public boolean isNull() {
         return this.innerObject == null;
     }
 
-    /** 
+    /**
      * Check if this Value represents a Boolean.
-     * 
+     *
      * @return boolean
      */
     public boolean isBoolean() {
         return this.innerObject instanceof Boolean;
     }
 
-    /** 
+    /**
      * Check if this Value represents a String.
-     * 
+     *
      * @return boolean
      */
     public boolean isString() {
         return this.innerObject instanceof String;
     }
 
-    /** 
+    /**
      * Check if this Value represents a numeric value.
-     * 
+     *
      * @return boolean
      */
     public boolean isNumber() {
         return this.innerObject instanceof Number;
     }
 
-    /** 
+    /**
      * Check if this Value represents a Structure.
-     * 
+     *
      * @return boolean
      */
     public boolean isStructure() {
         return this.innerObject instanceof Structure;
     }
-    
-    /** 
+
+    /**
      * Check if this Value represents a List of Values.
-     * 
+     *
      * @return boolean
      */
     public boolean isList() {
@@ -155,87 +156,87 @@ public class Value implements Cloneable {
         return true;
     }
 
-    /** 
+    /**
      * Check if this Value represents an Instant.
-     * 
+     *
      * @return boolean
      */
     public boolean isInstant() {
         return this.innerObject instanceof Instant;
     }
-    
-    /** 
+
+    /**
      * Retrieve the underlying Boolean value, or null.
-     * 
+     *
      * @return Boolean
      */
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL",
-        justification = "This is not a plain true/false method. It's understood it can return null.")
+            justification = "This is not a plain true/false method. It's understood it can return null.")
     public Boolean asBoolean() {
         if (this.isBoolean()) {
-            return (Boolean)this.innerObject;
+            return (Boolean) this.innerObject;
         }
         return null;
     }
-    
-    /** 
+
+    /**
      * Retrieve the underlying object.
-     * 
+     *
      * @return Object
      */
     public Object asObject() {
         return this.innerObject;
     }
 
-    /** 
+    /**
      * Retrieve the underlying String value, or null.
-     * 
+     *
      * @return String
      */
     public String asString() {
         if (this.isString()) {
-            return (String)this.innerObject;
+            return (String) this.innerObject;
         }
         return null;
     }
 
-    /** 
+    /**
      * Retrieve the underlying numeric value as an Integer, or null.
      * If the value is not an integer, it will be rounded using Math.round().
-     * 
+     *
      * @return Integer
      */
     public Integer asInteger() {
         if (this.isNumber() && !this.isNull()) {
-            return ((Number)this.innerObject).intValue();
-        }
-        return null;
-    }
-    
-    /** 
-     * Retrieve the underlying numeric value as a Double, or null.
-     * 
-     * @return Double
-     */
-    public Double asDouble() {
-        if (this.isNumber() && !isNull()) {
-            return ((Number)this.innerObject).doubleValue();
+            return ((Number) this.innerObject).intValue();
         }
         return null;
     }
 
-    /** 
+    /**
+     * Retrieve the underlying numeric value as a Double, or null.
+     *
+     * @return Double
+     */
+    public Double asDouble() {
+        if (this.isNumber() && !isNull()) {
+            return ((Number) this.innerObject).doubleValue();
+        }
+        return null;
+    }
+
+    /**
      * Retrieve the underlying Structure value, or null.
-     * 
+     *
      * @return Structure
      */
     public Structure asStructure() {
         if (this.isStructure()) {
-            return (Structure)this.innerObject;
+            return (Structure) this.innerObject;
         }
         return null;
     }
-    
+
     /**
      * Retrieve the underlying List value, or null.
      *
@@ -249,14 +250,14 @@ public class Value implements Cloneable {
         return null;
     }
 
-    /** 
+    /**
      * Retrieve the underlying Instant value, or null.
-     * 
+     *
      * @return Instant
      */
     public Instant asInstant() {
         if (this.isInstant()) {
-            return (Instant)this.innerObject;
+            return (Instant) this.innerObject;
         }
         return null;
     }
@@ -306,8 +307,8 @@ public class Value implements Cloneable {
             return new Value((Structure) object);
         } else if (object instanceof List) {
             return new Value(((List<Object>) object).stream()
-                .map(o -> objectToValue(o))
-                .collect(Collectors.toList()));
+                    .map(o -> objectToValue(o))
+                    .collect(Collectors.toList()));
         } else if (object instanceof Instant) {
             return new Value((Instant) object);
         } else if (object instanceof Map) {

--- a/src/main/java/dev/openfeature/sdk/exceptions/ExceptionUtils.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/ExceptionUtils.java
@@ -9,7 +9,8 @@ public class ExceptionUtils {
 
     /**
      * Creates an Error for the specific error code.
-     * @param errorCode the ErrorCode to use
+     *
+     * @param errorCode    the ErrorCode to use
      * @param errorMessage the error message to include in the returned error
      * @return the specific OpenFeatureError for the errorCode
      */

--- a/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/FlagNotFoundError.java
@@ -8,7 +8,8 @@ import lombok.experimental.StandardException;
 @StandardException
 public class FlagNotFoundError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
-    @Getter private final ErrorCode errorCode = ErrorCode.FLAG_NOT_FOUND;
+    @Getter
+    private final ErrorCode errorCode = ErrorCode.FLAG_NOT_FOUND;
 
     @Override
     public synchronized Throwable fillInStackTrace() {

--- a/src/main/java/dev/openfeature/sdk/exceptions/InvalidContextError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/InvalidContextError.java
@@ -11,6 +11,7 @@ import lombok.experimental.StandardException;
 public class InvalidContextError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
 
-    @Getter private final ErrorCode errorCode = ErrorCode.INVALID_CONTEXT;
+    @Getter
+    private final ErrorCode errorCode = ErrorCode.INVALID_CONTEXT;
 
 }

--- a/src/main/java/dev/openfeature/sdk/exceptions/ParseError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/ParseError.java
@@ -11,6 +11,7 @@ import lombok.experimental.StandardException;
 public class ParseError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
 
-    @Getter private final ErrorCode errorCode = ErrorCode.PARSE_ERROR;
+    @Getter
+    private final ErrorCode errorCode = ErrorCode.PARSE_ERROR;
 
 }

--- a/src/main/java/dev/openfeature/sdk/exceptions/ProviderNotReadyError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/ProviderNotReadyError.java
@@ -8,5 +8,6 @@ import lombok.experimental.StandardException;
 @StandardException
 public class ProviderNotReadyError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
-    @Getter private final ErrorCode errorCode = ErrorCode.PROVIDER_NOT_READY;
+    @Getter
+    private final ErrorCode errorCode = ErrorCode.PROVIDER_NOT_READY;
 }

--- a/src/main/java/dev/openfeature/sdk/exceptions/TargetingKeyMissingError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/TargetingKeyMissingError.java
@@ -11,6 +11,7 @@ import lombok.experimental.StandardException;
 public class TargetingKeyMissingError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
 
-    @Getter private final ErrorCode errorCode = ErrorCode.TARGETING_KEY_MISSING;
+    @Getter
+    private final ErrorCode errorCode = ErrorCode.TARGETING_KEY_MISSING;
 
 }

--- a/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
+++ b/src/main/java/dev/openfeature/sdk/exceptions/TypeMismatchError.java
@@ -11,6 +11,7 @@ import lombok.experimental.StandardException;
 public class TypeMismatchError extends OpenFeatureError {
     private static final long serialVersionUID = 1L;
 
-    @Getter private final ErrorCode errorCode = ErrorCode.TYPE_MISMATCH;
+    @Getter
+    private final ErrorCode errorCode = ErrorCode.TYPE_MISMATCH;
 
 }

--- a/src/main/java/dev/openfeature/sdk/hooks/logging/LoggingHook.java
+++ b/src/main/java/dev/openfeature/sdk/hooks/logging/LoggingHook.java
@@ -18,7 +18,7 @@ import org.slf4j.spi.LoggingEventBuilder;
  */
 @Slf4j
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED",
-    justification = "we can ignore return values of chainables (builders) here")
+        justification = "we can ignore return values of chainables (builders) here")
 public class LoggingHook implements Hook<Object> {
 
     static final String DOMAIN_KEY = "domain";
@@ -32,7 +32,7 @@ public class LoggingHook implements Hook<Object> {
     static final String VARIANT_KEY = "variant";
     static final String VALUE_KEY = "value";
 
-    private boolean includeEvaluationContext;
+    private final boolean includeEvaluationContext;
 
     /**
      * Construct a new LoggingHook.
@@ -43,7 +43,9 @@ public class LoggingHook implements Hook<Object> {
 
     /**
      * Construct a new LoggingHook.
-     * @param includeEvaluationContext include a serialized evaluation context in the log message (defaults to false)
+     *
+     * @param includeEvaluationContext include a serialized evaluation context in the log message (defaults to
+     *                                 false)
      */
     public LoggingHook(boolean includeEvaluationContext) {
         this.includeEvaluationContext = includeEvaluationContext;

--- a/src/main/java/dev/openfeature/sdk/internal/AutoCloseableLock.java
+++ b/src/main/java/dev/openfeature/sdk/internal/AutoCloseableLock.java
@@ -2,7 +2,7 @@ package dev.openfeature.sdk.internal;
 
 @SuppressWarnings("checkstyle:MissingJavadocType")
 public interface AutoCloseableLock extends AutoCloseable {
-    
+
     /**
      * Override the exception in AutoClosable.
      */

--- a/src/main/java/dev/openfeature/sdk/internal/AutoCloseableReentrantReadWriteLock.java
+++ b/src/main/java/dev/openfeature/sdk/internal/AutoCloseableReentrantReadWriteLock.java
@@ -10,6 +10,7 @@ public class AutoCloseableReentrantReadWriteLock extends ReentrantReadWriteLock 
 
     /**
      * Get the single write lock as an AutoCloseableLock.
+     *
      * @return unlock method ref
      */
     public AutoCloseableLock writeLockAutoCloseable() {
@@ -19,6 +20,7 @@ public class AutoCloseableReentrantReadWriteLock extends ReentrantReadWriteLock 
 
     /**
      * Get the multi read lock as an AutoCloseableLock.
+     *
      * @return unlock method ref
      */
     public AutoCloseableLock readLockAutoCloseable() {

--- a/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
+++ b/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
@@ -15,9 +15,10 @@ public class ObjectUtils {
 
     /**
      * If the source param is null, return the default value.
-     * @param source maybe null object
+     *
+     * @param source       maybe null object
      * @param defaultValue thing to use if source is null
-     * @param <T> list type
+     * @param <T>          list type
      * @return resulting object
      */
     public static <T> List<T> defaultIfNull(List<T> source, Supplier<List<T>> defaultValue) {
@@ -29,10 +30,11 @@ public class ObjectUtils {
 
     /**
      * If the source param is null, return the default value.
-     * @param source maybe null object
+     *
+     * @param source       maybe null object
      * @param defaultValue thing to use if source is null
-     * @param <K> map key type
-     * @param <V> map value type
+     * @param <K>          map key type
+     * @param <V>          map value type
      * @return resulting map
      */
     public static <K, V> Map<K, V> defaultIfNull(Map<K, V> source, Supplier<Map<K, V>> defaultValue) {
@@ -44,9 +46,10 @@ public class ObjectUtils {
 
     /**
      * If the source param is null, return the default value.
-     * @param source maybe null object
+     *
+     * @param source       maybe null object
      * @param defaultValue thing to use if source is null
-     * @param <T> type
+     * @param <T>          type
      * @return resulting object
      */
     public static <T> T defaultIfNull(T source, Supplier<T> defaultValue) {
@@ -58,15 +61,16 @@ public class ObjectUtils {
 
     /**
      * Concatenate a bunch of lists.
+     *
      * @param sources bunch of lists.
-     * @param <T> list type
+     * @param <T>     list type
      * @return resulting object
      */
     @SafeVarargs
     public static <T> List<T> merge(List<T>... sources) {
         return Arrays
-            .stream(sources)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+                .stream(sources)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/dev/openfeature/sdk/internal/TriConsumer.java
+++ b/src/main/java/dev/openfeature/sdk/internal/TriConsumer.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 /**
  * Like {@link java.util.function.BiConsumer} but with 3 params.
- * 
+ *
  * @see java.util.function.BiConsumer
  */
 @FunctionalInterface

--- a/src/main/java/dev/openfeature/sdk/providers/memory/ContextEvaluator.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/ContextEvaluator.java
@@ -4,6 +4,7 @@ import dev.openfeature.sdk.EvaluationContext;
 
 /**
  * Context evaluator - use for resolving flag according to evaluation context, for handling targeting.
+ *
  * @param <T> expected value type
  */
 public interface ContextEvaluator<T> {

--- a/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
+++ b/src/main/java/dev/openfeature/sdk/providers/memory/InMemoryProvider.java
@@ -49,6 +49,7 @@ public class InMemoryProvider extends EventProvider {
 
     /**
      * Initializes the provider.
+     *
      * @param evaluationContext evaluation context
      * @throws Exception on error
      */
@@ -63,6 +64,7 @@ public class InMemoryProvider extends EventProvider {
      * Updates the provider flags configuration.
      * For existing flags, the new configurations replace the old one.
      * For new flags, they are added to the configuration.
+     *
      * @param newFlags the new flag configurations
      */
     public void updateFlags(Map<String, Flag<?>> newFlags) {
@@ -70,9 +72,9 @@ public class InMemoryProvider extends EventProvider {
         this.flags.putAll(newFlags);
 
         ProviderEventDetails details = ProviderEventDetails.builder()
-            .flagsChanged(new ArrayList<>(flagsChanged))
-            .message("flags changed")
-            .build();
+                .flagsChanged(new ArrayList<>(flagsChanged))
+                .message("flags changed")
+                .build();
         emitProviderConfigurationChanged(details);
     }
 
@@ -80,14 +82,15 @@ public class InMemoryProvider extends EventProvider {
      * Updates a single provider flag configuration.
      * For existing flag, the new configuration replaces the old one.
      * For new flag, they are added to the configuration.
+     *
      * @param newFlag the flag to update
      */
     public void updateFlag(String flagKey, Flag<?> newFlag) {
         this.flags.put(flagKey, newFlag);
         ProviderEventDetails details = ProviderEventDetails.builder()
-            .flagsChanged(Collections.singletonList(flagKey))
-            .message("flag added/updated")
-            .build();
+                .flagsChanged(Collections.singletonList(flagKey))
+                .message("flag added/updated")
+                .build();
         emitProviderConfigurationChanged(details);
     }
 
@@ -144,10 +147,10 @@ public class InMemoryProvider extends EventProvider {
             value = (T) flag.getVariants().get(flag.getDefaultVariant());
         }
         return ProviderEvaluation.<T>builder()
-            .value(value)
-            .variant(flag.getDefaultVariant())
-            .reason(Reason.STATIC.toString())
-            .build();
+                .value(value)
+                .variant(flag.getDefaultVariant())
+                .reason(Reason.STATIC.toString())
+                .build();
     }
 
 }

--- a/src/test/java/dev/openfeature/sdk/DeveloperExperienceTest.java
+++ b/src/test/java/dev/openfeature/sdk/DeveloperExperienceTest.java
@@ -20,7 +20,8 @@ import dev.openfeature.sdk.fixtures.HookFixtures;
 class DeveloperExperienceTest implements HookFixtures {
     transient String flagKey = "mykey";
 
-    @Test void simpleBooleanFlag() {
+    @Test
+    void simpleBooleanFlag() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider());
         Client client = api.getClient();
@@ -28,7 +29,8 @@ class DeveloperExperienceTest implements HookFixtures {
         assertFalse(retval);
     }
 
-    @Test void clientHooks() {
+    @Test
+    void clientHooks() {
         Hook<Boolean> exampleHook = mockBooleanHook();
 
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
@@ -40,7 +42,8 @@ class DeveloperExperienceTest implements HookFixtures {
         assertFalse(retval);
     }
 
-    @Test void evalHooks() {
+    @Test
+    void evalHooks() {
         Hook<Boolean> clientHook = mockBooleanHook();
         Hook<Boolean> evalHook = mockBooleanHook();
 
@@ -59,7 +62,8 @@ class DeveloperExperienceTest implements HookFixtures {
      * As an application author, you probably know special things about your users. You can communicate these to the
      * provider via {@link MutableContext}
      */
-    @Test void providingContext() {
+    @Test
+    void providingContext() {
 
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider());
@@ -76,7 +80,8 @@ class DeveloperExperienceTest implements HookFixtures {
         assertFalse(retval);
     }
 
-    @Test void brokenProvider() {
+    @Test
+    void brokenProvider() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         FeatureProviderTestUtils.setFeatureProvider(new AlwaysBrokenProvider());
         Client client = api.getClient();
@@ -99,7 +104,7 @@ class DeveloperExperienceTest implements HookFixtures {
                 return Optional.empty();
             }
         }
-        
+
         final String defaultValue = "string-value";
         final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         final Client client = api.getClient();
@@ -111,7 +116,7 @@ class DeveloperExperienceTest implements HookFixtures {
         assertEquals(new StringBuilder(defaultValue).reverse().toString(), doSomethingValue);
 
         api.clearHooks();
-        
+
         // subsequent evaluations should now use new provider set by hook
         String noOpValue = client.getStringValue("val", defaultValue);
         assertEquals(noOpValue, defaultValue);

--- a/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
+++ b/src/test/java/dev/openfeature/sdk/DoSomethingProvider.java
@@ -5,7 +5,7 @@ class DoSomethingProvider implements FeatureProvider {
     static final String name = "Something";
     // Flag evaluation metadata
     static final ImmutableMetadata DEFAULT_METADATA = ImmutableMetadata.builder().build();
-    private ImmutableMetadata flagMetadata;
+    private final ImmutableMetadata flagMetadata;
 
     public DoSomethingProvider() {
         this.flagMetadata = DEFAULT_METADATA;
@@ -53,7 +53,8 @@ class DoSomethingProvider implements FeatureProvider {
     }
 
     @Override
-    public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext invocationContext) {
+    public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue,
+            EvaluationContext invocationContext) {
         return ProviderEvaluation.<Value>builder()
                 .value(null)
                 .flagMetadata(flagMetadata)

--- a/src/test/java/dev/openfeature/sdk/EvalContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/EvalContextTest.java
@@ -11,20 +11,23 @@ import java.util.Map;
 
 import static dev.openfeature.sdk.EvaluationContext.TARGETING_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class EvalContextTest {
-    @Specification(number="3.1.1",
-            text="The `evaluation context` structure **MUST** define an optional `targeting key` field of " +
+    @Specification(number = "3.1.1",
+            text = "The `evaluation context` structure **MUST** define an optional `targeting key` field of " +
                     "type string, identifying the subject of the flag evaluation.")
-    @Test void requires_targeting_key() {
+    @Test
+    void requires_targeting_key() {
         EvaluationContext ec = new ImmutableContext("targeting-key", new HashMap<>());
         assertEquals("targeting-key", ec.getTargetingKey());
     }
 
-    @Specification(number="3.1.2", text= "The evaluation context MUST support the inclusion of " +
+    @Specification(number = "3.1.2", text = "The evaluation context MUST support the inclusion of " +
             "custom fields, having keys of type `string`, and " +
             "values of type `boolean | string | number | datetime | structure`.")
-    @Test void eval_context() {
+    @Test
+    void eval_context() {
         Map<String, Value> attributes = new HashMap<>();
         Instant dt = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         attributes.put("str", new Value("test"));
@@ -42,13 +45,14 @@ public class EvalContextTest {
         assertEquals(dt, ec.getValue("dt").asInstant().truncatedTo(ChronoUnit.MILLIS));
     }
 
-    @Specification(number="3.1.2", text="The evaluation context MUST support the inclusion of " +
+    @Specification(number = "3.1.2", text = "The evaluation context MUST support the inclusion of " +
             "custom fields, having keys of type `string`, and " +
             "values of type `boolean | string | number | datetime | structure`.")
-    @Test void eval_context_structure_array() {
+    @Test
+    void eval_context_structure_array() {
         Map<String, Value> attributes = new HashMap<>();
         attributes.put("obj", new Value(new MutableStructure().add("val1", 1).add("val2", "2")));
-        List<Value> values =  new ArrayList<Value>(){{
+        List<Value> values = new ArrayList<Value>() {{
             add(new Value("one"));
             add(new Value("two"));
         }};
@@ -64,9 +68,10 @@ public class EvalContextTest {
         assertEquals("two", arr.get(1).asString());
     }
 
-    @Specification(number="3.1.3", text="The evaluation context MUST support fetching the custom fields by key and also fetching all key value pairs.")
-    @Test void fetch_all() {
-        Map<String, Value> attributes  = new HashMap<>();
+    @Specification(number = "3.1.3", text = "The evaluation context MUST support fetching the custom fields by key and also fetching all key value pairs.")
+    @Test
+    void fetch_all() {
+        Map<String, Value> attributes = new HashMap<>();
         Instant dt = Instant.now();
         MutableStructure mutableStructure = new MutableStructure().add("val1", 1).add("val2", "2");
         attributes.put("str", new Value("test"));
@@ -96,28 +101,31 @@ public class EvalContextTest {
         assertEquals("2", foundObj.getValue("val2").asString());
     }
 
-    @Specification(number="3.1.4", text="The evaluation context fields MUST have an unique key.")
-    @Test void unique_key_across_types() {
+    @Specification(number = "3.1.4", text = "The evaluation context fields MUST have an unique key.")
+    @Test
+    void unique_key_across_types() {
         MutableContext ec = new MutableContext();
         ec.add("key", "val");
         ec.add("key", "val2");
         assertEquals("val2", ec.getValue("key").asString());
         ec.add("key", 3);
-        assertEquals(null, ec.getValue("key").asString());
+        assertNull(ec.getValue("key").asString());
         assertEquals(3, ec.getValue("key").asInteger());
     }
 
-    @Test void unique_key_across_types_immutableContext() {
-        HashMap<String, Value>  attributes = new HashMap<>();
+    @Test
+    void unique_key_across_types_immutableContext() {
+        HashMap<String, Value> attributes = new HashMap<>();
         attributes.put("key", new Value("val"));
         attributes.put("key", new Value("val2"));
         attributes.put("key", new Value(3));
         EvaluationContext ec = new ImmutableContext(attributes);
-        assertEquals(null, ec.getValue("key").asString());
+        assertNull(ec.getValue("key").asString());
         assertEquals(3, ec.getValue("key").asInteger());
     }
 
-    @Test void can_chain_attribute_addition() {
+    @Test
+    void can_chain_attribute_addition() {
         MutableContext ec = new MutableContext();
         MutableContext out = ec.add("str", "test")
                 .add("int", 4)
@@ -126,24 +134,26 @@ public class EvalContextTest {
         assertEquals(MutableContext.class, out.getClass());
     }
 
-    @Test void can_add_key_with_null() {
+    @Test
+    void can_add_key_with_null() {
         MutableContext ec = new MutableContext()
-                .add("Boolean", (Boolean)null)
-                .add("String", (String)null)
-                .add("Double", (Double)null)
-                .add("Structure", (MutableStructure)null)
-                .add("List", (List<Value>)null)
-                .add("Instant", (Instant)null);
+                .add("Boolean", (Boolean) null)
+                .add("String", (String) null)
+                .add("Double", (Double) null)
+                .add("Structure", (MutableStructure) null)
+                .add("List", (List<Value>) null)
+                .add("Instant", (Instant) null);
         assertEquals(6, ec.asMap().size());
-        assertEquals(null, ec.getValue("Boolean").asBoolean());
-        assertEquals(null, ec.getValue("String").asString());
-        assertEquals(null, ec.getValue("Double").asDouble());
-        assertEquals(null, ec.getValue("Structure").asStructure());
-        assertEquals(null, ec.getValue("List").asList());
-        assertEquals(null, ec.getValue("Instant").asString());
+        assertNull(ec.getValue("Boolean").asBoolean());
+        assertNull(ec.getValue("String").asString());
+        assertNull(ec.getValue("Double").asDouble());
+        assertNull(ec.getValue("Structure").asStructure());
+        assertNull(ec.getValue("List").asList());
+        assertNull(ec.getValue("Instant").asString());
     }
 
-    @Test void Immutable_context_merge_targeting_key() {
+    @Test
+    void Immutable_context_merge_targeting_key() {
         String key1 = "key1";
         EvaluationContext ctx1 = new ImmutableContext(key1, new HashMap<>());
         EvaluationContext ctx2 = new ImmutableContext(new HashMap<>());
@@ -156,19 +166,21 @@ public class EvalContextTest {
         ctxMerged = ctx1.merge(ctx2);
         assertEquals(key2, ctxMerged.getTargetingKey());
 
-        ctx2 = new ImmutableContext(" ",new HashMap<>());
+        ctx2 = new ImmutableContext(" ", new HashMap<>());
         ctxMerged = ctx1.merge(ctx2);
         assertEquals(key1, ctxMerged.getTargetingKey());
     }
 
-    @Test void merge_null_returns_value() {
+    @Test
+    void merge_null_returns_value() {
         MutableContext ctx1 = new MutableContext("key");
         ctx1.add("mything", "value");
         EvaluationContext result = ctx1.merge(null);
         assertEquals(ctx1, result);
     }
 
-    @Test void merge_targeting_key() {
+    @Test
+    void merge_targeting_key() {
         String key1 = "key1";
         MutableContext ctx1 = new MutableContext(key1);
         MutableContext ctx2 = new MutableContext();
@@ -186,14 +198,15 @@ public class EvalContextTest {
         assertEquals(key2, ctxMerged.getTargetingKey());
     }
 
-    @Test void asObjectMap() {
+    @Test
+    void asObjectMap() {
         String key1 = "key1";
         MutableContext ctx = new MutableContext(key1);
         ctx.add("stringItem", "stringValue");
         ctx.add("boolItem", false);
         ctx.add("integerItem", 1);
         ctx.add("doubleItem", 1.2);
-        ctx.add("instantItem",  Instant.ofEpochSecond(1663331342));
+        ctx.add("instantItem", Instant.ofEpochSecond(1663331342));
         List<Value> listItem = new ArrayList<>();
         listItem.add(new Value("item1"));
         listItem.add(new Value("item2"));
@@ -207,10 +220,9 @@ public class EvalContextTest {
         structureValue.put("structBoolItem", new Value(false));
         structureValue.put("structIntegerItem", new Value(1));
         structureValue.put("structDoubleItem", new Value(1.2));
-        structureValue.put("structInstantItem",  new Value(Instant.ofEpochSecond(1663331342)));
+        structureValue.put("structInstantItem", new Value(Instant.ofEpochSecond(1663331342)));
         Structure structure = new MutableStructure(structureValue);
         ctx.add("structureItem", structure);
-
 
         Map<String, Object> want = new HashMap<>();
         want.put(TARGETING_KEY, key1);
@@ -218,7 +230,7 @@ public class EvalContextTest {
         want.put("boolItem", false);
         want.put("integerItem", 1);
         want.put("doubleItem", 1.2);
-        want.put("instantItem",  Instant.ofEpochSecond(1663331342));
+        want.put("instantItem", Instant.ofEpochSecond(1663331342));
         List<String> wantListItem = new ArrayList<>();
         wantListItem.add("item1");
         wantListItem.add("item2");
@@ -232,9 +244,9 @@ public class EvalContextTest {
         wantStructureValue.put("structBoolItem", false);
         wantStructureValue.put("structIntegerItem", 1);
         wantStructureValue.put("structDoubleItem", 1.2);
-        wantStructureValue.put("structInstantItem",  Instant.ofEpochSecond(1663331342));
-        want.put("structureItem",wantStructureValue);
+        wantStructureValue.put("structInstantItem", Instant.ofEpochSecond(1663331342));
+        want.put("structureItem", wantStructureValue);
 
-        assertEquals(want,ctx.asObjectMap());
+        assertEquals(want, ctx.asObjectMap());
     }
 }

--- a/src/test/java/dev/openfeature/sdk/EventProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/EventProviderTest.java
@@ -127,6 +127,6 @@ class EventProviderTest {
 
     @SuppressWarnings("unchecked")
     private TriConsumer<EventProvider, ProviderEvent, ProviderEventDetails> mockOnEmit() {
-        return (TriConsumer<EventProvider, ProviderEvent, ProviderEventDetails>)mock(TriConsumer.class);
+        return (TriConsumer<EventProvider, ProviderEvent, ProviderEventDetails>) mock(TriConsumer.class);
     }
 }

--- a/src/test/java/dev/openfeature/sdk/EventsTest.java
+++ b/src/test/java/dev/openfeature/sdk/EventsTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -99,12 +100,14 @@ class EventsTest {
 
                 @Test
                 @DisplayName("should support all event types")
-                @Specification(number = "5.1.1", text = "The provider MAY define a mechanism for signaling the occurrence "
-                        + "of one of a set of events, including PROVIDER_READY, PROVIDER_ERROR, "
-                        + "PROVIDER_CONFIGURATION_CHANGED and PROVIDER_STALE, with a provider event details payload.")
-                @Specification(number = "5.2.2", text = "The API MUST provide a function for associating handler functions"
-                        +
-                        " with a particular provider event type.")
+                @Specification(number = "5.1.1", text =
+                        "The provider MAY define a mechanism for signaling the occurrence "
+                                + "of one of a set of events, including PROVIDER_READY, PROVIDER_ERROR, "
+                                + "PROVIDER_CONFIGURATION_CHANGED and PROVIDER_STALE, with a provider event details payload.")
+                @Specification(number = "5.2.2", text =
+                        "The API MUST provide a function for associating handler functions"
+                                +
+                                " with a particular provider event type.")
                 void apiShouldSupportAllEventTypes() {
                     final String name = "apiShouldSupportAllEventTypes";
                     final Consumer<EventDetails> handler1 = mockHandler();
@@ -303,9 +306,10 @@ class EventsTest {
             @Specification(number = "5.1.1", text = "The provider MAY define a mechanism for signaling the occurrence "
                     + "of one of a set of events, including PROVIDER_READY, PROVIDER_ERROR, "
                     + "PROVIDER_CONFIGURATION_CHANGED and PROVIDER_STALE, with a provider event details payload.")
-            @Specification(number = "5.2.1", text = "The client MUST provide a function for associating handler functions"
-                    +
-                    " with a particular provider event type.")
+            @Specification(number = "5.2.1", text =
+                    "The client MUST provide a function for associating handler functions"
+                            +
+                            " with a particular provider event type.")
             void shouldSupportAllEventTypes() {
                 final String name = "shouldSupportAllEventTypes";
                 final Consumer<EventDetails> handler1 = mockHandler();
@@ -337,7 +341,7 @@ class EventsTest {
 
     @Test
     @DisplayName("shutdown provider should not run handlers")
-    void shouldNotRunHandlers()  {
+    void shouldNotRunHandlers() {
         final Consumer<EventDetails> handler1 = mockHandler();
         final Consumer<EventDetails> handler2 = mockHandler();
         final String name = "shouldNotRunHandlers";
@@ -484,7 +488,7 @@ class EventsTest {
         OpenFeatureAPI.getInstance().onProviderConfigurationChanged(handler1);
         client.onProviderConfigurationChanged(handler2);
 
-        List<String> flagsChanged = Arrays.asList("flag");
+        List<String> flagsChanged = Collections.singletonList("flag");
         ImmutableMetadata metadata = ImmutableMetadata.builder().addInteger("int", 1).build();
         String message = "a message";
         ProviderEventDetails details = ProviderEventDetails.builder()
@@ -594,7 +598,7 @@ class EventsTest {
 
     @Nested
     class HandlerRemoval {
-        @Specification(number="5.2.7", text="The API and client MUST provide a function allowing the removal of event handlers.")
+        @Specification(number = "5.2.7", text = "The API and client MUST provide a function allowing the removal of event handlers.")
         @Test
         @DisplayName("should not run removed events")
         void removedEventsShouldNotRun() {

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationDetailsTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationDetailsTest.java
@@ -29,13 +29,13 @@ class FlagEvaluationDetailsTest {
         ImmutableMetadata metadata = ImmutableMetadata.builder().build();
 
         FlagEvaluationDetails<Integer> details = new FlagEvaluationDetails<>(
-        flagKey,
-        value,
-        variant,
-        reason.toString(),
-        errorCode,
-        errorMessage,
-        metadata);
+                flagKey,
+                value,
+                variant,
+                reason.toString(),
+                errorCode,
+                errorMessage,
+                metadata);
 
         assertEquals(flagKey, details.getFlagKey());
         assertEquals(value, details.getValue());
@@ -48,13 +48,13 @@ class FlagEvaluationDetailsTest {
 
     @Test
     @DisplayName("should be able to compare 2 FlagEvaluationDetails")
-    public void compareFlagEvaluationDetails(){
+    public void compareFlagEvaluationDetails() {
         FlagEvaluationDetails fed1 = FlagEvaluationDetails.builder()
                 .reason(Reason.ERROR.toString())
                 .value(false)
                 .errorCode(ErrorCode.GENERAL)
                 .errorMessage("error XXX")
-                .flagMetadata(ImmutableMetadata.builder().addString("metadata","1").build())
+                .flagMetadata(ImmutableMetadata.builder().addString("metadata", "1").build())
                 .build();
 
         FlagEvaluationDetails fed2 = FlagEvaluationDetails.builder()
@@ -62,9 +62,9 @@ class FlagEvaluationDetailsTest {
                 .value(false)
                 .errorCode(ErrorCode.GENERAL)
                 .errorMessage("error XXX")
-                .flagMetadata(ImmutableMetadata.builder().addString("metadata","1").build())
+                .flagMetadata(ImmutableMetadata.builder().addString("metadata", "1").build())
                 .build();
 
-        assertEquals(fed1,fed2);
+        assertEquals(fed1, fed2);
     }
 }

--- a/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/FlagEvaluationSpecTest.java
@@ -52,34 +52,40 @@ class FlagEvaluationSpecTest implements HookFixtures {
         api = OpenFeatureAPI.getInstance();
     }
 
-    @AfterEach void reset_ctx() {
+    @AfterEach
+    void reset_ctx() {
         api.setEvaluationContext(null);
     }
 
-    @BeforeEach void set_logger() {
+    @BeforeEach
+    void set_logger() {
         logger = Mockito.mock(Logger.class);
         LoggerMock.setMock(OpenFeatureClient.class, logger);
     }
 
-    @AfterEach void reset_logs() {
+    @AfterEach
+    void reset_logs() {
         LoggerMock.setMock(OpenFeatureClient.class, logger);
     }
 
-    @Specification(number="1.1.1", text="The API, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the API are present at runtime.")
-    @Test void global_singleton() {
+    @Specification(number = "1.1.1", text = "The API, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the API are present at runtime.")
+    @Test
+    void global_singleton() {
         assertSame(OpenFeatureAPI.getInstance(), OpenFeatureAPI.getInstance());
     }
 
-    @Specification(number="1.1.2.1", text="The API MUST define a provider mutator, a function to set the default provider, which accepts an API-conformant provider implementation.")
-    @Test void provider() {
+    @Specification(number = "1.1.2.1", text = "The API MUST define a provider mutator, a function to set the default provider, which accepts an API-conformant provider implementation.")
+    @Test
+    void provider() {
         FeatureProvider mockProvider = mock(FeatureProvider.class);
         FeatureProviderTestUtils.setFeatureProvider(mockProvider);
         assertThat(api.getProvider()).isEqualTo(mockProvider);
     }
 
     @SneakyThrows
-    @Specification(number="1.1.8", text="The API SHOULD provide functions to set a provider and wait for the initialize function to return or throw.")
-    @Test void providerAndWait() {
+    @Specification(number = "1.1.8", text = "The API SHOULD provide functions to set a provider and wait for the initialize function to return or throw.")
+    @Test
+    void providerAndWait() {
         FeatureProvider provider = new TestEventsProvider(500);
         OpenFeatureAPI.getInstance().setProviderAndWait(provider);
         assertThat(api.getProvider().getState()).isEqualTo(ProviderState.READY);
@@ -91,8 +97,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
     }
 
     @SneakyThrows
-    @Specification(number="1.1.8", text="The API SHOULD provide functions to set a provider and wait for the initialize function to return or throw.")
-    @Test void providerAndWaitError() {
+    @Specification(number = "1.1.8", text = "The API SHOULD provide functions to set a provider and wait for the initialize function to return or throw.")
+    @Test
+    void providerAndWaitError() {
         FeatureProvider provider1 = new TestEventsProvider(500, true, "fake error");
         assertThrows(GeneralError.class, () -> api.setProviderAndWait(provider1));
 
@@ -101,8 +108,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertThrows(GeneralError.class, () -> api.setProviderAndWait(providerName, provider2));
     }
 
-    @Specification(number="2.4.5", text="The provider SHOULD indicate an error if flag resolution is attempted before the provider is ready.")
-    @Test void shouldReturnNotReadyIfNotInitialized() {
+    @Specification(number = "2.4.5", text = "The provider SHOULD indicate an error if flag resolution is attempted before the provider is ready.")
+    @Test
+    void shouldReturnNotReadyIfNotInitialized() {
         FeatureProvider provider = new InMemoryProvider(new HashMap<>()) {
             @Override
             public void initialize(EvaluationContext evaluationContext) throws Exception {
@@ -113,17 +121,20 @@ class FlagEvaluationSpecTest implements HookFixtures {
         OpenFeatureAPI.getInstance().setProvider(providerName, provider);
         assertThat(api.getProvider(providerName).getState()).isEqualTo(ProviderState.NOT_READY);
         Client client = OpenFeatureAPI.getInstance().getClient(providerName);
-        assertEquals(ErrorCode.PROVIDER_NOT_READY, client.getBooleanDetails("return_error_when_not_initialized", false).getErrorCode());
+        assertEquals(ErrorCode.PROVIDER_NOT_READY,
+                client.getBooleanDetails("return_error_when_not_initialized", false).getErrorCode());
     }
 
-    @Specification(number="1.1.5", text="The API MUST provide a function for retrieving the metadata field of the configured provider.")
-    @Test void provider_metadata() {
+    @Specification(number = "1.1.5", text = "The API MUST provide a function for retrieving the metadata field of the configured provider.")
+    @Test
+    void provider_metadata() {
         FeatureProviderTestUtils.setFeatureProvider(new DoSomethingProvider());
         assertThat(api.getProviderMetadata().getName()).isEqualTo(DoSomethingProvider.name);
     }
 
-    @Specification(number="1.1.4", text="The API MUST provide a function to add hooks which accepts one or more API-conformant hooks, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")
-    @Test void hook_addition() {
+    @Specification(number = "1.1.4", text = "The API MUST provide a function to add hooks which accepts one or more API-conformant hooks, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")
+    @Test
+    void hook_addition() {
         Hook h1 = mock(Hook.class);
         Hook h2 = mock(Hook.class);
         api.addHooks(h1);
@@ -136,8 +147,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(h2, api.getHooks().get(1));
     }
 
-    @Specification(number="1.1.6", text="The API MUST provide a function for creating a client which accepts the following options:  - domain (optional): A logical string identifier for binding clients to provider.")
-    @Test void domainName() {
+    @Specification(number = "1.1.6", text = "The API MUST provide a function for creating a client which accepts the following options:  - domain (optional): A logical string identifier for binding clients to provider.")
+    @Test
+    void domainName() {
         assertNull(api.getClient().getMetadata().getDomain());
 
         String domain = "Sir Calls-a-lot";
@@ -145,8 +157,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(domain, clientForDomain.getMetadata().getDomain());
     }
 
-    @Specification(number="1.2.1", text="The client MUST provide a method to add hooks which accepts one or more API-conformant hooks, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")
-    @Test void hookRegistration() {
+    @Specification(number = "1.2.1", text = "The client MUST provide a method to add hooks which accepts one or more API-conformant hooks, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.")
+    @Test
+    void hookRegistration() {
         Client c = _client();
         Hook m1 = mock(Hook.class);
         Hook m2 = mock(Hook.class);
@@ -158,9 +171,10 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertTrue(hooks.contains(m2));
     }
 
-    @Specification(number="1.3.1.1", text="The client MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure, with parameters flag key (string, required), default value (boolean | number | string | structure, required), evaluation context (optional), and evaluation options (optional), which returns the flag value.")
-    @Specification(number="1.3.3.1", text="The client SHOULD provide functions for floating-point numbers and integers, consistent with language idioms.")
-    @Test void value_flags() {
+    @Specification(number = "1.3.1.1", text = "The client MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure, with parameters flag key (string, required), default value (boolean | number | string | structure, required), evaluation context (optional), and evaluation options (optional), which returns the flag value.")
+    @Specification(number = "1.3.3.1", text = "The client SHOULD provide functions for floating-point numbers and integers, consistent with language idioms.")
+    @Test
+    void value_flags() {
         FeatureProviderTestUtils.setFeatureProvider(new DoSomethingProvider());
 
         Client c = api.getClient();
@@ -168,11 +182,13 @@ class FlagEvaluationSpecTest implements HookFixtures {
 
         assertEquals(true, c.getBooleanValue(key, false));
         assertEquals(true, c.getBooleanValue(key, false, new ImmutableContext()));
-        assertEquals(true, c.getBooleanValue(key, false, new ImmutableContext(), FlagEvaluationOptions.builder().build()));
+        assertEquals(true,
+                c.getBooleanValue(key, false, new ImmutableContext(), FlagEvaluationOptions.builder().build()));
 
         assertEquals("gnirts-ym", c.getStringValue(key, "my-string"));
         assertEquals("gnirts-ym", c.getStringValue(key, "my-string", new ImmutableContext()));
-        assertEquals("gnirts-ym", c.getStringValue(key, "my-string", new ImmutableContext(), FlagEvaluationOptions.builder().build()));
+        assertEquals("gnirts-ym",
+                c.getStringValue(key, "my-string", new ImmutableContext(), FlagEvaluationOptions.builder().build()));
 
         assertEquals(400, c.getIntegerValue(key, 4));
         assertEquals(400, c.getIntegerValue(key, 4, new ImmutableContext()));
@@ -182,18 +198,19 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(40.0, c.getDoubleValue(key, .4, new ImmutableContext()));
         assertEquals(40.0, c.getDoubleValue(key, .4, new ImmutableContext(), FlagEvaluationOptions.builder().build()));
 
-        assertEquals(null, c.getObjectValue(key, new Value()));
-        assertEquals(null, c.getObjectValue(key, new Value(), new ImmutableContext()));
-        assertEquals(null, c.getObjectValue(key, new Value(), new ImmutableContext(), FlagEvaluationOptions.builder().build()));
+        assertNull(c.getObjectValue(key, new Value()));
+        assertNull(c.getObjectValue(key, new Value(), new ImmutableContext()));
+        assertNull(c.getObjectValue(key, new Value(), new ImmutableContext(), FlagEvaluationOptions.builder().build()));
     }
 
-    @Specification(number="1.4.1.1", text="The client MUST provide methods for detailed flag value evaluation with parameters flag key (string, required), default value (boolean | number | string | structure, required), evaluation context (optional), and evaluation options (optional), which returns an evaluation details structure.")
-    @Specification(number="1.4.3", text="The evaluation details structure's value field MUST contain the evaluated flag value.")
-    @Specification(number="1.4.4.1", text="The evaluation details structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped value field.")
-    @Specification(number="1.4.5", text="The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method.")
-    @Specification(number="1.4.6", text="In cases of normal execution, the evaluation details structure's variant field MUST contain the value of the variant field in the flag resolution structure returned by the configured provider, if the field is set.")
-    @Specification(number="1.4.7", text="In cases of normal execution, the `evaluation details` structure's `reason` field MUST contain the value of the `reason` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.")
-    @Test void detail_flags() {
+    @Specification(number = "1.4.1.1", text = "The client MUST provide methods for detailed flag value evaluation with parameters flag key (string, required), default value (boolean | number | string | structure, required), evaluation context (optional), and evaluation options (optional), which returns an evaluation details structure.")
+    @Specification(number = "1.4.3", text = "The evaluation details structure's value field MUST contain the evaluated flag value.")
+    @Specification(number = "1.4.4.1", text = "The evaluation details structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped value field.")
+    @Specification(number = "1.4.5", text = "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method.")
+    @Specification(number = "1.4.6", text = "In cases of normal execution, the evaluation details structure's variant field MUST contain the value of the variant field in the flag resolution structure returned by the configured provider, if the field is set.")
+    @Specification(number = "1.4.7", text = "In cases of normal execution, the `evaluation details` structure's `reason` field MUST contain the value of the `reason` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.")
+    @Test
+    void detail_flags() {
         FeatureProviderTestUtils.setFeatureProvider(new DoSomethingProvider());
         Client c = api.getClient();
         String key = "key";
@@ -206,7 +223,8 @@ class FlagEvaluationSpecTest implements HookFixtures {
                 .build();
         assertEquals(bd, c.getBooleanDetails(key, true));
         assertEquals(bd, c.getBooleanDetails(key, true, new ImmutableContext()));
-        assertEquals(bd, c.getBooleanDetails(key, true, new ImmutableContext(), FlagEvaluationOptions.builder().build()));
+        assertEquals(bd,
+                c.getBooleanDetails(key, true, new ImmutableContext(), FlagEvaluationOptions.builder().build()));
 
         FlagEvaluationDetails<String> sd = FlagEvaluationDetails.<String>builder()
                 .flagKey(key)
@@ -216,7 +234,8 @@ class FlagEvaluationSpecTest implements HookFixtures {
                 .build();
         assertEquals(sd, c.getStringDetails(key, "test"));
         assertEquals(sd, c.getStringDetails(key, "test", new ImmutableContext()));
-        assertEquals(sd, c.getStringDetails(key, "test", new ImmutableContext(), FlagEvaluationOptions.builder().build()));
+        assertEquals(sd,
+                c.getStringDetails(key, "test", new ImmutableContext(), FlagEvaluationOptions.builder().build()));
 
         FlagEvaluationDetails<Integer> id = FlagEvaluationDetails.<Integer>builder()
                 .flagKey(key)
@@ -239,24 +258,26 @@ class FlagEvaluationSpecTest implements HookFixtures {
         // TODO: Structure detail tests.
     }
 
-    @Specification(number="1.5.1", text="The evaluation options structure's hooks field denotes an ordered collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.")
-    @Test void hooks() {
+    @Specification(number = "1.5.1", text = "The evaluation options structure's hooks field denotes an ordered collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.")
+    @Test
+    void hooks() {
         Client c = _client();
         Hook<Boolean> clientHook = mockBooleanHook();
         Hook<Boolean> invocationHook = mockBooleanHook();
         c.addHooks(clientHook);
         c.getBooleanValue("key", false, null, FlagEvaluationOptions.builder()
-            .hook(invocationHook)
-            .build());
+                .hook(invocationHook)
+                .build());
         verify(clientHook, times(1)).before(any(), any());
         verify(invocationHook, times(1)).before(any(), any());
     }
 
-    @Specification(number="1.4.8", text="In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain an `error code`.")
-    @Specification(number="1.4.9", text="In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` SHOULD indicate an error.")
-    @Specification(number="1.4.10", text="Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.")
-    @Specification(number="1.4.13", text="In cases of abnormal execution, the `evaluation details` structure's `error message` field **MAY** contain a string containing additional details about the nature of the error.")
-    @Test void broken_provider() {
+    @Specification(number = "1.4.8", text = "In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain an `error code`.")
+    @Specification(number = "1.4.9", text = "In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` SHOULD indicate an error.")
+    @Specification(number = "1.4.10", text = "Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.")
+    @Specification(number = "1.4.13", text = "In cases of abnormal execution, the `evaluation details` structure's `error message` field **MAY** contain a string containing additional details about the nature of the error.")
+    @Test
+    void broken_provider() {
         FeatureProviderTestUtils.setFeatureProvider(new AlwaysBrokenProvider());
         Client c = api.getClient();
         assertFalse(c.getBooleanValue("key", false));
@@ -265,8 +286,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(TestConstants.BROKEN_MESSAGE, details.getErrorMessage());
     }
 
-    @Specification(number="1.4.11", text="Methods, functions, or operations on the client SHOULD NOT write log messages.")
-    @Test void log_on_error() throws NotImplementedException {
+    @Specification(number = "1.4.11", text = "Methods, functions, or operations on the client SHOULD NOT write log messages.")
+    @Test
+    void log_on_error() throws NotImplementedException {
         FeatureProviderTestUtils.setFeatureProvider(new AlwaysBrokenProvider());
         Client c = api.getClient();
         FlagEvaluationDetails<Boolean> result = c.getBooleanDetails("test", false);
@@ -278,8 +300,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
                 any());
     }
 
-    @Specification(number="1.2.2", text="The client interface MUST define a metadata member or accessor, containing an immutable domain field or accessor of type string, which corresponds to the domain value supplied during client creation. In previous drafts, this property was called name. For backwards compatibility, implementations should consider name an alias to domain.")
-    @Test void clientMetadata() {
+    @Specification(number = "1.2.2", text = "The client interface MUST define a metadata member or accessor, containing an immutable domain field or accessor of type string, which corresponds to the domain value supplied during client creation. In previous drafts, this property was called name. For backwards compatibility, implementations should consider name an alias to domain.")
+    @Test
+    void clientMetadata() {
         Client c = _client();
         assertNull(c.getMetadata().getName());
         assertNull(c.getMetadata().getDomain());
@@ -292,27 +315,30 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(domainName, c2.getMetadata().getDomain());
     }
 
-    @Specification(number="1.4.9", text="In cases of abnormal execution (network failure, unhandled error, etc) the reason field in the evaluation details SHOULD indicate an error.")
-    @Test void reason_is_error_when_there_are_errors() {
+    @Specification(number = "1.4.9", text = "In cases of abnormal execution (network failure, unhandled error, etc) the reason field in the evaluation details SHOULD indicate an error.")
+    @Test
+    void reason_is_error_when_there_are_errors() {
         FeatureProviderTestUtils.setFeatureProvider(new AlwaysBrokenProvider());
         Client c = api.getClient();
         FlagEvaluationDetails<Boolean> result = c.getBooleanDetails("test", false);
         assertEquals(Reason.ERROR.toString(), result.getReason());
     }
 
-    @Specification(number="1.4.14", text="If the flag metadata field in the flag resolution structure returned by the configured provider is set, the evaluation details structure's flag metadata field MUST contain that value. Otherwise, it MUST contain an empty record.")
-    @Test void flag_metadata_passed() {
+    @Specification(number = "1.4.14", text = "If the flag metadata field in the flag resolution structure returned by the configured provider is set, the evaluation details structure's flag metadata field MUST contain that value. Otherwise, it MUST contain an empty record.")
+    @Test
+    void flag_metadata_passed() {
         FeatureProviderTestUtils.setFeatureProvider(new DoSomethingProvider(null));
         Client c = api.getClient();
         FlagEvaluationDetails<Boolean> result = c.getBooleanDetails("test", false);
         assertNotNull(result.getFlagMetadata());
     }
 
-    @Specification(number="3.2.2.1", text="The API MUST have a method for setting the global evaluation context.")
-    @Test void api_context() {
+    @Specification(number = "3.2.2.1", text = "The API MUST have a method for setting the global evaluation context.")
+    @Test
+    void api_context() {
         String contextKey = "some-key";
         String contextValue = "some-value";
-        DoSomethingProvider provider = spy( new DoSomethingProvider());
+        DoSomethingProvider provider = spy(new DoSomethingProvider());
         FeatureProviderTestUtils.setFeatureProvider(provider);
 
         Map<String, Value> attributes = new HashMap<>();
@@ -325,12 +351,14 @@ class FlagEvaluationSpecTest implements HookFixtures {
         client.getBooleanValue("any-flag", false);
 
         // assert that the value from the global context was passed to the provider
-        verify(provider).getBooleanEvaluation(any(), any(), argThat((arg) -> arg.getValue(contextKey).asString().equals(contextValue)));
+        verify(provider).getBooleanEvaluation(any(), any(),
+                argThat((arg) -> arg.getValue(contextKey).asString().equals(contextValue)));
     }
 
-    @Specification(number="3.2.1.1", text="The API, Client and invocation MUST have a method for supplying evaluation context.")
-    @Specification(number="3.2.3", text="Evaluation context MUST be merged in the order: API (global; lowest precedence) -> transaction -> client -> invocation -> before hooks (highest precedence), with duplicate values being overwritten.")
-    @Test void multi_layer_context_merges_correctly() {
+    @Specification(number = "3.2.1.1", text = "The API, Client and invocation MUST have a method for supplying evaluation context.")
+    @Specification(number = "3.2.3", text = "Evaluation context MUST be merged in the order: API (global; lowest precedence) -> transaction -> client -> invocation -> before hooks (highest precedence), with duplicate values being overwritten.")
+    @Test
+    void multi_layer_context_merges_correctly() {
         DoSomethingProvider provider = spy(new DoSomethingProvider());
         FeatureProviderTestUtils.setFeatureProvider(provider);
         TransactionContextPropagator transactionContextPropagator = new ThreadLocalTransactionContextPropagator();
@@ -343,8 +371,10 @@ class FlagEvaluationSpecTest implements HookFixtures {
                 attrs.put("common7", new Value("5"));
                 return Optional.ofNullable(new ImmutableContext(attrs));
             }
+
             @Override
-            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details, Map<String, Object> hints) {
+            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details,
+                    Map<String, Object> hints) {
                 Hook.super.after(ctx, details, hints);
             }
         });
@@ -441,8 +471,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
         }), any(), any());
     }
 
-    @Specification(number="3.3.1.1", text="The API SHOULD have a method for setting a transaction context propagator.")
-    @Test void setting_transaction_context_propagator() {
+    @Specification(number = "3.3.1.1", text = "The API SHOULD have a method for setting a transaction context propagator.")
+    @Test
+    void setting_transaction_context_propagator() {
         DoSomethingProvider provider = new DoSomethingProvider();
         FeatureProviderTestUtils.setFeatureProvider(provider);
 
@@ -451,8 +482,9 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(transactionContextPropagator, api.getTransactionContextPropagator());
     }
 
-    @Specification(number="3.3.1.2.1", text="The API MUST have a method for setting the evaluation context of the transaction context propagator for the current transaction.")
-    @Test void setting_transaction_context() {
+    @Specification(number = "3.3.1.2.1", text = "The API MUST have a method for setting the evaluation context of the transaction context propagator for the current transaction.")
+    @Test
+    void setting_transaction_context() {
         DoSomethingProvider provider = new DoSomethingProvider();
         FeatureProviderTestUtils.setFeatureProvider(provider);
 
@@ -467,9 +499,10 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(transactionContext, transactionContextPropagator.getTransactionContext());
     }
 
-    @Specification(number="3.3.1.2.2", text="A transaction context propagator MUST have a method for setting the evaluation context of the current transaction.")
-    @Specification(number="3.3.1.2.3", text="A transaction context propagator MUST have a method for getting the evaluation context of the current transaction.")
-    @Test void transaction_context_propagator_setting_context() {
+    @Specification(number = "3.3.1.2.2", text = "A transaction context propagator MUST have a method for setting the evaluation context of the current transaction.")
+    @Specification(number = "3.3.1.2.3", text = "A transaction context propagator MUST have a method for getting the evaluation context of the current transaction.")
+    @Test
+    void transaction_context_propagator_setting_context() {
         TransactionContextPropagator transactionContextPropagator = new ThreadLocalTransactionContextPropagator();
 
         Map<String, Value> attributes = new HashMap<>();
@@ -480,23 +513,33 @@ class FlagEvaluationSpecTest implements HookFixtures {
         assertEquals(transactionContext, transactionContextPropagator.getTransactionContext());
     }
 
-    @Specification(number="1.3.4", text="The client SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied default value should be returned.")
-    @Test void type_system_prevents_this() {}
+    @Specification(number = "1.3.4", text = "The client SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied default value should be returned.")
+    @Test
+    void type_system_prevents_this() {
+    }
 
-    @Specification(number="1.1.7", text="The client creation function MUST NOT throw, or otherwise abnormally terminate.")
-    @Test void constructor_does_not_throw() {}
+    @Specification(number = "1.1.7", text = "The client creation function MUST NOT throw, or otherwise abnormally terminate.")
+    @Test
+    void constructor_does_not_throw() {
+    }
 
-    @Specification(number="1.4.12", text="The client SHOULD provide asynchronous or non-blocking mechanisms for flag evaluation.")
-    @Test void one_thread_per_request_model() {}
+    @Specification(number = "1.4.12", text = "The client SHOULD provide asynchronous or non-blocking mechanisms for flag evaluation.")
+    @Test
+    void one_thread_per_request_model() {
+    }
 
-    @Specification(number="1.4.14.1", text="Condition: Flag metadata MUST be immutable.")
-    @Test void compiler_enforced() {}
+    @Specification(number = "1.4.14.1", text = "Condition: Flag metadata MUST be immutable.")
+    @Test
+    void compiler_enforced() {
+    }
 
-    @Specification(number="1.4.2.1", text="The client MUST provide methods for detailed flag value evaluation with parameters flag key (string, required), default value (boolean | number | string | structure, required), and evaluation options (optional), which returns an evaluation details structure.")
-    @Specification(number="1.3.2.1", text="The client MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure, with parameters flag key (string, required), default value (boolean | number | string | structure, required), and evaluation options (optional), which returns the flag value.")
-    @Specification(number="3.2.2.2", text="The Client and invocation MUST NOT have a method for supplying evaluation context.")
-    @Specification(number="3.2.4.1", text="When the global evaluation context is set, the on context changed handler MUST run.")
-    @Specification(number="3.3.2.1", text="The API MUST NOT have a method for setting a transaction context propagator.")
-    @Test void not_applicable_for_dynamic_context() {}
+    @Specification(number = "1.4.2.1", text = "The client MUST provide methods for detailed flag value evaluation with parameters flag key (string, required), default value (boolean | number | string | structure, required), and evaluation options (optional), which returns an evaluation details structure.")
+    @Specification(number = "1.3.2.1", text = "The client MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure, with parameters flag key (string, required), default value (boolean | number | string | structure, required), and evaluation options (optional), which returns the flag value.")
+    @Specification(number = "3.2.2.2", text = "The Client and invocation MUST NOT have a method for supplying evaluation context.")
+    @Specification(number = "3.2.4.1", text = "When the global evaluation context is set, the on context changed handler MUST run.")
+    @Specification(number = "3.3.2.1", text = "The API MUST NOT have a method for setting a transaction context propagator.")
+    @Test
+    void not_applicable_for_dynamic_context() {
+    }
 
 }

--- a/src/test/java/dev/openfeature/sdk/HookContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookContextTest.java
@@ -6,9 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class HookContextTest {
-    @Specification(number="4.2.2.2", text="Condition: The client metadata field in the hook context MUST be immutable.")
-    @Specification(number="4.2.2.3", text="Condition: The provider metadata field in the hook context MUST be immutable.")
-    @Test void metadata_field_is_type_metadata() {
+    @Specification(number = "4.2.2.2", text = "Condition: The client metadata field in the hook context MUST be immutable.")
+    @Specification(number = "4.2.2.3", text = "Condition: The provider metadata field in the hook context MUST be immutable.")
+    @Test
+    void metadata_field_is_type_metadata() {
         ClientMetadata clientMetadata = mock(ClientMetadata.class);
         Metadata meta = mock(Metadata.class);
         HookContext<Object> hc = HookContext.from(
@@ -24,7 +25,8 @@ class HookContextTest {
         assertTrue(Metadata.class.isAssignableFrom(hc.getProviderMetadata().getClass()));
     }
 
-    @Specification(number="4.3.3.1", text="The before stage MUST run before flag resolution occurs. It accepts a hook context (required) and hook hints (optional) as parameters. It has no return value.")
-    @Test void not_applicable_for_dynamic_context() {}
+    @Specification(number = "4.3.3.1", text = "The before stage MUST run before flag resolution occurs. It accepts a hook context (required) and hook hints (optional) as parameters. It has no return value.")
+    @Test
+    void not_applicable_for_dynamic_context() {}
 
 }

--- a/src/test/java/dev/openfeature/sdk/HookSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSpecTest.java
@@ -39,8 +39,9 @@ class HookSpecTest implements HookFixtures {
         OpenFeatureAPI.getInstance().clearHooks();
     }
 
-    @Specification(number="4.1.3", text="The flag key, flag type, and default value properties MUST be immutable. If the language does not support immutability, the hook MUST NOT modify these properties.")
-    @Test void immutableValues() {
+    @Specification(number = "4.1.3", text = "The flag key, flag type, and default value properties MUST be immutable. If the language does not support immutability, the hook MUST NOT modify these properties.")
+    @Test
+    void immutableValues() {
         try {
             HookContext.class.getMethod("setFlagKey");
             fail("Shouldn't be able to find this method");
@@ -63,8 +64,9 @@ class HookSpecTest implements HookFixtures {
         }
     }
 
-    @Specification(number="4.1.1", text="Hook context MUST provide: the flag key, flag value type, evaluation context, and the default value.")
-    @Test void nullish_properties_on_hookcontext() {
+    @Specification(number = "4.1.1", text = "Hook context MUST provide: the flag key, flag value type, evaluation context, and the default value.")
+    @Test
+    void nullish_properties_on_hookcontext() {
         // missing ctx
         try {
             HookContext.<Integer>builder()
@@ -127,8 +129,9 @@ class HookSpecTest implements HookFixtures {
 
     }
 
-    @Specification(number="4.1.2", text="The hook context SHOULD provide: access to the client metadata and the provider metadata fields.")
-    @Test void optional_properties() {
+    @Specification(number = "4.1.2", text = "The hook context SHOULD provide: access to the client metadata and the provider metadata fields.")
+    @Test
+    void optional_properties() {
         // don't specify
         HookContext.<Integer>builder()
                 .flagKey("key")
@@ -156,8 +159,9 @@ class HookSpecTest implements HookFixtures {
                 .build();
     }
 
-    @Specification(number="4.3.2.1", text="The before stage MUST run before flag resolution occurs. It accepts a hook context (required) and hook hints (optional) as parameters and returns either an evaluation context or nothing.")
-    @Test void before_runs_ahead_of_evaluation() {
+    @Specification(number = "4.3.2.1", text = "The before stage MUST run before flag resolution occurs. It accepts a hook context (required) and hook hints (optional) as parameters and returns either an evaluation context or nothing.")
+    @Test
+    void before_runs_ahead_of_evaluation() {
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new AlwaysBrokenProvider());
         Client client = api.getClient();
@@ -169,13 +173,15 @@ class HookSpecTest implements HookFixtures {
         verify(evalHook, times(1)).before(any(), any());
     }
 
-    @Test void feo_has_hook_list() {
+    @Test
+    void feo_has_hook_list() {
         FlagEvaluationOptions feo = FlagEvaluationOptions.builder()
                 .build();
         assertNotNull(feo.getHooks());
     }
 
-    @Test void error_hook_run_during_non_finally_stage() {
+    @Test
+    void error_hook_run_during_non_finally_stage() {
         final boolean[] error_called = {false};
         Hook h = mockBooleanHook();
         doThrow(RuntimeException.class).when(h).finallyAfter(any(), any());
@@ -184,7 +190,8 @@ class HookSpecTest implements HookFixtures {
     }
 
 
-    @Test void error_hook_must_run_if_resolution_details_returns_an_error_code() {
+    @Test
+    void error_hook_must_run_if_resolution_details_returns_an_error_code() {
 
         String errorMessage = "not found...";
 
@@ -209,7 +216,7 @@ class HookSpecTest implements HookFixtures {
         verify(hook, times(1)).before(any(), any());
         verify(hook, times(1)).error(any(), captor.capture(), any());
         verify(hook, times(1)).finallyAfter(any(), any());
-        verify(hook, never()).after(any(),any(), any());
+        verify(hook, never()).after(any(), any(), any());
 
         Exception exception = captor.getValue();
         assertEquals(errorMessage, exception.getMessage());
@@ -217,12 +224,13 @@ class HookSpecTest implements HookFixtures {
     }
 
 
-    @Specification(number="4.3.6", text="The after stage MUST run after flag resolution occurs. It accepts a hook context (required), flag evaluation details (required) and hook hints (optional). It has no return value.")
-    @Specification(number="4.3.7", text="The error hook MUST run when errors are encountered in the before stage, the after stage or during flag resolution. It accepts hook context (required), exception representing what went wrong (required), and hook hints (optional). It has no return value.")
-    @Specification(number="4.3.8", text="The finally hook MUST run after the before, after, and error stages. It accepts a hook context (required) and hook hints (optional). There is no return value.")
-    @Specification(number="4.4.1", text="The API, Client, Provider, and invocation MUST have a method for registering hooks.")
-    @Specification(number="4.4.2", text="Hooks MUST be evaluated in the following order:  - before: API, Client, Invocation, Provider - after: Provider, Invocation, Client, API - error (if applicable): Provider, Invocation, Client, API - finally: Provider, Invocation, Client, API")
-    @Test void hook_eval_order() {
+    @Specification(number = "4.3.6", text = "The after stage MUST run after flag resolution occurs. It accepts a hook context (required), flag evaluation details (required) and hook hints (optional). It has no return value.")
+    @Specification(number = "4.3.7", text = "The error hook MUST run when errors are encountered in the before stage, the after stage or during flag resolution. It accepts hook context (required), exception representing what went wrong (required), and hook hints (optional). It has no return value.")
+    @Specification(number = "4.3.8", text = "The finally hook MUST run after the before, after, and error stages. It accepts a hook context (required) and hook hints (optional). There is no return value.")
+    @Specification(number = "4.4.1", text = "The API, Client, Provider, and invocation MUST have a method for registering hooks.")
+    @Specification(number = "4.4.2", text = "Hooks MUST be evaluated in the following order:  - before: API, Client, Invocation, Provider - after: Provider, Invocation, Client, API - error (if applicable): Provider, Invocation, Client, API - finally: Provider, Invocation, Client, API")
+    @Test
+    void hook_eval_order() {
         List<String> evalOrder = new ArrayList<>();
         OpenFeatureAPI api = OpenFeatureAPI.getInstance();
         api.setProvider(new NoOpProvider() {
@@ -261,7 +269,8 @@ class HookSpecTest implements HookFixtures {
             }
 
             @Override
-            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details, Map<String, Object> hints) {
+            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details,
+                    Map<String, Object> hints) {
                 evalOrder.add("api after");
                 throw new RuntimeException(); // trigger error flows.
             }
@@ -286,7 +295,8 @@ class HookSpecTest implements HookFixtures {
             }
 
             @Override
-            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details, Map<String, Object> hints) {
+            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details,
+                    Map<String, Object> hints) {
                 evalOrder.add("client after");
             }
 
@@ -302,41 +312,43 @@ class HookSpecTest implements HookFixtures {
         });
 
         c.getBooleanValue("key", false, null, FlagEvaluationOptions
-            .builder()
-            .hook(new BooleanHook() {
-                @Override
-                public Optional<EvaluationContext> before(HookContext<Boolean> ctx, Map<String, Object> hints) {
-                    evalOrder.add("invocation before");
-                    return null;
-                }
+                .builder()
+                .hook(new BooleanHook() {
+                    @Override
+                    public Optional<EvaluationContext> before(HookContext<Boolean> ctx, Map<String, Object> hints) {
+                        evalOrder.add("invocation before");
+                        return null;
+                    }
 
-                @Override
-                public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details, Map<String, Object> hints) {
-                    evalOrder.add("invocation after");
-                }
+                    @Override
+                    public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details,
+                            Map<String, Object> hints) {
+                        evalOrder.add("invocation after");
+                    }
 
-                @Override
-                public void error(HookContext<Boolean> ctx, Exception error, Map<String, Object> hints) {
-                    evalOrder.add("invocation error");
-                }
+                    @Override
+                    public void error(HookContext<Boolean> ctx, Exception error, Map<String, Object> hints) {
+                        evalOrder.add("invocation error");
+                    }
 
-                @Override
-                public void finallyAfter(HookContext<Boolean> ctx, Map<String, Object> hints) {
-                    evalOrder.add("invocation finally");
-                }
-            })
-            .build());
+                    @Override
+                    public void finallyAfter(HookContext<Boolean> ctx, Map<String, Object> hints) {
+                        evalOrder.add("invocation finally");
+                    }
+                })
+                .build());
 
         List<String> expectedOrder = Arrays.asList(
-            "api before", "client before", "invocation before", "provider before",
-            "provider after", "invocation after", "client after", "api after",
-            "provider error", "invocation error", "client error", "api error",
-            "provider finally", "invocation finally", "client finally", "api finally");
+                "api before", "client before", "invocation before", "provider before",
+                "provider after", "invocation after", "client after", "api after",
+                "provider error", "invocation error", "client error", "api error",
+                "provider finally", "invocation finally", "client finally", "api finally");
         assertEquals(expectedOrder, evalOrder);
     }
 
-    @Specification(number="4.4.6", text="If an error occurs during the evaluation of before or after hooks, any remaining hooks in the before or after stages MUST NOT be invoked.")
-    @Test void error_stops_before() {
+    @Specification(number = "4.4.6", text = "If an error occurs during the evaluation of before or after hooks, any remaining hooks in the before or after stages MUST NOT be invoked.")
+    @Test
+    void error_stops_before() {
         Hook<Boolean> h = mockBooleanHook();
         doThrow(RuntimeException.class).when(h).before(any(), any());
         Hook<Boolean> h2 = mockBooleanHook();
@@ -353,8 +365,9 @@ class HookSpecTest implements HookFixtures {
         verify(h2, times(0)).before(any(), any());
     }
 
-    @Specification(number="4.4.6", text="If an error occurs during the evaluation of before or after hooks, any remaining hooks in the before or after stages MUST NOT be invoked.")
-    @Test void error_stops_after() {
+    @Specification(number = "4.4.6", text = "If an error occurs during the evaluation of before or after hooks, any remaining hooks in the before or after stages MUST NOT be invoked.")
+    @Test
+    void error_stops_after() {
         Hook<Boolean> h = mockBooleanHook();
         doThrow(RuntimeException.class).when(h).after(any(), any(), any());
         Hook<Boolean> h2 = mockBooleanHook();
@@ -369,33 +382,39 @@ class HookSpecTest implements HookFixtures {
         verify(h2, times(0)).after(any(), any(), any());
     }
 
-    @Specification(number="4.2.1", text="hook hints MUST be a structure supports definition of arbitrary properties, with keys of type string, and values of type boolean | string | number | datetime | structure..")
-    @Specification(number="4.5.2", text="hook hints MUST be passed to each hook.")
-    @Specification(number="4.2.2.1", text="Condition: Hook hints MUST be immutable.")
-    @Specification(number="4.5.3", text="The hook MUST NOT alter the hook hints structure.")
-    @Test void hook_hints() {
+    @Specification(number = "4.2.1", text = "hook hints MUST be a structure supports definition of arbitrary properties, with keys of type string, and values of type boolean | string | number | datetime | structure..")
+    @Specification(number = "4.5.2", text = "hook hints MUST be passed to each hook.")
+    @Specification(number = "4.2.2.1", text = "Condition: Hook hints MUST be immutable.")
+    @Specification(number = "4.5.3", text = "The hook MUST NOT alter the hook hints structure.")
+    @Test
+    void hook_hints() {
         String hintKey = "My hint key";
         Client client = getClient(null);
         Hook<Boolean> mutatingHook = new BooleanHook() {
             @Override
             public Optional<EvaluationContext> before(HookContext<Boolean> ctx, Map<String, Object> hints) {
-                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(UnsupportedOperationException.class);
+                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(
+                        UnsupportedOperationException.class);
                 return Optional.empty();
             }
 
             @Override
-            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details, Map<String, Object> hints) {
-                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(UnsupportedOperationException.class);
+            public void after(HookContext<Boolean> ctx, FlagEvaluationDetails<Boolean> details,
+                    Map<String, Object> hints) {
+                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(
+                        UnsupportedOperationException.class);
             }
 
             @Override
             public void error(HookContext<Boolean> ctx, Exception error, Map<String, Object> hints) {
-                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(UnsupportedOperationException.class);
+                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(
+                        UnsupportedOperationException.class);
             }
 
             @Override
             public void finallyAfter(HookContext<Boolean> ctx, Map<String, Object> hints) {
-                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(UnsupportedOperationException.class);
+                assertThatCode(() -> hints.put(hintKey, "changed value")).isInstanceOf(
+                        UnsupportedOperationException.class);
             }
         };
 
@@ -409,14 +428,16 @@ class HookSpecTest implements HookFixtures {
                 .build());
     }
 
-    @Specification(number="4.5.1", text="Flag evaluation options MAY contain hook hints, a map of data to be provided to hook invocations.")
-    @Test void missing_hook_hints() {
+    @Specification(number = "4.5.1", text = "Flag evaluation options MAY contain hook hints, a map of data to be provided to hook invocations.")
+    @Test
+    void missing_hook_hints() {
         FlagEvaluationOptions feo = FlagEvaluationOptions.builder().build();
         assertNotNull(feo.getHookHints());
         assertTrue(feo.getHookHints().isEmpty());
     }
 
-    @Test void flag_eval_hook_order() {
+    @Test
+    void flag_eval_hook_order() {
         Hook hook = mockBooleanHook();
         FeatureProvider provider = mock(FeatureProvider.class);
         when(provider.getBooleanEvaluation(any(), any(), any()))
@@ -437,9 +458,10 @@ class HookSpecTest implements HookFixtures {
         order.verify(hook).finallyAfter(any(), any());
     }
 
-    @Specification(number="4.4.5", text="If an error occurs in the before or after hooks, the error hooks MUST be invoked.")
-    @Specification(number="4.4.7", text="If an error occurs in the before hooks, the default value MUST be returned.")
-    @Test void error_hooks__before() {
+    @Specification(number = "4.4.5", text = "If an error occurs in the before or after hooks, the error hooks MUST be invoked.")
+    @Specification(number = "4.4.7", text = "If an error occurs in the before hooks, the default value MUST be returned.")
+    @Test
+    void error_hooks__before() {
         Hook hook = mockBooleanHook();
         doThrow(RuntimeException.class).when(hook).before(any(), any());
         Client client = getClient(null);
@@ -450,8 +472,9 @@ class HookSpecTest implements HookFixtures {
         assertEquals(false, value, "Falls through to the default.");
     }
 
-    @Specification(number="4.4.5", text="If an error occurs in the before or after hooks, the error hooks MUST be invoked.")
-    @Test void error_hooks__after() {
+    @Specification(number = "4.4.5", text = "If an error occurs in the before or after hooks, the error hooks MUST be invoked.")
+    @Test
+    void error_hooks__after() {
         Hook hook = mockBooleanHook();
         doThrow(RuntimeException.class).when(hook).after(any(), any(), any());
         Client client = getClient(null);
@@ -461,7 +484,8 @@ class HookSpecTest implements HookFixtures {
         verify(hook, times(1)).error(any(), any(), any());
     }
 
-    @Test void multi_hooks_early_out__before() {
+    @Test
+    void multi_hooks_early_out__before() {
         Hook<Boolean> hook = mockBooleanHook();
         Hook<Boolean> hook2 = mockBooleanHook();
         doThrow(RuntimeException.class).when(hook).before(any(), any());
@@ -483,7 +507,8 @@ class HookSpecTest implements HookFixtures {
 
     @Specification(number = "4.1.4", text = "The evaluation context MUST be mutable only within the before hook.")
     @Specification(number = "4.3.4", text = "Any `evaluation context` returned from a `before` hook MUST be passed to subsequent `before` hooks (via `HookContext`).")
-    @Test void beforeContextUpdated() {
+    @Test
+    void beforeContextUpdated() {
         String targetingKey = "test-key";
         EvaluationContext ctx = new ImmutableContext(targetingKey);
         Hook<Boolean> hook = mockBooleanHook();
@@ -508,15 +533,15 @@ class HookSpecTest implements HookFixtures {
 
     }
 
-    @Specification(number="4.3.5", text="When before hooks have finished executing, any resulting evaluation context MUST be merged with the existing evaluation context.")
-    @Test void mergeHappensCorrectly() {
-        Map<String, Value>  attributes= new HashMap<>();
+    @Specification(number = "4.3.5", text = "When before hooks have finished executing, any resulting evaluation context MUST be merged with the existing evaluation context.")
+    @Test
+    void mergeHappensCorrectly() {
+        Map<String, Value> attributes = new HashMap<>();
         attributes.put("test", new Value("works"));
         attributes.put("another", new Value("exists"));
         EvaluationContext hookCtx = new ImmutableContext(attributes);
 
-
-        Map<String, Value>  attributes1= new HashMap<>();
+        Map<String, Value> attributes1 = new HashMap<>();
         attributes1.put("something", new Value("here"));
         attributes1.put("test", new Value("broken"));
         EvaluationContext invocationCtx = new ImmutableContext(attributes1);
@@ -545,8 +570,9 @@ class HookSpecTest implements HookFixtures {
         assertEquals("here", ec.getValue("something").asString());
     }
 
-    @Specification(number="4.4.3", text="If a finally hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining finally hooks.")
-    @Test void first_finally_broken() {
+    @Specification(number = "4.4.3", text = "If a finally hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining finally hooks.")
+    @Test
+    void first_finally_broken() {
         Hook hook = mockBooleanHook();
         doThrow(RuntimeException.class).when(hook).before(any(), any());
         doThrow(RuntimeException.class).when(hook).finallyAfter(any(), any());
@@ -565,8 +591,9 @@ class HookSpecTest implements HookFixtures {
         order.verify(hook).finallyAfter(any(), any());
     }
 
-    @Specification(number="4.4.4", text="If an error hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining error hooks.")
-    @Test void first_error_broken() {
+    @Specification(number = "4.4.4", text = "If an error hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining error hooks.")
+    @Test
+    void first_error_broken() {
         Hook hook = mockBooleanHook();
         doThrow(RuntimeException.class).when(hook).before(any(), any());
         doThrow(RuntimeException.class).when(hook).error(any(), any(), any());
@@ -595,18 +622,20 @@ class HookSpecTest implements HookFixtures {
         return api.getClient();
     }
 
-    @Specification(number="4.3.1", text="Hooks MUST specify at least one stage.")
-    @Test void default_methods_so_impossible() {}
+    @Specification(number = "4.3.1", text = "Hooks MUST specify at least one stage.")
+    @Test
+    void default_methods_so_impossible() {}
 
-    @Specification(number="4.3.9.1", text="Instead of finally, finallyAfter SHOULD be used.")
+    @Specification(number = "4.3.9.1", text = "Instead of finally, finallyAfter SHOULD be used.")
     @SneakyThrows
-    @Test void doesnt_use_finally() {
+    @Test
+    void doesnt_use_finally() {
         assertThatCode(() -> Hook.class.getMethod("finally", HookContext.class, Map.class))
-            .as("Not possible. Finally is a reserved word.")
-            .isInstanceOf(NoSuchMethodException.class);
+                .as("Not possible. Finally is a reserved word.")
+                .isInstanceOf(NoSuchMethodException.class);
 
         assertThatCode(() -> Hook.class.getMethod("finallyAfter", HookContext.class, Map.class))
-            .doesNotThrowAnyException();
+                .doesNotThrowAnyException();
     }
 
 }

--- a/src/test/java/dev/openfeature/sdk/HookSupportTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSupportTest.java
@@ -25,14 +25,16 @@ class HookSupportTest implements HookFixtures {
         Map<String, Value> attributes = new HashMap<>();
         attributes.put("baseKey", new Value("baseValue"));
         EvaluationContext baseContext = new ImmutableContext(attributes);
-        HookContext<String> hookContext = new HookContext<>("flagKey", FlagValueType.STRING, "defaultValue", baseContext, () -> "client", () -> "provider");
+        HookContext<String> hookContext = new HookContext<>("flagKey", FlagValueType.STRING, "defaultValue",
+                baseContext, () -> "client", () -> "provider");
         Hook<String> hook1 = mockStringHook();
         Hook<String> hook2 = mockStringHook();
         when(hook1.before(any(), any())).thenReturn(Optional.of(evaluationContextWithValue("bla", "blubber")));
         when(hook2.before(any(), any())).thenReturn(Optional.of(evaluationContextWithValue("foo", "bar")));
         HookSupport hookSupport = new HookSupport();
 
-        EvaluationContext result = hookSupport.beforeHooks(FlagValueType.STRING, hookContext, Arrays.asList(hook1, hook2), Collections.emptyMap());
+        EvaluationContext result = hookSupport.beforeHooks(FlagValueType.STRING, hookContext,
+                Arrays.asList(hook1, hook2), Collections.emptyMap());
 
         assertThat(result.getValue("bla").asString()).isEqualTo("blubber");
         assertThat(result.getValue("foo").asString()).isEqualTo("bar");
@@ -47,12 +49,17 @@ class HookSupportTest implements HookFixtures {
         HookSupport hookSupport = new HookSupport();
         EvaluationContext baseContext = new ImmutableContext();
         IllegalStateException expectedException = new IllegalStateException("All fine, just a test");
-        HookContext<Object> hookContext = new HookContext<>("flagKey", flagValueType, createDefaultValue(flagValueType), baseContext, () -> "client", () -> "provider");
+        HookContext<Object> hookContext = new HookContext<>("flagKey", flagValueType, createDefaultValue(flagValueType),
+                baseContext, () -> "client", () -> "provider");
 
-        hookSupport.beforeHooks(flagValueType, hookContext, Collections.singletonList(genericHook), Collections.emptyMap());
-        hookSupport.afterHooks(flagValueType, hookContext, FlagEvaluationDetails.builder().build(), Collections.singletonList(genericHook), Collections.emptyMap());
-        hookSupport.afterAllHooks(flagValueType, hookContext, Collections.singletonList(genericHook), Collections.emptyMap());
-        hookSupport.errorHooks(flagValueType, hookContext, expectedException, Collections.singletonList(genericHook), Collections.emptyMap());
+        hookSupport.beforeHooks(flagValueType, hookContext, Collections.singletonList(genericHook),
+                Collections.emptyMap());
+        hookSupport.afterHooks(flagValueType, hookContext, FlagEvaluationDetails.builder().build(),
+                Collections.singletonList(genericHook), Collections.emptyMap());
+        hookSupport.afterAllHooks(flagValueType, hookContext, Collections.singletonList(genericHook),
+                Collections.emptyMap());
+        hookSupport.errorHooks(flagValueType, hookContext, expectedException, Collections.singletonList(genericHook),
+                Collections.emptyMap());
 
         verify(genericHook).before(any(), any());
         verify(genericHook).after(any(), any(), any());

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import static dev.openfeature.sdk.EvaluationContext.TARGETING_KEY;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -23,7 +24,7 @@ class ImmutableContextTest {
         // should check the usage of Map.of() which is a more likely use case, but that API isn't available in Java 8
         EvaluationContext ctx = new ImmutableContext("targeting key", Collections.unmodifiableMap(attributes));
         attributes.put("key3", new Value("val3"));
-        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, ctx.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1", "key2", TARGETING_KEY}, ctx.keySet().toArray());
     }
 
     @DisplayName("attributes mutation should not affect the immutable context")
@@ -34,7 +35,7 @@ class ImmutableContextTest {
         attributes.put("key2", new Value("val2"));
         EvaluationContext ctx = new ImmutableContext("targeting key", attributes);
         attributes.put("key3", new Value("val3"));
-        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, ctx.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1", "key2", TARGETING_KEY}, ctx.keySet().toArray());
     }
 
     @DisplayName("targeting key should be changed from the overriding context")
@@ -60,11 +61,12 @@ class ImmutableContextTest {
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());
     }
+
     @DisplayName("missing targeting key should return null")
     @Test
     void missingTargetingKeyShould() {
         EvaluationContext ctx = new ImmutableContext();
-        assertEquals(null, ctx.getTargetingKey());
+        assertNull(ctx.getTargetingKey());
     }
 
     @DisplayName("Merge should retain all the attributes from the existing context when overriding context is null")
@@ -76,7 +78,7 @@ class ImmutableContextTest {
         EvaluationContext ctx = new ImmutableContext("targeting_key", attributes);
         EvaluationContext merge = ctx.merge(null);
         assertEquals("targeting_key", merge.getTargetingKey());
-        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
     }
 
     @DisplayName("Merge should retain subkeys from the existing context when the overriding context has the same targeting key")
@@ -92,20 +94,20 @@ class ImmutableContextTest {
         attributes.put("key2", new Value("val2"));
         ovKey1Attributes.put("overriding_key1_1", new Value("overriding_val_1_1"));
         overridingAttributes.put("key1", new Value(new ImmutableStructure(ovKey1Attributes)));
-        
+
         EvaluationContext ctx = new ImmutableContext("targeting_key", attributes);
         EvaluationContext overriding = new ImmutableContext("targeting_key", overridingAttributes);
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());
-        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
-        
+        assertArrayEquals(new Object[] {"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
+
         Value key1 = merge.getValue("key1");
         assertTrue(key1.isStructure());
-        
+
         Structure value = key1.asStructure();
-        assertArrayEquals(new Object[]{"key1_1","overriding_key1_1"}, value.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1_1", "overriding_key1_1"}, value.keySet().toArray());
     }
-    
+
     @DisplayName("Merge should retain subkeys from the existing context when the overriding context doesn't have targeting key")
     @Test
     void mergeShouldRetainItsSubkeysWhenOverridingContextHasNoTargetingKey() {
@@ -115,16 +117,16 @@ class ImmutableContextTest {
         key1Attributes.put("key1_1", new Value("val1_1"));
         attributes.put("key1", new Value(new ImmutableStructure(key1Attributes)));
         attributes.put("key2", new Value("val2"));
-        
+
         EvaluationContext ctx = new ImmutableContext(attributes);
         EvaluationContext overriding = new ImmutableContext();
         EvaluationContext merge = ctx.merge(overriding);
-        assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
-        
+        assertArrayEquals(new Object[] {"key1", "key2"}, merge.keySet().toArray());
+
         Value key1 = merge.getValue("key1");
         assertTrue(key1.isStructure());
-        
+
         Structure value = key1.asStructure();
-        assertArrayEquals(new Object[]{"key1_1"}, value.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1_1"}, value.keySet().toArray());
     }
 }

--- a/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableStructureTest.java
@@ -13,12 +13,14 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ImmutableStructureTest {
-    @Test void noArgShouldContainEmptyAttributes() {
+    @Test
+    void noArgShouldContainEmptyAttributes() {
         ImmutableStructure structure = new ImmutableStructure();
         assertEquals(0, structure.asMap().keySet().size());
     }
 
-    @Test void mapArgShouldContainNewMap() {
+    @Test
+    void mapArgShouldContainNewMap() {
         String KEY = "key";
         Map<String, Value> map = new HashMap<String, Value>() {
             {
@@ -30,7 +32,8 @@ class ImmutableStructureTest {
         assertNotSame(structure.asMap(), map); // should be a copy
     }
 
-    @Test void MutatingGetValueShouldNotChangeOriginalValue() {
+    @Test
+    void MutatingGetValueShouldNotChangeOriginalValue() {
         String KEY = "key";
         List<Value> lists = new ArrayList<>();
         lists.add(new Value(KEY));
@@ -47,7 +50,8 @@ class ImmutableStructureTest {
         assertNotSame(structure.asMap(), map); // should be a copy
     }
 
-    @Test void MutatingGetInstantValueShouldNotChangeOriginalValue() {
+    @Test
+    void MutatingGetInstantValueShouldNotChangeOriginalValue() {
         String KEY = "key";
         Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         Map<String, Value> map = new HashMap<String, Value>() {
@@ -65,11 +69,12 @@ class ImmutableStructureTest {
         assertEquals(now, structure.getValue(KEY).asInstant());
     }
 
-    @Test void MutatingGetStructureValueShouldNotChangeOriginalValue() {
+    @Test
+    void MutatingGetStructureValueShouldNotChangeOriginalValue() {
         String KEY = "key";
         List<Value> lists = new ArrayList<>();
         lists.add(new Value("dummy_list_1"));
-        MutableStructure mutableStructure = new MutableStructure().add("key1","val1").add("list", lists);
+        MutableStructure mutableStructure = new MutableStructure().add("key1", "val1").add("list", lists);
         Map<String, Value> map = new HashMap<String, Value>() {
             {
                 put(KEY, new Value(mutableStructure));
@@ -81,14 +86,15 @@ class ImmutableStructureTest {
         //mutate the return value
         structure.getValue(KEY).asStructure().asMap().put("key3", new Value("val3"));
         assertEquals(2, structure.getValue(KEY).asStructure().asMap().size());
-        assertArrayEquals(new Object[]{"key1", "list"}, structure.getValue(KEY).asStructure().keySet().toArray());
-        assertTrue(structure.getValue(KEY).asStructure() instanceof ImmutableStructure);
+        assertArrayEquals(new Object[] {"key1", "list"}, structure.getValue(KEY).asStructure().keySet().toArray());
+        assertInstanceOf(ImmutableStructure.class, structure.getValue(KEY).asStructure());
         //mutate list value
         lists.add(new Value("dummy_list_2"));
         //mutate the return list value
         structure.getValue(KEY).asStructure().asMap().get("list").asList().add(new Value("dummy_list_3"));
         assertEquals(1, structure.getValue(KEY).asStructure().asMap().get("list").asList().size());
-        assertEquals("dummy_list_1", structure.getValue(KEY).asStructure().asMap().get("list").asList().get(0).asString());
+        assertEquals("dummy_list_1",
+                structure.getValue(KEY).asStructure().asMap().get("list").asList().get(0).asString());
     }
 
     @Test
@@ -112,7 +118,8 @@ class ImmutableStructureTest {
         assertNull(value);
     }
 
-    @Test void objectMapTest() {
+    @Test
+    void objectMapTest() {
         Map<String, Value> attrs = new HashMap<>();
         attrs.put("test", new Value(45));
         ImmutableStructure structure = new ImmutableStructure(attrs);

--- a/src/test/java/dev/openfeature/sdk/InitializeBehaviorSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/InitializeBehaviorSpecTest.java
@@ -19,10 +19,10 @@ class InitializeBehaviorSpecTest {
     class DefaultProvider {
 
         @Specification(number = "1.1.2.2", text = "The `provider mutator` function MUST invoke the `initialize` "
-            + "function on the newly registered provider before using it to resolve flag values.")
+                + "function on the newly registered provider before using it to resolve flag values.")
         @Test
         @DisplayName("must call initialize function of the newly registered provider before using it for "
-            + "flag evaluation")
+                + "flag evaluation")
         void mustCallInitializeFunctionOfTheNewlyRegisteredProviderBeforeUsingItForFlagEvaluation() throws Exception {
             FeatureProvider featureProvider = mock(FeatureProvider.class);
             doReturn(ProviderState.NOT_READY).when(featureProvider).getState();
@@ -33,9 +33,9 @@ class InitializeBehaviorSpecTest {
         }
 
         @Specification(number = "1.4.10", text = "Methods, functions, or operations on the client MUST NOT throw "
-            + "exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the "
-            + "`default value` in the event of abnormal execution. Exceptions include functions or methods for "
-            + "the purposes for configuration or setup.")
+                + "exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the "
+                + "`default value` in the event of abnormal execution. Exceptions include functions or methods for "
+                + "the purposes for configuration or setup.")
         @Test
         @DisplayName("should catch exception thrown by the provider on initialization")
         void shouldCatchExceptionThrownByTheProviderOnInitialization() throws Exception {
@@ -44,7 +44,7 @@ class InitializeBehaviorSpecTest {
             doThrow(TestException.class).when(featureProvider).initialize(any());
 
             assertThatCode(() -> OpenFeatureAPI.getInstance().setProvider(featureProvider))
-                .doesNotThrowAnyException();
+                    .doesNotThrowAnyException();
 
             verify(featureProvider, timeout(1000)).initialize(any());
         }
@@ -54,11 +54,12 @@ class InitializeBehaviorSpecTest {
     class ProviderForNamedClient {
 
         @Specification(number = "1.1.2.2", text = "The `provider mutator` function MUST invoke the `initialize`"
-            + " function on the newly registered provider before using it to resolve flag values.")
+                + " function on the newly registered provider before using it to resolve flag values.")
         @Test
         @DisplayName("must call initialize function of the newly registered named provider before using it "
-            + "for flag evaluation")
-        void mustCallInitializeFunctionOfTheNewlyRegisteredNamedProviderBeforeUsingItForFlagEvaluation() throws Exception {
+                + "for flag evaluation")
+        void mustCallInitializeFunctionOfTheNewlyRegisteredNamedProviderBeforeUsingItForFlagEvaluation()
+                throws Exception {
             FeatureProvider featureProvider = mock(FeatureProvider.class);
             doReturn(ProviderState.NOT_READY).when(featureProvider).getState();
 
@@ -68,9 +69,9 @@ class InitializeBehaviorSpecTest {
         }
 
         @Specification(number = "1.4.10", text = "Methods, functions, or operations on the client MUST NOT throw "
-            + "exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the "
-            + "`default value` in the event of abnormal execution. Exceptions include functions or methods for "
-            + "the purposes for configuration or setup.")
+                + "exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the "
+                + "`default value` in the event of abnormal execution. Exceptions include functions or methods for "
+                + "the purposes for configuration or setup.")
         @Test
         @DisplayName("should catch exception thrown by the named client provider on initialization")
         void shouldCatchExceptionThrownByTheNamedClientProviderOnInitialization() throws Exception {
@@ -79,7 +80,7 @@ class InitializeBehaviorSpecTest {
             doThrow(TestException.class).when(featureProvider).initialize(any());
 
             assertThatCode(() -> OpenFeatureAPI.getInstance().setProvider(DOMAIN_NAME, featureProvider))
-                .doesNotThrowAnyException();
+                    .doesNotThrowAnyException();
 
             verify(featureProvider, timeout(1000)).initialize(any());
         }

--- a/src/test/java/dev/openfeature/sdk/LockingTest.java
+++ b/src/test/java/dev/openfeature/sdk/LockingTest.java
@@ -18,13 +18,13 @@ import dev.openfeature.sdk.internal.AutoCloseableReentrantReadWriteLock;
 
 @Isolated()
 class LockingTest {
-    
+
     private static OpenFeatureAPI api;
     private OpenFeatureClient client;
     private AutoCloseableReentrantReadWriteLock apiLock;
     private AutoCloseableReentrantReadWriteLock clientContextLock;
     private AutoCloseableReentrantReadWriteLock clientHooksLock;
-    
+
     @BeforeAll
     static void beforeAll() {
         api = OpenFeatureAPI.getInstance();
@@ -34,7 +34,7 @@ class LockingTest {
     @BeforeEach
     void beforeEach() {
         client = (OpenFeatureClient) api.getClient("LockingTest");
-        
+
         apiLock = setupLock(apiLock, mockInnerReadLock(), mockInnerWriteLock());
         OpenFeatureAPI.lock = apiLock;
 
@@ -93,7 +93,7 @@ class LockingTest {
 
         @Nested
         class Client {
-            
+
             // Note that the API lock is used for adding client handlers, they are all added (indirectly) on the API object.
 
             @Test

--- a/src/test/java/dev/openfeature/sdk/MetadataTest.java
+++ b/src/test/java/dev/openfeature/sdk/MetadataTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class MetadataTest {
-    @Specification(number="4.2.2.2", text="Condition: The client metadata field in the hook context MUST be immutable.")
-    @Specification(number="4.2.2.3", text="Condition: The provider metadata field in the hook context MUST be immutable.")
+    @Specification(number = "4.2.2.2", text = "Condition: The client metadata field in the hook context MUST be immutable.")
+    @Specification(number = "4.2.2.3", text = "Condition: The provider metadata field in the hook context MUST be immutable.")
     @Test
     void metadata_is_immutable() {
         try {

--- a/src/test/java/dev/openfeature/sdk/MutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/MutableContextTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import static dev.openfeature.sdk.EvaluationContext.TARGETING_KEY;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MutableContextTest {
@@ -23,7 +24,7 @@ class MutableContextTest {
         // should check the usage of Map.of() which is a more likely use case, but that API isn't available in Java 8
         EvaluationContext ctx = new MutableContext("targeting key", Collections.unmodifiableMap(attributes));
         attributes.put("key3", new Value("val3"));
-        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, ctx.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1", "key2", TARGETING_KEY}, ctx.keySet().toArray());
     }
 
     @DisplayName("targeting key should be changed from the overriding context")
@@ -49,11 +50,12 @@ class MutableContextTest {
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());
     }
+
     @DisplayName("missing targeting key should return null")
     @Test
     void missingTargetingKeyShould() {
         EvaluationContext ctx = new MutableContext();
-        assertEquals(null, ctx.getTargetingKey());
+        assertNull(ctx.getTargetingKey());
     }
 
     @DisplayName("Merge should retain all the attributes from the existing context when overriding context is null")
@@ -65,7 +67,7 @@ class MutableContextTest {
         EvaluationContext ctx = new MutableContext("targeting_key", attributes);
         EvaluationContext merge = ctx.merge(null);
         assertEquals("targeting_key", merge.getTargetingKey());
-        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
     }
 
     @DisplayName("Merge should retain subkeys from the existing context when the overriding context has the same targeting key")
@@ -81,20 +83,20 @@ class MutableContextTest {
         attributes.put("key2", new Value("val2"));
         ovKey1Attributes.put("overriding_key1_1", new Value("overriding_val_1_1"));
         overridingAttributes.put("key1", new Value(new ImmutableStructure(ovKey1Attributes)));
-        
+
         EvaluationContext ctx = new MutableContext("targeting_key", attributes);
         EvaluationContext overriding = new MutableContext("targeting_key", overridingAttributes);
         EvaluationContext merge = ctx.merge(overriding);
         assertEquals("targeting_key", merge.getTargetingKey());
-        assertArrayEquals(new Object[]{"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
-        
+        assertArrayEquals(new Object[] {"key1", "key2", TARGETING_KEY}, merge.keySet().toArray());
+
         Value key1 = merge.getValue("key1");
         assertTrue(key1.isStructure());
-        
+
         Structure value = key1.asStructure();
-        assertArrayEquals(new Object[]{"key1_1","overriding_key1_1"}, value.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1_1", "overriding_key1_1"}, value.keySet().toArray());
     }
-    
+
     @DisplayName("Merge should retain subkeys from the existing context when the overriding context doesn't have targeting key")
     @Test
     void mergeShouldRetainItsSubkeysWhenOverridingContextHasNoTargetingKey() {
@@ -104,17 +106,17 @@ class MutableContextTest {
         key1Attributes.put("key1_1", new Value("val1_1"));
         attributes.put("key1", new Value(new ImmutableStructure(key1Attributes)));
         attributes.put("key2", new Value("val2"));
-        
+
         EvaluationContext ctx = new MutableContext(attributes);
         EvaluationContext overriding = new MutableContext();
         EvaluationContext merge = ctx.merge(overriding);
-        assertArrayEquals(new Object[]{"key1", "key2"}, merge.keySet().toArray());
-        
+        assertArrayEquals(new Object[] {"key1", "key2"}, merge.keySet().toArray());
+
         Value key1 = merge.getValue("key1");
         assertTrue(key1.isStructure());
-        
+
         Structure value = key1.asStructure();
-        assertArrayEquals(new Object[]{"key1_1"}, value.keySet().toArray());
+        assertArrayEquals(new Object[] {"key1_1"}, value.keySet().toArray());
     }
 
     @DisplayName("Ensure mutations are chainable")
@@ -129,6 +131,6 @@ class MutableContextTest {
         assertEquals("TARGETING_KEY", context.getTargetingKey());
         assertEquals("val1", context.getValue("key1").asString());
         assertEquals(2, context.getValue("key2").asInteger());
-        assertEquals(3.0, context.getValue("key3").asDouble());        
+        assertEquals(3.0, context.getValue("key3").asDouble());
     }
 }

--- a/src/test/java/dev/openfeature/sdk/NoOpProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/NoOpProviderTest.java
@@ -5,32 +5,37 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 public class NoOpProviderTest {
-    @Test void bool() {
+    @Test
+    void bool() {
         NoOpProvider p = new NoOpProvider();
         ProviderEvaluation<Boolean> eval = p.getBooleanEvaluation("key", true, null);
         assertEquals(true, eval.getValue());
     }
 
-    @Test void str() {
+    @Test
+    void str() {
         NoOpProvider p = new NoOpProvider();
 
         ProviderEvaluation<String> eval = p.getStringEvaluation("key", "works", null);
         assertEquals("works", eval.getValue());
     }
 
-    @Test void integer() {
+    @Test
+    void integer() {
         NoOpProvider p = new NoOpProvider();
         ProviderEvaluation<Integer> eval = p.getIntegerEvaluation("key", 4, null);
         assertEquals(4, eval.getValue());
     }
 
-    @Test void noOpdouble() {
+    @Test
+    void noOpdouble() {
         NoOpProvider p = new NoOpProvider();
         ProviderEvaluation<Double> eval = p.getDoubleEvaluation("key", 0.4, null);
         assertEquals(0.4, eval.getValue());
     }
 
-    @Test void value() {
+    @Test
+    void value() {
         NoOpProvider p = new NoOpProvider();
         Value s = new Value();
         ProviderEvaluation<Value> eval = p.getObjectEvaluation("key", s, null);

--- a/src/test/java/dev/openfeature/sdk/NotImplementedException.java
+++ b/src/test/java/dev/openfeature/sdk/NotImplementedException.java
@@ -4,7 +4,7 @@ public class NotImplementedException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
-    public NotImplementedException(String message){
+    public NotImplementedException(String message) {
         super(message);
     }
 }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -33,7 +33,7 @@ class OpenFeatureAPITest {
                 .isEqualTo(api.getProviderMetadata("namedProviderTest").getName());
     }
 
-    @Specification(number="1.1.3", text="The API MUST provide a function to bind a given provider to one or more clients using a domain. If the domain already has a bound provider, it is overwritten with the new mapping.")
+    @Specification(number = "1.1.3", text = "The API MUST provide a function to bind a given provider to one or more clients using a domain. If the domain already has a bound provider, it is overwritten with the new mapping.")
     @Test
     void namedProviderOverwrittenTest() {
         String domain = "namedProviderOverwrittenTest";

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureClientTest.java
@@ -21,14 +21,17 @@ class OpenFeatureClientTest implements HookFixtures {
 
     private Logger logger;
 
-    @BeforeEach void set_logger() {
+    @BeforeEach
+    void set_logger() {
         logger = Mockito.mock(Logger.class);
         LoggerMock.setMock(OpenFeatureClient.class, logger);
     }
 
-    @AfterEach void reset_logs() {
+    @AfterEach
+    void reset_logs() {
         LoggerMock.setMock(OpenFeatureClient.class, logger);
     }
+
     @Test
     @DisplayName("should not throw exception if hook has different type argument than hookContext")
     void shouldNotThrowExceptionIfHookHasDifferentTypeArgumentThanHookContext() {
@@ -59,12 +62,12 @@ class OpenFeatureClientTest implements HookFixtures {
         FeatureProvider mockProvider = mock(FeatureProvider.class);
         // this makes it so that true is returned only if the targeting key set at the client level is honored
         when(mockProvider.getBooleanEvaluation(
-          eq(flag), eq(defaultValue), argThat(
-            context -> context.getTargetingKey().equals(targetingKey)))).thenReturn(ProviderEvaluation.<Boolean>builder()
-          .value(true).build());
+                eq(flag), eq(defaultValue), argThat(
+                        context -> context.getTargetingKey().equals(targetingKey)))).thenReturn(
+                ProviderEvaluation.<Boolean>builder()
+                        .value(true).build());
         when(api.getProvider()).thenReturn(mockProvider);
         when(api.getProvider(any())).thenReturn(mockProvider);
-
 
         OpenFeatureClient client = new OpenFeatureClient(api, "name", "version");
         client.setEvaluationContext(ctx);
@@ -83,7 +86,7 @@ class OpenFeatureClientTest implements HookFixtures {
         Hook<?> hook2 = Mockito.mock(Hook.class);
 
         OpenFeatureClient result = client.addHooks(hook1, hook2);
-        assertEquals(client, result);  
+        assertEquals(client, result);
     }
 
     @Test
@@ -96,5 +99,5 @@ class OpenFeatureClientTest implements HookFixtures {
         OpenFeatureClient result = client.setEvaluationContext(ctx);
         assertEquals(client, result);
     }
-   
+
 }

--- a/src/test/java/dev/openfeature/sdk/ProviderEvaluationTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderEvaluationTest.java
@@ -28,12 +28,12 @@ class ProviderEvaluationTest {
         ImmutableMetadata metadata = ImmutableMetadata.builder().build();
 
         ProviderEvaluation<Integer> details = new ProviderEvaluation<>(
-        value,
-        variant,
-        reason.toString(),
-        errorCode,
-        errorMessage,
-        metadata);
+                value,
+                variant,
+                reason.toString(),
+                errorCode,
+                errorMessage,
+                metadata);
 
         assertEquals(value, details.getValue());
         assertEquals(variant, details.getVariant());

--- a/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
@@ -90,7 +90,7 @@ class ProviderRepositoryTest {
             void shouldAvoidAdditionalInitializationCallIfProviderHasBeenInitializedAlready() throws Exception {
                 FeatureProvider provider = createMockedReadyProvider();
                 setFeatureProvider(provider);
-                
+
                 verify(provider, never()).initialize(any());
             }
         }
@@ -254,11 +254,11 @@ class ProviderRepositoryTest {
                 Consumer<FeatureProvider> afterInit = mock(Consumer.class);
                 Consumer<FeatureProvider> afterShutdown = mock(Consumer.class);
                 BiConsumer<FeatureProvider, OpenFeatureError> afterError = mock(BiConsumer.class);
-        
+
                 FeatureProvider oldProvider = providerRepository.getProvider();
                 FeatureProvider featureProvider1 = createMockedProvider();
                 FeatureProvider featureProvider2 = createMockedProvider();
-        
+
                 setFeatureProvider(featureProvider1, afterSet, afterInit, afterShutdown, afterError);
                 setFeatureProvider(featureProvider2);
                 verify(afterSet, timeout(TIMEOUT)).accept(featureProvider1);
@@ -275,12 +275,12 @@ class ProviderRepositoryTest {
                 Consumer<FeatureProvider> afterInit = mock(Consumer.class);
                 Consumer<FeatureProvider> afterShutdown = mock(Consumer.class);
                 BiConsumer<FeatureProvider, OpenFeatureError> afterError = mock(BiConsumer.class);
-        
+
                 FeatureProvider errorFeatureProvider = createMockedErrorProvider();
-        
+
                 setFeatureProvider(errorFeatureProvider, afterSet, afterInit, afterShutdown, afterError);
                 verify(afterSet, timeout(TIMEOUT)).accept(errorFeatureProvider);
-                verify(afterInit, never()).accept(any());;
+                verify(afterInit, never()).accept(any());
                 verify(afterError, timeout(TIMEOUT)).accept(eq(errorFeatureProvider), any());
             }
         }

--- a/src/test/java/dev/openfeature/sdk/Specification.java
+++ b/src/test/java/dev/openfeature/sdk/Specification.java
@@ -5,5 +5,6 @@ import java.lang.annotation.Repeatable;
 @Repeatable(Specifications.class)
 public @interface Specification {
     String number();
+
     String text();
 }

--- a/src/test/java/dev/openfeature/sdk/StructureTest.java
+++ b/src/test/java/dev/openfeature/sdk/StructureTest.java
@@ -17,12 +17,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StructureTest {
-    @Test public void noArgShouldContainEmptyAttributes() {
+    @Test
+    public void noArgShouldContainEmptyAttributes() {
         MutableStructure structure = new MutableStructure();
         assertEquals(0, structure.asMap().keySet().size());
     }
 
-    @Test public void mapArgShouldContainNewMap() {
+    @Test
+    public void mapArgShouldContainNewMap() {
         String KEY = "key";
         Map<String, Value> map = new HashMap<String, Value>() {
             {
@@ -34,7 +36,8 @@ public class StructureTest {
         assertNotSame(structure.asMap(), map); // should be a copy
     }
 
-    @Test public void addAndGetAddAndReturnValues() {
+    @Test
+    public void addAndGetAddAndReturnValues() {
         String BOOL_KEY = "bool";
         String STRING_KEY = "string";
         String INT_KEY = "int";
@@ -104,7 +107,7 @@ public class StructureTest {
     @Test
     void asObjectHandlesNullValue() {
         Map<String, Value> map = new HashMap<>();
-        map.put("null", new Value((String)null));
+        map.put("null", new Value((String) null));
         ImmutableStructure structure = new ImmutableStructure(map);
         assertNull(structure.asObjectMap().get("null"));
     }
@@ -112,6 +115,6 @@ public class StructureTest {
     @Test
     void convertValueHandlesNullValue() {
         ImmutableStructure structure = new ImmutableStructure();
-        assertNull(structure.convertValue(new Value((String)null)));
+        assertNull(structure.convertValue(new Value((String) null)));
     }
 }

--- a/src/test/java/dev/openfeature/sdk/ValueTest.java
+++ b/src/test/java/dev/openfeature/sdk/ValueTest.java
@@ -13,12 +13,14 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class ValueTest {
-    @Test public void noArgShouldContainNull() {
+    @Test
+    public void noArgShouldContainNull() {
         Value value = new Value();
         assertTrue(value.isNull());
     }
 
-    @Test public void objectArgShouldContainObject() {
+    @Test
+    public void objectArgShouldContainObject() {
         try {
             // int is a special case, see intObjectArgShouldConvertToInt()
             List<Object> list = new ArrayList<>();
@@ -30,7 +32,7 @@ public class ValueTest {
             list.add(Instant.now());
 
             int i = 0;
-            for (Object l: list) {
+            for (Object l : list) {
                 Value value = new Value(l);
                 assertEquals(list.get(i), value.asObject());
                 i++;
@@ -40,7 +42,8 @@ public class ValueTest {
         }
     }
 
-    @Test public void intObjectArgShouldConvertToInt() {
+    @Test
+    public void intObjectArgShouldConvertToInt() {
         try {
             Object innerValue = 1;
             Value value = new Value(innerValue);
@@ -50,7 +53,8 @@ public class ValueTest {
         }
     }
 
-    @Test public void invalidObjectArgShouldThrow() {
+    @Test
+    public void invalidObjectArgShouldThrow() {
 
         class Something {}
 
@@ -59,18 +63,21 @@ public class ValueTest {
         });
     }
 
-    @Test public void boolArgShouldContainBool() {
+    @Test
+    public void boolArgShouldContainBool() {
         boolean innerValue = true;
         Value value = new Value(innerValue);
         assertTrue(value.isBoolean());
         assertEquals(innerValue, value.asBoolean());
     }
 
-    @Test public void numericArgShouldReturnDoubleOrInt() {
+    @Test
+    public void numericArgShouldReturnDoubleOrInt() {
         double innerDoubleValue = 1.75;
         Value doubleValue = new Value(innerDoubleValue);
         assertTrue(doubleValue.isNumber());
-        assertEquals(1, doubleValue.asInteger());     // the double value represented by this object converted to type int
+        assertEquals(1,
+                doubleValue.asInteger());     // the double value represented by this object converted to type int
         assertEquals(1.75, doubleValue.asDouble());
 
         int innerIntValue = 100;
@@ -80,21 +87,24 @@ public class ValueTest {
         assertEquals(innerIntValue, intValue.asDouble());
     }
 
-    @Test public void stringArgShouldContainString() {
+    @Test
+    public void stringArgShouldContainString() {
         String innerValue = "hi!";
         Value value = new Value(innerValue);
         assertTrue(value.isString());
         assertEquals(innerValue, value.asString());
     }
 
-    @Test public void dateShouldContainDate() {
+    @Test
+    public void dateShouldContainDate() {
         Instant innerValue = Instant.now();
         Value value = new Value(innerValue);
         assertTrue(value.isInstant());
         assertEquals(innerValue, value.asInstant());
     }
 
-    @Test public void structureShouldContainStructure() {
+    @Test
+    public void structureShouldContainStructure() {
         String INNER_KEY = "key";
         String INNER_VALUE = "val";
         MutableStructure innerValue = new MutableStructure().add(INNER_KEY, INNER_VALUE);
@@ -103,7 +113,8 @@ public class ValueTest {
         assertEquals(INNER_VALUE, value.asStructure().getValue(INNER_KEY).asString());
     }
 
-    @Test public void listArgShouldContainList() {
+    @Test
+    public void listArgShouldContainList() {
         String ITEM_VALUE = "val";
         List<Value> innerValue = new ArrayList<Value>();
         innerValue.add(new Value(ITEM_VALUE));
@@ -112,22 +123,24 @@ public class ValueTest {
         assertEquals(ITEM_VALUE, value.asList().get(0).asString());
     }
 
-    @Test public void listMustBeOfValues() {
+    @Test
+    public void listMustBeOfValues() {
         String item = "item";
         List<String> list = new ArrayList<>();
         list.add(item);
         try {
-            new Value((Object) list);
+            new Value(list);
             fail("Should fail due to creation of list of non-values.");
         } catch (InstantiationException e) {
             assertEquals("Invalid value type: class java.util.ArrayList", e.getMessage());
         }
     }
 
-    @Test public void emptyListAllowed() {
+    @Test
+    public void emptyListAllowed() {
         List<String> list = new ArrayList<>();
         try {
-            Value value = new Value((Object) list);
+            Value value = new Value(list);
             assertTrue(value.isList());
             List<Value> values = value.asList();
             assertTrue(values.isEmpty());
@@ -136,15 +149,17 @@ public class ValueTest {
         }
     }
 
-    @Test public void valueConstructorValidateListInternals() {
+    @Test
+    public void valueConstructorValidateListInternals() {
         List<Object> list = new ArrayList<>();
         list.add(new Value("item"));
         list.add("item");
 
-        assertThrows(InstantiationException.class, ()-> new Value(list));
+        assertThrows(InstantiationException.class, () -> new Value(list));
     }
 
-    @Test public void noOpFinalize() {
+    @Test
+    public void noOpFinalize() {
         Value val = new Value();
         assertDoesNotThrow(val::finalize); // does nothing, but we want to defined in and make it final.
     }

--- a/src/test/java/dev/openfeature/sdk/e2e/RunCucumberTest.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/RunCucumberTest.java
@@ -12,5 +12,5 @@ import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 @SelectClasspathResource("features")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
 public class RunCucumberTest {
-  
+
 }

--- a/src/test/java/dev/openfeature/sdk/hooks/logging/LoggingHookTest.java
+++ b/src/test/java/dev/openfeature/sdk/hooks/logging/LoggingHookTest.java
@@ -95,7 +95,8 @@ class LoggingHookTest {
     @Test
     void afterLogsAllPropsExceptEvaluationContext() {
         LoggingHook hook = new LoggingHook();
-        FlagEvaluationDetails<Object> details = FlagEvaluationDetails.builder().reason(REASON).variant(VARIANT).value(VALUE).build();
+        FlagEvaluationDetails<Object> details = FlagEvaluationDetails.builder().reason(REASON).variant(VARIANT)
+                .value(VALUE).build();
         hook.after(hookContext, details, null);
 
         verify(logger).atDebug();
@@ -109,7 +110,8 @@ class LoggingHookTest {
     @Test
     void afterLogsAllPropsAndEvaluationContext() {
         LoggingHook hook = new LoggingHook(true);
-        FlagEvaluationDetails<Object> details = FlagEvaluationDetails.builder().reason(REASON).variant(VARIANT).value(VALUE).build();
+        FlagEvaluationDetails<Object> details = FlagEvaluationDetails.builder().reason(REASON).variant(VARIANT)
+                .value(VALUE).build();
         hook.after(hookContext, details, null);
 
         verify(logger).atDebug();

--- a/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/providers/memory/InMemoryProviderTest.java
@@ -46,10 +46,10 @@ class InMemoryProviderTest {
         client = OpenFeatureAPI.getInstance().getClient();
         provider.updateFlags(flags);
         provider.updateFlag("addedFlag", Flag.builder()
-            .variant("on", true)
-            .variant("off", false)
-            .defaultVariant("on")
-            .build());
+                .variant("on", true)
+                .variant("off", false)
+                .defaultVariant("on")
+                .build());
     }
 
     @SneakyThrows
@@ -81,9 +81,9 @@ class InMemoryProviderTest {
     @Test
     void getObjectEvaluation() {
         Value expectedObject = new Value(mapToStructure(ImmutableMap.of(
-            "showImages", new Value(true),
-            "title", new Value("Check out these pics!"),
-            "imagesPerPage", new Value(100)
+                "showImages", new Value(true),
+                "title", new Value("Check out these pics!"),
+                "imagesPerPage", new Value(100)
         )));
         assertEquals(expectedObject, client.getObjectValue("object-flag", new Value(true)));
     }
@@ -108,7 +108,8 @@ class InMemoryProviderTest {
         InMemoryProvider inMemoryProvider = new InMemoryProvider(new HashMap<>());
 
         // ErrorCode.PROVIDER_NOT_READY should be returned when evaluated via the client
-        assertThrows(ProviderNotReadyError.class, ()-> inMemoryProvider.getBooleanEvaluation("fail_not_initialized", false, new ImmutableContext()));
+        assertThrows(ProviderNotReadyError.class,
+                () -> inMemoryProvider.getBooleanEvaluation("fail_not_initialized", false, new ImmutableContext()));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/dev/openfeature/sdk/testutils/FeatureProviderTestUtils.java
+++ b/src/test/java/dev/openfeature/sdk/testutils/FeatureProviderTestUtils.java
@@ -17,11 +17,12 @@ public class FeatureProviderTestUtils {
         waitForProviderInitializationComplete(OpenFeatureAPI::getProvider, provider);
     }
 
-    private static void waitForProviderInitializationComplete(Function<OpenFeatureAPI, FeatureProvider> extractor, FeatureProvider provider) {
+    private static void waitForProviderInitializationComplete(Function<OpenFeatureAPI, FeatureProvider> extractor,
+            FeatureProvider provider) {
         await()
-            .pollDelay(Duration.ofMillis(1))
-            .atMost(Duration.ofSeconds(1))
-            .until(() -> extractor.apply(OpenFeatureAPI.getInstance()) == provider);
+                .pollDelay(Duration.ofMillis(1))
+                .atMost(Duration.ofSeconds(1))
+                .until(() -> extractor.apply(OpenFeatureAPI.getInstance()) == provider);
     }
 
     public static void setFeatureProvider(String domain, FeatureProvider provider) {

--- a/src/test/java/dev/openfeature/sdk/testutils/TestFlagsUtils.java
+++ b/src/test/java/dev/openfeature/sdk/testutils/TestFlagsUtils.java
@@ -18,56 +18,57 @@ public class TestFlagsUtils {
 
     /**
      * Building flags for testing purposes.
+     *
      * @return map of flags
      */
     public static Map<String, Flag<?>> buildFlags() {
         Map<String, Flag<?>> flags = new HashMap<>();
         flags.put("boolean-flag", Flag.builder()
-            .variant("on", true)
-            .variant("off", false)
-            .defaultVariant("on")
-            .build());
+                .variant("on", true)
+                .variant("off", false)
+                .defaultVariant("on")
+                .build());
         flags.put("string-flag", Flag.builder()
-            .variant("greeting", "hi")
-            .variant("parting", "bye")
-            .defaultVariant("greeting")
-            .build());
+                .variant("greeting", "hi")
+                .variant("parting", "bye")
+                .defaultVariant("greeting")
+                .build());
         flags.put("integer-flag", Flag.builder()
-            .variant("one", 1)
-            .variant("ten", 10)
-            .defaultVariant("ten")
-            .build());
+                .variant("one", 1)
+                .variant("ten", 10)
+                .defaultVariant("ten")
+                .build());
         flags.put("float-flag", Flag.builder()
-            .variant("tenth", 0.1)
-            .variant("half", 0.5)
-            .defaultVariant("half")
-            .build());
+                .variant("tenth", 0.1)
+                .variant("half", 0.5)
+                .defaultVariant("half")
+                .build());
         flags.put("object-flag", Flag.builder()
-            .variant("empty", new HashMap<>())
-            .variant("template", new Value(mapToStructure(ImmutableMap.of(
-                "showImages", new Value(true),
-                "title", new Value("Check out these pics!"),
-                "imagesPerPage", new Value(100)
-            ))))
-            .defaultVariant("template")
-            .build());
+                .variant("empty", new HashMap<>())
+                .variant("template", new Value(mapToStructure(ImmutableMap.of(
+                        "showImages", new Value(true),
+                        "title", new Value("Check out these pics!"),
+                        "imagesPerPage", new Value(100)
+                ))))
+                .defaultVariant("template")
+                .build());
         flags.put("context-aware", Flag.<String>builder()
-            .variant("internal", "INTERNAL")
-            .variant("external", "EXTERNAL")
-            .defaultVariant("external")
-            .contextEvaluator((flag, evaluationContext) -> {
-                if (new Value(false).equals(evaluationContext.getValue("customer"))) {
-                    return (String) flag.getVariants().get("internal");
-                } else {
-                    return (String) flag.getVariants().get(flag.getDefaultVariant());
-                }
-            })
-            .build());
+                .variant("internal", "INTERNAL")
+                .variant("external", "EXTERNAL")
+                .defaultVariant("external")
+                .contextEvaluator((flag, evaluationContext) -> {
+                    if (new Value(false).equals(evaluationContext.getValue("customer"))) {
+                        return (String) flag.getVariants().get("internal");
+                    } else {
+                        return (String) flag.getVariants().get(flag.getDefaultVariant());
+                    }
+                })
+                .build());
         flags.put("wrong-flag", Flag.builder()
-            .variant("one", "uno")
-            .variant("two", "dos")
-            .defaultVariant("one")
-            .build());
+                .variant("one", "uno")
+                .variant("two", "dos")
+                .defaultVariant("one")
+                .build());
         return flags;
     }
 }


### PR DESCRIPTION
Many people struggle with their code styles when contributing for the first time. With this pull request, we're adding a .editorconfig to manage those settings in a centralized place, making everyone's lives easier.

With this iteration, we're adding IntelliJ Idea configuration.

The first commit contains the configuration, and I applied the second one to the whole code base.
