### PR TITLE
fix: TrackingEventDetails interface to include numeric getValue() call

### DIFF
--- a/src/main/java/dev/openfeature/sdk/TrackingEventDetails.java
+++ b/src/main/java/dev/openfeature/sdk/TrackingEventDetails.java
@@ -1,6 +1,14 @@
 package dev.openfeature.sdk;
 
+import java.util.Optional;
+
 /**
  * Data pertinent to a particular tracking event.
  */
-public interface TrackingEventDetails extends Structure {}
+public interface TrackingEventDetails extends Structure {
+
+    /**
+     * Returns the optional numeric tracking value.
+     */
+    Optional<Number> getValue();
+}


### PR DESCRIPTION
## This PR
- fix: `TrackingEventDetails` interface to include numeric `Optional<Number> getValue();` function interface. Only the `Value getValue(String key);` was being exposed by extending `Structure`.


