### PR TITLE
docs: add try-catch example for setProviderAndWait usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,12 @@ public void example(){
 
     // configure a provider
     OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-    api.setProviderAndWait(new InMemoryProvider(myFlags));
+    try {
+        api.setProviderAndWait(new InMemoryProvider(myFlags));
+    } catch (Exception e) {
+        // handle initialization failure
+        e.printStackTrace();
+    }
 
     // create a client
     Client client = api.getClient();
@@ -149,7 +154,12 @@ To register a provider in a blocking manner to ensure it is ready before further
   
 ```java
     OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-    api.setProviderAndWait(new MyProvider());
+    try {
+        api.setProviderAndWait(new MyProvider());
+    }  catch (Exception e) {
+        // handle initialization failure
+        e.printStackTrace();
+    }
 ```  
   
 #### Asynchronous    

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -208,8 +208,8 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
 
     /**
      * Sets the default provider and waits for its initialization to complete.
-     * <p>
-     * Note: If the provider fails during initialization, an {@link OpenFeatureError} will be thrown.
+     *
+     * <p>Note: If the provider fails during initialization, an {@link OpenFeatureError} will be thrown.
      * It is recommended to wrap this call in a try-catch block to handle potential initialization failures gracefully.
      *
      * @param provider the {@link FeatureProvider} to set as the default.
@@ -229,10 +229,10 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
 
     /**
      * Add a provider for a domain and wait for initialization to finish.
-     * <p>
-     * Note: If the provider fails during initialization, an {@link OpenFeatureError} will be thrown.
+     *
+     * <p>Note: If the provider fails during initialization, an {@link OpenFeatureError} will be thrown.
      * It is recommended to wrap this call in a try-catch block to handle potential initialization failures gracefully.
-     * 
+     *
      * @param domain   The domain to bind the provider to.
      * @param provider The provider to set.
      * @throws OpenFeatureError if the provider fails during initialization.

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -207,7 +207,13 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
     }
 
     /**
-     * Set the default provider and wait for initialization to finish.
+     * Sets the default provider and waits for its initialization to complete.
+     * <p>
+     * Note: If the provider fails during initialization, an {@link OpenFeatureError} will be thrown.
+     * It is recommended to wrap this call in a try-catch block to handle potential initialization failures gracefully.
+     *
+     * @param provider the {@link FeatureProvider} to set as the default.
+     * @throws OpenFeatureError if the provider fails during initialization.
      */
     public void setProviderAndWait(FeatureProvider provider) throws OpenFeatureError {
         try (AutoCloseableLock __ = lock.writeLockAutoCloseable()) {
@@ -223,9 +229,13 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
 
     /**
      * Add a provider for a domain and wait for initialization to finish.
-     *
+     * <p>
+     * Note: If the provider fails during initialization, an {@link OpenFeatureError} will be thrown.
+     * It is recommended to wrap this call in a try-catch block to handle potential initialization failures gracefully.
+     * 
      * @param domain   The domain to bind the provider to.
      * @param provider The provider to set.
+     * @throws OpenFeatureError if the provider fails during initialization.
      */
     public void setProviderAndWait(String domain, FeatureProvider provider) throws OpenFeatureError {
         try (AutoCloseableLock __ = lock.writeLockAutoCloseable()) {


### PR DESCRIPTION
**Fixes #1424**

This PR improves the README examples by wrapping the setProviderAndWait method inside a try-catch block.
Since setProviderAndWait can throw an exception if the provider initialization fails, it's important to handle it safely to prevent unexpected crashes during runtime.

**Changes made:**

- Updated the main usage example to wrap setProviderAndWait with a try-catch.
- Updated the synchronous usage section with a try-catch block and explanatory comment.

**Why?**

- Improves the reliability and production-readiness of the documentation examples.
- Helps users adopt better error handling practices from the start.

**Checklist:**

- [x]  Added try-catch around setProviderAndWait
- [x]  Updated both main and synchronous usage sections
- [x]  Ensured formatting matches the current README style