### PR TITLE
feat: add getNumberEvaluation method delegating to getDoubleEvaluation (#501)

### DIFF
--- a/src/main/java/dev/openfeature/sdk/FeatureProvider.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProvider.java
@@ -15,12 +15,39 @@ public interface FeatureProvider {
         return new ArrayList<>();
     }
 
+    /**
+     * Resolves a feature flag value as a {@link Number}.
+     *
+     * @param key          the unique identifier for the flag
+     * @param defaultValue the default value to return if the flag cannot be resolved
+     * @param ctx          the evaluation context containing any relevant information for resolution
+     * @return a {@link ProviderEvaluation} containing the resolved {@code Number} value and additional evaluation details
+     */
+    default ProviderEvaluation<Number> getNumberEvaluation(String key, Number defaultValue, EvaluationContext ctx) {
+        ProviderEvaluation<Double> dep = getDoubleEvaluation(key, defaultValue.doubleValue(), ctx);
+        return new ProviderEvaluation<>(
+                dep.getValue(),
+                dep.getReason(),
+                dep.getVariant(),
+                dep.getErrorCode(),
+                dep.getErrorMessage(),
+                dep.getFlagMetadata());
+    }
+
     ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx);
 
     ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx);
 
+    /**
+     * @deprecated please use {@link #getNumberEvaluation(String, Number, EvaluationContext)}
+     */
+    @Deprecated
     ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx);
 
+    /**
+     * @deprecated please use {@link #getNumberEvaluation(String, Number, EvaluationContext)}
+     */
+    @Deprecated
     ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx);
 
     ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx);

--- a/src/main/java/dev/openfeature/sdk/FlagValueType.java
+++ b/src/main/java/dev/openfeature/sdk/FlagValueType.java
@@ -3,6 +3,7 @@ package dev.openfeature.sdk;
 @SuppressWarnings("checkstyle:MissingJavadocType")
 public enum FlagValueType {
     STRING,
+    NUMBER,
     INTEGER,
     DOUBLE,
     OBJECT,

--- a/src/main/java/dev/openfeature/sdk/NoOpProvider.java
+++ b/src/main/java/dev/openfeature/sdk/NoOpProvider.java
@@ -41,6 +41,7 @@ public class NoOpProvider implements FeatureProvider {
     }
 
     @Override
+    @Deprecated
     public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
         return ProviderEvaluation.<Integer>builder()
                 .value(defaultValue)
@@ -50,6 +51,7 @@ public class NoOpProvider implements FeatureProvider {
     }
 
     @Override
+    @Deprecated
     public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
         return ProviderEvaluation.<Double>builder()
                 .value(defaultValue)

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -287,9 +287,11 @@ public class OpenFeatureClient implements Client {
             case STRING:
                 return provider.getStringEvaluation(key, (String) defaultValue, invocationContext);
             case INTEGER:
-                return provider.getIntegerEvaluation(key, (Integer) defaultValue, invocationContext);
+                return provider.getNumberEvaluation(key, (Integer) defaultValue, invocationContext);
+            case NUMBER:
+                return provider.getNumberEvaluation(key, (Number) defaultValue, invocationContext);
             case DOUBLE:
-                return provider.getDoubleEvaluation(key, (Double) defaultValue, invocationContext);
+                return provider.getNumberEvaluation(key, (Double) defaultValue, invocationContext);
             case OBJECT:
                 return provider.getObjectEvaluation(key, (Value) defaultValue, invocationContext);
             default:

--- a/src/test/java/dev/openfeature/sdk/NoOpProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/NoOpProviderTest.java
@@ -41,4 +41,11 @@ public class NoOpProviderTest {
         ProviderEvaluation<Value> eval = p.getObjectEvaluation("key", s, null);
         assertEquals(s, eval.getValue());
     }
+
+    @Test
+    void noOpNumber() {
+        NoOpProvider p = new NoOpProvider();
+        ProviderEvaluation<Number> eval = p.getNumberEvaluation("key", 123456789L, null);
+        assertEquals(123456789.0, eval.getValue());
+    }
 }

--- a/src/test/java/dev/openfeature/sdk/ProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderSpecTest.java
@@ -40,6 +40,9 @@ public class ProviderSpecTest {
         ProviderEvaluation<Integer> int_result = p.getIntegerEvaluation("key", 4, new ImmutableContext());
         assertNotNull(int_result.getValue());
 
+        ProviderEvaluation<Number> number_result = p.getNumberEvaluation("key", 2L, new ImmutableContext());
+        assertNotNull(number_result.getValue());
+
         ProviderEvaluation<Double> double_result = p.getDoubleEvaluation("key", 0.4, new ImmutableContext());
         assertNotNull(double_result.getValue());
 
@@ -96,6 +99,9 @@ public class ProviderSpecTest {
     void variant_set() {
         ProviderEvaluation<Integer> int_result = p.getIntegerEvaluation("key", 4, new ImmutableContext());
         assertNotNull(int_result.getReason());
+
+        ProviderEvaluation<Number> number_result = p.getNumberEvaluation("key", 2L, new ImmutableContext());
+        assertNotNull(number_result.getReason());
 
         ProviderEvaluation<Double> double_result = p.getDoubleEvaluation("key", 0.4, new ImmutableContext());
         assertNotNull(double_result.getReason());


### PR DESCRIPTION
Please give me some feedback. This is my second open source contribution and I'm not sure if this is what the correct approach.                                                                                                                                     