### PR TITLE
fix: make builder visible for javadocs, move javadoc gen to codequali…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,29 +507,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>deploy</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-
-                <plugins>
-                    <!-- Begin publish to maven central -->
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <publishingServerId>central</publishingServerId>
-                            <autoPublish>true</autoPublish>
-                        </configuration>
-                    </plugin>
-                    <!-- End publish to maven central -->
 
                     <!-- Begin source & javadocs being generated -->
                     <plugin>
@@ -565,6 +542,29 @@
                         </executions>
                     </plugin>
                     <!-- end source & javadoc -->
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>deploy</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+
+                <plugins>
+                    <!-- Begin publish to maven central -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                    <!-- End publish to maven central -->
 
                     <!-- sign the jars -->
                     <plugin>

--- a/src/main/java/dev/openfeature/sdk/HookContextWithoutData.java
+++ b/src/main/java/dev/openfeature/sdk/HookContextWithoutData.java
@@ -45,4 +45,11 @@ class HookContextWithoutData<T> implements HookContext<T> {
         return new HookContextWithoutData<>(
                 key, type, defaultValue, ImmutableContext.EMPTY, clientMetadata, providerMetadata);
     }
+
+    /**
+     * Make the builder visible for javadocs.
+     *
+     * @param <T>   flag value type
+     */
+    public static class HookContextWithoutDataBuilder<T> {}
 }


### PR DESCRIPTION


## This PR
fixes [this error](https://github.com/open-feature/java-sdk/actions/runs/17733643186) in the action on merge & moves the javadoc generation to the codequality profile (which is run on the PR and not the deploy step on-merge or release actions)


### How to test
should be tested now by PR github actions or run mvn clean verify locally

