### PR TITLE
fix: flacky e2e tests

### DIFF
--- a/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
@@ -114,14 +114,20 @@ public class ProviderSteps {
             case FATAL:
             case ERROR:
                 mockProvider.emitProviderReady(details);
+                waitForProviderState(ProviderState.READY, client);
                 mockProvider.emitProviderError(details);
                 break;
             case STALE:
                 mockProvider.emitProviderReady(details);
+                waitForProviderState(ProviderState.READY, client);
                 mockProvider.emitProviderStale(details);
                 break;
             default:
         }
+        waitForProviderState(providerState, client);
+    }
+
+    private static void waitForProviderState(ProviderState providerState, Client client) {
         Awaitility.await().until(() -> {
             ProviderState providerState1 = client.getProviderState();
             return providerState1 == providerState;

--- a/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
@@ -112,6 +112,8 @@ public class ProviderSteps {
                 ProviderEventDetails.builder().errorCode(errorCode).build();
         switch (providerState) {
             case FATAL:
+                // The FATAL state is set via an exception during initialization. No further events are needed.
+                break;
             case ERROR:
                 mockProvider.emitProviderReady(details);
                 waitForProviderState(ProviderState.READY, client);


### PR DESCRIPTION
Seems like we do have a race condition, where we are not entering a certain state, i assume that this might be caused by a race condition, of too many events back to back and how they are processed.

Maybe we should change the implementation of our eventing to a queue, which gets filled and taken from, to ensure events are thrown in the order they are emitted?