### PR TITLE
fix: improve vmlens handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>com.vmlens</groupId>
             <artifactId>api</artifactId>
-            <version>1.2.13</version>
+            <version>1.2.14</version>
             <scope>test</scope>
         </dependency>
 
@@ -348,7 +348,7 @@
             </activation>
             <build>
                 <plugins>
-                    <!--<plugin>
+                    <plugin>
                         <groupId>com.vmlens</groupId>
                         <artifactId>vmlens-maven-plugin</artifactId>
                         <version>1.2.14</version>
@@ -359,11 +359,14 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
+                                	<includes>
+						                <include>**/*CT.java</include>
+					                </includes>
                                     <failIfNoTests>true</failIfNoTests>
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>-->
+                    </plugin>
                     <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <version>3.8.1</version>

--- a/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
@@ -25,9 +25,7 @@ import dev.openfeature.sdk.providers.memory.Flag;
 import dev.openfeature.sdk.providers.memory.InMemoryProvider;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import java.time.Duration;
 import java.util.Map;
-import org.awaitility.Awaitility;
 
 public class ProviderSteps {
     private final State state;
@@ -114,19 +112,15 @@ public class ProviderSteps {
         switch (providerState) {
             case FATAL:
             case ERROR:
-                mockProvider.emitProviderReady(details);
-                mockProvider.emitProviderError(details);
+                mockProvider.emitProviderReady(details).await();
+                mockProvider.emitProviderError(details).await();
                 break;
             case STALE:
-                mockProvider.emitProviderReady(details);
-                mockProvider.emitProviderStale(details);
+                mockProvider.emitProviderReady(details).await();
+                mockProvider.emitProviderStale(details).await();
                 break;
             default:
         }
-        Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> {
-            ProviderState providerState1 = client.getProviderState();
-            return providerState1 == providerState;
-        });
     }
 
     private void configureMockEvaluations(FeatureProvider mockProvider, ErrorCode errorCode, String errorMessage) {

--- a/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
@@ -25,6 +25,7 @@ import dev.openfeature.sdk.providers.memory.Flag;
 import dev.openfeature.sdk.providers.memory.InMemoryProvider;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import java.time.Duration;
 import java.util.Map;
 import org.awaitility.Awaitility;
 
@@ -122,7 +123,7 @@ public class ProviderSteps {
                 break;
             default:
         }
-        Awaitility.await().until(() -> {
+        Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> {
             ProviderState providerState1 = client.getProviderState();
             return providerState1 == providerState;
         });

--- a/src/test/java/dev/openfeature/sdk/vmlens/VmLensCT.java
+++ b/src/test/java/dev/openfeature/sdk/vmlens/VmLensCT.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class VmLensTest {
+class VmLensCT {
     final OpenFeatureAPI api = OpenFeatureAPITestUtil.createAPI();
 
     @BeforeEach


### PR DESCRIPTION
## This PR

Renamed the VmLensTest to VmLensCT and changed the VMLens plugin config to include only tests with postfix CT.

### Related Issues

Fixes #1611

### Notes

The VMLens test no takes something around 4s.

### Follow-up Tasks

Please let me know if you prefer a special profile, or if the time is now o.k.



