### PR TITLE
feat: all executors now create daemon threads to reduce shutdown time

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EventProvider.java
+++ b/src/main/java/dev/openfeature/sdk/EventProvider.java
@@ -23,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public abstract class EventProvider implements FeatureProvider {
     private EventProviderListener eventProviderListener;
     private final ExecutorService emitterExecutor =
-            Executors.newCachedThreadPool(new ConfigurableThreadFactory("openfeature-event-emitter-thread"));
+            Executors.newCachedThreadPool(new ConfigurableThreadFactory("openfeature-event-emitter-thread", true));
 
     void setEventProviderListener(EventProviderListener eventProviderListener) {
         this.eventProviderListener = eventProviderListener;

--- a/src/main/java/dev/openfeature/sdk/EventSupport.java
+++ b/src/main/java/dev/openfeature/sdk/EventSupport.java
@@ -28,7 +28,7 @@ class EventSupport {
     private final Map<String, HandlerStore> handlerStores = new ConcurrentHashMap<>();
     private final HandlerStore globalHandlerStore = new HandlerStore();
     private final ExecutorService taskExecutor =
-            Executors.newCachedThreadPool(new ConfigurableThreadFactory("openfeature-event-handler-thread"));
+            Executors.newCachedThreadPool(new ConfigurableThreadFactory("openfeature-event-handler-thread", true));
 
     /**
      * Run all the event handlers associated with this domain.


### PR DESCRIPTION
## This PR

Following on from #1633, where a `ConfigurableThreadFactory` was introduced to allow Threads created by an Executor to be named and either be created as daemon/non-daemon,  this PR now changes the SDK so that all executors will create daemon threads.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Resolves #1580

### Notes


### Follow-up Tasks


### How to test

