### PR TITLE
fix: allow for providers to safely shutdown

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -330,7 +330,7 @@ class ProviderRepository {
         managersToShutdown.forEach(this::shutdownProvider);
         taskExecutor.shutdown();
         try {
-            if (!taskExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
+            if (!taskExecutor.awaitTermination(EventSupport.SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 log.warn("Task executor did not terminate before the timeout period had elapsed");
                 taskExecutor.shutdownNow();
             }

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -277,5 +278,14 @@ class ProviderRepository {
                 .forEach(this::shutdownProvider);
         this.stateManagers.clear();
         taskExecutor.shutdown();
+        try {
+            if (!taskExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
+                log.warn("Task executor did not terminate before the timeout period had elapsed");
+                taskExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            taskExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
@@ -142,5 +142,19 @@ class ShutdownBehaviorSpecTest {
             NoOpProvider p2 = new NoOpProvider();
             api.setProvider(p2);
         }
+
+        @Test
+        @DisplayName("calling shutdown twice should be safe and idempotent")
+        void callingShutdownTwiceShouldBeSafe() {
+            FeatureProvider provider = ProviderFixture.createMockedProvider();
+            setFeatureProvider(provider);
+
+            api.shutdown();
+
+            // Second shutdown should be a no-op (no exception, provider not called twice)
+            api.shutdown();
+
+            verify(provider, times(1)).shutdown();
+        }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
+++ b/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
@@ -1,0 +1,189 @@
+package dev.openfeature.sdk.vmlens;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.vmlens.api.AllInterleavings;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.OpenFeatureAPITestUtil;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Concurrency tests for ProviderRepository shutdown behavior using VMLens.
+ *
+ * These tests verify that concurrent shutdown operations are safe and produce
+ * consistent results regardless of thread interleaving. Tests operate through
+ * the public OpenFeatureAPI since ProviderRepository is package-private.
+ *
+ */
+class ProviderRepositoryCT {
+
+    private FeatureProvider createMockedProvider(String name, AtomicInteger shutdownCounter) {
+        FeatureProvider provider = mock(FeatureProvider.class);
+        when(provider.getMetadata()).thenReturn(() -> name);
+        doAnswer(invocation -> {
+            shutdownCounter.incrementAndGet();
+            return null;
+        }).when(provider).shutdown();
+        try {
+            doAnswer(invocation -> null).when(provider).initialize(any());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return provider;
+    }
+
+    /**
+     * Test: When multiple threads call shutdown() concurrently, the provider's
+     * shutdown() method should be called exactly once.
+     *
+     * This verifies that the isShuttingDown guard in ProviderRepository correctly
+     * prevents multiple threads from executing the shutdown logic.
+     */
+    @Test
+    void concurrentShutdown_providerShutdownCalledExactlyOnce() throws InterruptedException {
+        try (AllInterleavings allInterleavings =
+                new AllInterleavings("Concurrent API shutdown - provider called once")) {
+            while (allInterleavings.hasNext()) {
+                // Fresh state for each interleaving
+                AtomicInteger shutdownCount = new AtomicInteger(0);
+                FeatureProvider provider = createMockedProvider("test-provider", shutdownCount);
+                OpenFeatureAPI api = OpenFeatureAPITestUtil.createAPI();
+
+                // Set provider and wait for initialization to complete
+                api.setProviderAndWait(provider);
+
+                // Run concurrent shutdowns through the public API
+                Thread t1 = new Thread(api::shutdown);
+                Thread t2 = new Thread(api::shutdown);
+                Thread t3 = new Thread(api::shutdown);
+
+                t1.start();
+                t2.start();
+                t3.start();
+
+                t1.join();
+                t2.join();
+                t3.join();
+
+                // INVARIANT: Provider shutdown must be called exactly once
+                assertThat(shutdownCount.get())
+                    .as("Provider.shutdown() should be called exactly once regardless of thread interleaving")
+                    .isEqualTo(1);
+            }
+        }
+    }
+
+    /**
+     * Test: When setProvider and shutdown race, either:
+     * - setProvider succeeds (runs before shutdown sets isShuttingDown flag)
+     * - setProvider throws IllegalStateException (runs after shutdown sets flag)
+     *
+     * In either case, the original provider should always be shut down.
+     */
+    @Test
+    void setProviderDuringShutdown_eitherSucceedsOrThrows() throws InterruptedException {
+        try (AllInterleavings allInterleavings =
+                new AllInterleavings("setProvider racing with shutdown")) {
+            while (allInterleavings.hasNext()) {
+                // Fresh state for each interleaving
+                AtomicInteger provider1ShutdownCount = new AtomicInteger(0);
+                AtomicInteger provider2ShutdownCount = new AtomicInteger(0);
+                FeatureProvider provider1 = createMockedProvider("provider-1", provider1ShutdownCount);
+                FeatureProvider provider2 = createMockedProvider("provider-2", provider2ShutdownCount);
+                OpenFeatureAPI api = OpenFeatureAPITestUtil.createAPI();
+
+                // Set initial provider
+                api.setProviderAndWait(provider1);
+
+                // Track outcomes
+                AtomicInteger setProviderSucceeded = new AtomicInteger(0);
+                AtomicInteger setProviderFailed = new AtomicInteger(0);
+
+                Thread shutdownThread = new Thread(api::shutdown);
+                Thread setProviderThread = new Thread(() -> {
+                    try {
+                        api.setProvider(provider2);
+                        setProviderSucceeded.incrementAndGet();
+                    } catch (IllegalStateException e) {
+                        if (e.getMessage().contains("shutting down")) {
+                            setProviderFailed.incrementAndGet();
+                        } else {
+                            throw e;
+                        }
+                    }
+                });
+
+                shutdownThread.start();
+                setProviderThread.start();
+
+                shutdownThread.join();
+                setProviderThread.join();
+
+                // INVARIANT: setProvider must have exactly one outcome
+                int totalOutcomes = setProviderSucceeded.get() + setProviderFailed.get();
+                assertThat(totalOutcomes)
+                    .as("setProvider must have exactly one outcome (success or failure)")
+                    .isEqualTo(1);
+
+                // INVARIANT: Original provider should always be shut down
+                assertThat(provider1ShutdownCount.get())
+                    .as("Original provider should be shut down exactly once")
+                    .isEqualTo(1);
+            }
+        }
+    }
+
+    /**
+     * Test: Multiple providers registered to different domains should all be
+     * shut down exactly once when shutdown() is called concurrently.
+     */
+    @Test
+    void concurrentShutdown_allDomainProvidersShutdownExactlyOnce() throws InterruptedException {
+        try (AllInterleavings allInterleavings =
+                new AllInterleavings("Concurrent shutdown - all domain providers")) {
+            while (allInterleavings.hasNext()) {
+                AtomicInteger defaultShutdownCount = new AtomicInteger(0);
+                AtomicInteger domain1ShutdownCount = new AtomicInteger(0);
+                AtomicInteger domain2ShutdownCount = new AtomicInteger(0);
+
+                FeatureProvider defaultProvider = createMockedProvider("default", defaultShutdownCount);
+                FeatureProvider domain1Provider = createMockedProvider("domain1", domain1ShutdownCount);
+                FeatureProvider domain2Provider = createMockedProvider("domain2", domain2ShutdownCount);
+
+                OpenFeatureAPI api = OpenFeatureAPITestUtil.createAPI();
+
+                // Register providers to different domains
+                api.setProviderAndWait(defaultProvider);
+                api.setProviderAndWait("domain1", domain1Provider);
+                api.setProviderAndWait("domain2", domain2Provider);
+
+                // Run concurrent shutdowns
+                Thread t1 = new Thread(api::shutdown);
+                Thread t2 = new Thread(api::shutdown);
+
+                t1.start();
+                t2.start();
+
+                t1.join();
+                t2.join();
+
+                // INVARIANT: Each provider shut down exactly once
+                assertThat(defaultShutdownCount.get())
+                    .as("Default provider shutdown count")
+                    .isEqualTo(1);
+                assertThat(domain1ShutdownCount.get())
+                    .as("Domain1 provider shutdown count")
+                    .isEqualTo(1);
+                assertThat(domain2ShutdownCount.get())
+                    .as("Domain2 provider shutdown count")
+                    .isEqualTo(1);
+            }
+        }
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
+++ b/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
@@ -30,18 +30,14 @@ class ProviderRepositoryCT {
     import java.util.concurrent.atomic.AtomicInteger;
     import org.junit.jupiter.api.Test;
 
-    private FeatureProvider createMockedProvider(String name, AtomicInteger shutdownCounter) {
+    private FeatureProvider createMockedProvider(String name, AtomicInteger shutdownCounter) throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
         when(provider.getMetadata()).thenReturn(() -> name);
         doAnswer(invocation -> {
             shutdownCounter.incrementAndGet();
             return null;
         }).when(provider).shutdown();
-        try {
-            doAnswer(invocation -> null).when(provider).initialize(any());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        doAnswer(invocation -> null).when(provider).initialize(any());
         return provider;
     }
 

--- a/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
+++ b/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
@@ -1,34 +1,25 @@
 package dev.openfeature.sdk.vmlens;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.vmlens.api.AllInterleavings;
+import com.vmlens.api.Runner;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.OpenFeatureAPITestUtil;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
 /**
  * Concurrency tests for ProviderRepository shutdown behavior using VMLens.
  *
- * These tests verify that concurrent shutdown operations are safe and produce
+ * <p>These tests verify that concurrent shutdown operations are safe and produce
  * consistent results regardless of thread interleaving. Tests operate through
  * the public OpenFeatureAPI since ProviderRepository is package-private.
- *
- * NOTE: Tests are commented out due to a VMLens limitation/bug where calling
- * ThreadPoolExecutor.shutdown() inside AllInterleavings causes VMLens to crash
- * with a NullPointerException in ThreadPoolMap.joinAll(). This is because VMLens
- * instruments ThreadPoolExecutor and cannot handle shutdown() being called during
- * test execution. See: https://github.com/vmlens/vmlens
  */
 class ProviderRepositoryCT {
-
-    /*
-    import static org.assertj.core.api.Assertions.assertThat;
-    import static org.mockito.ArgumentMatchers.any;
-    import static org.mockito.Mockito.doAnswer;
-    import static org.mockito.Mockito.mock;
-    import static org.mockito.Mockito.when;
-
-    import com.vmlens.api.AllInterleavings;
-    import com.vmlens.api.Runner;
-    import dev.openfeature.sdk.FeatureProvider;
-    import dev.openfeature.sdk.OpenFeatureAPI;
-    import dev.openfeature.sdk.OpenFeatureAPITestUtil;
-    import java.util.concurrent.atomic.AtomicInteger;
-    import org.junit.jupiter.api.Test;
 
     private FeatureProvider createMockedProvider(String name, AtomicInteger shutdownCounter) throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
@@ -42,7 +33,7 @@ class ProviderRepositoryCT {
     }
 
     @Test
-    void concurrentShutdown_providerShutdownCalledExactlyOnce() throws InterruptedException {
+    void concurrentShutdown_providerShutdownCalledExactlyOnce() throws Exception {
         try (AllInterleavings allInterleavings =
                 new AllInterleavings("Concurrent API shutdown - provider called once")) {
             while (allInterleavings.hasNext()) {
@@ -66,7 +57,7 @@ class ProviderRepositoryCT {
     }
 
     @Test
-    void setProviderDuringShutdown_eitherSucceedsOrThrows() throws InterruptedException {
+    void setProviderDuringShutdown_eitherSucceedsOrThrows() throws Exception {
         try (AllInterleavings allInterleavings =
                 new AllInterleavings("setProvider racing with shutdown")) {
             while (allInterleavings.hasNext()) {
@@ -115,7 +106,7 @@ class ProviderRepositoryCT {
     }
 
     @Test
-    void concurrentShutdown_allDomainProvidersShutdownExactlyOnce() throws InterruptedException {
+    void concurrentShutdown_allDomainProvidersShutdownExactlyOnce() throws Exception {
         try (AllInterleavings allInterleavings =
                 new AllInterleavings("Concurrent shutdown - all domain providers")) {
             while (allInterleavings.hasNext()) {
@@ -150,5 +141,4 @@ class ProviderRepositoryCT {
             }
         }
     }
-    */
 }


### PR DESCRIPTION
## Summary

Improves the shutdown behaviour of the `ProviderRepository` to ensure safe termination of the task executor. The previous implementation called `shutdown()` on the executor but did not wait for termination, potentially leading to abrupt shutdown, aborted provider shutdown sequences or hanging threads.

## Changes

  - Added graceful shutdown handling in `ProviderRepository.shutdown()` with a 3-second timeout
  - Added shutdown state tracking to prevent race conditions
  - Handles `RejectedExecutionException` when tasks are submitted to a shut down executor

## Implementation Details

  The shutdown process now:
1. Calls `shutdown()` on the task executor to prevent new tasks
2. Waits up to 3 seconds for running tasks to complete via `awaitTermination()`
3. If tasks don't complete within the timeout, calls `shutdownNow()` to force termination
4. Properly handles `InterruptedException` by calling `shutdownNow()` and restoring the interrupt flag
5. Prevents new providers from being registered during shutdown via `AtomicBoolean` flag
6. Handles `RejectedExecutionException` by running provider shutdown synchronously when executor is closed

## Test Coverage

Added comprehensive test coverage for shutdown behavior:
  [x] Successful shutdown when executor terminates within timeout
  [x] Forced shutdown when executor does not terminate within timeout
  [x] Graceful handling of interruption during shutdown
  [x] Protection against indefinite hangs during shutdown
  [x] Concurrent shutdown calls (idempotent behavior)
  [x] Shutdown during provider initialization
  [x] Provider replacement during shutdown
  [x] Prevention of new provider registration after shutdown starts

## Related Issues

https://github.com/open-feature/java-sdk/issues/1745

This change aligns with the broader effort to improve shutdown behaviour across the SDK, similar to PR #873 which addresses the same issue on Eventing.