### PR TITLE
feat: equivalent EvaluationContext impls are .equal

### DIFF
--- a/src/main/java/dev/openfeature/sdk/AbstractStructure.java
+++ b/src/main/java/dev/openfeature/sdk/AbstractStructure.java
@@ -3,10 +3,9 @@ package dev.openfeature.sdk;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
 @SuppressWarnings({"PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType"})
-@EqualsAndHashCode
 abstract class AbstractStructure implements Structure {
 
     protected final Map<String, Value> attributes;
@@ -47,5 +46,19 @@ abstract class AbstractStructure implements Structure {
                         HashMap::new,
                         (accumulated, entry) -> accumulated.put(entry.getKey(), convertValue(entry.getValue())),
                         HashMap::putAll);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof AbstractStructure)) {
+            return false;
+        }
+        AbstractStructure that = (AbstractStructure) object;
+        return Objects.equals(attributes, that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(attributes);
     }
 }

--- a/src/main/java/dev/openfeature/sdk/EvaluationContext.java
+++ b/src/main/java/dev/openfeature/sdk/EvaluationContext.java
@@ -25,6 +25,31 @@ public interface EvaluationContext extends Structure {
     EvaluationContext merge(EvaluationContext overridingContext);
 
     /**
+     * If the other object is an EvaluationContext, this method compares the results of asUnmodifiableMap() for
+     * equality. Otherwise, it returns false.
+     * <br>
+     * <br>
+     * Implementations of EvaluationContext are encouraged to delegate their equals() method to this method, or provide
+     * a more optimized check with the same semantics.
+     *
+     * @param other the object to compare to
+     * @return true if the other object is an EvaluationContext and has the same map representation, false otherwise
+     */
+    default boolean isEqualTo(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof EvaluationContext)) {
+            return false;
+        }
+        var otherContext = (EvaluationContext) other;
+        return asUnmodifiableMap().equals(otherContext.asUnmodifiableMap());
+    }
+
+    /**
      * Recursively merges the overriding map into the base Value map.
      * The base map is mutated, the overriding map is not.
      * Null maps will cause no-op.

--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Delegate;
 
@@ -17,7 +16,6 @@ import lombok.experimental.Delegate;
  * not be modified after instantiation.
  */
 @ToString
-@EqualsAndHashCode
 @SuppressWarnings("PMD.BeanMembersShouldSerialize")
 public final class ImmutableContext implements EvaluationContext {
 
@@ -25,6 +23,9 @@ public final class ImmutableContext implements EvaluationContext {
 
     @Delegate(excludes = DelegateExclusions.class)
     private final ImmutableStructure structure;
+
+    // Lazily computed hash code, safe because this class is immutable.
+    private volatile Integer cachedHashCode;
 
     /**
      * Create an immutable context with an empty targeting_key and attributes
@@ -94,6 +95,40 @@ public final class ImmutableContext implements EvaluationContext {
         Map<String, Value> attributes = this.asMap();
         EvaluationContext.mergeMaps(ImmutableStructure::new, attributes, overridingContext.asUnmodifiableMap());
         return new ImmutableContext(attributes);
+    }
+
+    /**
+     * Equality for EvaluationContext implementations is defined in terms of their resolved
+     * attribute maps. Two contexts are considered equal if their {@link #asMap()} representations
+     * contain the same key/value pairs, regardless of how the context was constructed or layered.
+     *
+     * @param o the object to compare with this context
+     * @return true if the other object is an EvaluationContext whose resolved attributes match
+     */
+    @Override
+    public boolean equals(Object o) {
+        return isEqualTo(o);
+    }
+
+    /**
+     * Computes a hash code consistent with {@link #equals(Object)}. Since this context is immutable,
+     * the hash code is lazily computed once from its resolved attribute map and then cached.
+     *
+     * @return the cached hash code derived from this context's attribute map
+     */
+    @Override
+    public int hashCode() {
+        Integer result = cachedHashCode;
+        if (result == null) {
+            synchronized (this) {
+                result = cachedHashCode;
+                if (result == null) {
+                    result = structure.hashCode();
+                    cachedHashCode = result;
+                }
+            }
+        }
+        return result;
     }
 
     @SuppressWarnings("all")

--- a/src/main/java/dev/openfeature/sdk/LayeredEvaluationContext.java
+++ b/src/main/java/dev/openfeature/sdk/LayeredEvaluationContext.java
@@ -21,6 +21,9 @@ public class LayeredEvaluationContext implements EvaluationContext {
     private ArrayList<EvaluationContext> hookContexts;
     private String targetingKey;
     private Set<String> keySet = null;
+    // Lazily computed resolved attribute map for this layered context.
+    // This must be invalidated whenever the underlying layers change.
+    private Map<String, Value> cachedMap;
 
     /**
      * Constructor for LayeredEvaluationContext.
@@ -174,15 +177,20 @@ public class LayeredEvaluationContext implements EvaluationContext {
         return getFromContext(apiContext, key);
     }
 
-    @Override
-    public Map<String, Value> asMap() {
+    private Map<String, Value> getResolvedMap() {
+        if (cachedMap != null) {
+            return cachedMap;
+        }
+
         if (keySet != null && keySet.isEmpty()) {
-            return new HashMap<>(0);
+            cachedMap = Collections.emptyMap();
+            return cachedMap;
         }
 
         HashMap<String, Value> map;
         if (keySet != null) {
-            map = new HashMap<>(keySet.size());
+            // use helper to size the map based on expected entries
+            map = HashMapUtils.forEntries(keySet.size());
         } else {
             map = new HashMap<>();
         }
@@ -205,7 +213,15 @@ public class LayeredEvaluationContext implements EvaluationContext {
                 map.putAll(hookContext.asMap());
             }
         }
-        return map;
+
+        cachedMap = Collections.unmodifiableMap(map);
+        return cachedMap;
+    }
+
+    @Override
+    public Map<String, Value> asMap() {
+        // Return a defensive copy so callers can't mutate our cached map.
+        return new HashMap<>(getResolvedMap());
     }
 
     @Override
@@ -214,7 +230,7 @@ public class LayeredEvaluationContext implements EvaluationContext {
             return Collections.emptyMap();
         }
 
-        return Collections.unmodifiableMap(asMap());
+        return getResolvedMap();
     }
 
     @Override
@@ -225,7 +241,8 @@ public class LayeredEvaluationContext implements EvaluationContext {
 
         HashMap<String, Object> map;
         if (keySet != null) {
-            map = new HashMap<>(keySet.size());
+            // use helper to size the map based on expected entries
+            map = HashMapUtils.forEntries(keySet.size());
         } else {
             map = new HashMap<>();
         }
@@ -248,7 +265,31 @@ public class LayeredEvaluationContext implements EvaluationContext {
                 map.putAll(hookContext.asObjectMap());
             }
         }
+
         return map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EvaluationContext)) {
+            return false;
+        }
+
+        EvaluationContext that = (EvaluationContext) o;
+
+        if (that instanceof LayeredEvaluationContext) {
+            return this.getResolvedMap().equals(((LayeredEvaluationContext) that).getResolvedMap());
+        }
+
+        return this.getResolvedMap().equals(that.asUnmodifiableMap());
+    }
+
+    @Override
+    public int hashCode() {
+        return getResolvedMap().hashCode();
     }
 
     void putHookContext(EvaluationContext context) {
@@ -265,5 +306,6 @@ public class LayeredEvaluationContext implements EvaluationContext {
         }
         this.hookContexts.add(context);
         this.keySet = null;
+        this.cachedMap = null;
     }
 }

--- a/src/main/java/dev/openfeature/sdk/MutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/MutableContext.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Delegate;
 
@@ -17,7 +16,6 @@ import lombok.experimental.Delegate;
  * be modified after instantiation.
  */
 @ToString
-@EqualsAndHashCode
 @SuppressWarnings("PMD.BeanMembersShouldSerialize")
 public class MutableContext implements EvaluationContext {
 
@@ -123,6 +121,24 @@ public class MutableContext implements EvaluationContext {
         Map<String, Value> attributes = this.asMap();
         EvaluationContext.mergeMaps(MutableStructure::new, attributes, overridingContext.asUnmodifiableMap());
         return new MutableContext(attributes);
+    }
+
+    /**
+     * Equality for EvaluationContext implementations is defined in terms of their resolved
+     * attribute maps. Two contexts are considered equal if their {@link #asMap()} representations
+     * contain the same key/value pairs, regardless of how the context was constructed or layered.
+     *
+     * @param o the object to compare with this context
+     * @return true if the other object is an EvaluationContext whose resolved attributes match
+     */
+    @Override
+    public boolean equals(Object o) {
+        return isEqualTo(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return structure.hashCode();
     }
 
     /**

--- a/src/test/java/dev/openfeature/sdk/MutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/MutableContextTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MutableContextTest {
@@ -139,30 +140,71 @@ class MutableContextTest {
         assertEquals(3.0, context.getValue("key3").asDouble());
     }
 
-    @DisplayName("Two different MutableContext objects with the different contents are not considered equal")
-    @Test
-    void unequalMutableContextsAreNotEqual() {
-        final Map<String, Value> attributes = new HashMap<>();
-        attributes.put("key1", new Value("val1"));
-        final MutableContext ctx = new MutableContext(attributes);
+    @Nested
+    class Equals {
+        MutableContext ctx = new MutableContext("c", Map.of("a", new Value("b")));
 
-        final Map<String, Value> attributes2 = new HashMap<>();
-        final MutableContext ctx2 = new MutableContext(attributes2);
+        @Test
+        void equalsItself() {
+            assertEquals(ctx, ctx);
+        }
 
-        assertNotEquals(ctx, ctx2);
+        @Test
+        void equalsLayeredEvalCtxIfSameValues() {
+            var layeredContext = new LayeredEvaluationContext(ctx, null, null, null);
+            assertEquals(layeredContext, ctx);
+            assertEquals(ctx, layeredContext);
+        }
+
+        @Test
+        void equalsDifferentMutableEvalCtxIfSameValues() {
+            var immutable = new ImmutableContext("c", Map.of("a", new Value("b")));
+            assertEquals(immutable, ctx);
+            assertEquals(ctx, immutable);
+        }
+
+        @DisplayName("Two different MutableContext objects with the different contents are not considered equal")
+        @Test
+        void unequalMutableContextsAreNotEqual() {
+            final Map<String, Value> attributes = new HashMap<>();
+            attributes.put("key1", new Value("val1"));
+            final MutableContext context = new MutableContext(attributes);
+
+            final Map<String, Value> attributes2 = new HashMap<>();
+            final MutableContext ctx2 = new MutableContext(attributes2);
+
+            assertNotEquals(context, ctx2);
+        }
+
+        @DisplayName("Two different MutableContext objects with the same content are considered equal")
+        @Test
+        void equalMutableContextsAreEqual() {
+            final Map<String, Value> attributes = new HashMap<>();
+            attributes.put("key1", new Value("val1"));
+            final MutableContext context = new MutableContext(attributes);
+
+            final Map<String, Value> attributes2 = new HashMap<>();
+            attributes2.put("key1", new Value("val1"));
+            final MutableContext ctx2 = new MutableContext(attributes2);
+
+            assertEquals(context, ctx2);
+        }
     }
 
-    @DisplayName("Two different MutableContext objects with the same content are considered equal")
-    @Test
-    void equalMutableContextsAreEqual() {
-        final Map<String, Value> attributes = new HashMap<>();
-        attributes.put("key1", new Value("val1"));
-        final MutableContext ctx = new MutableContext(attributes);
+    @Nested
+    class HashCode {
+        MutableContext ctx = new MutableContext("c", Map.of("a", new Value("b")));
 
-        final Map<String, Value> attributes2 = new HashMap<>();
-        attributes2.put("key1", new Value("val1"));
-        final MutableContext ctx2 = new MutableContext(attributes2);
+        @Test
+        void hashCodeEqualsLayeredEvalCtxIfSameValues() {
+            var layeredContext = new LayeredEvaluationContext(ctx, null, null, null);
+            assertEquals(layeredContext.hashCode(), ctx.hashCode());
+        }
 
-        assertEquals(ctx, ctx2);
+        @Test
+        void hashCodeEqualsDifferentMutableEvalCtxIfSameValues() {
+            var immutable = new ImmutableContext("c", Map.of("a", new Value("b")));
+            assertEquals(immutable.hashCode(), ctx.hashCode());
+        }
     }
 }


### PR DESCRIPTION
## This PR

Re-revert of https://github.com/open-feature/java-sdk/pull/1768 with associated fixes: The object map of the LayeredEvaluationContext needs to be computed by calling the `asObjectMap` method of the layered contexts. Otherwise, nested EvaluationContexts will not get unwrapped (i.e. converted to HashMaps)

### Related Issues

Fixes #1754

See also https://github.com/open-feature/java-sdk-contrib/pull/1665
