### PR TITLE
feat: Allow for providers with equal name in the multiprovider

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -32,5 +32,48 @@
         }
       ]
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "id": "multiprovider-non-unique-names",
+    "configuration": {
+      "ignore": true,
+      "justification": "The experimental MultiProvider changed its internal provider collection from a name-keyed Map to a List to allow providers with equal names. The MultiProvider and its Strategy are experimental and not intended for external implementation. See https://github.com/open-feature/java-sdk/pull/1848.",
+      "differences": [
+        {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter <T> dev.openfeature.sdk.ProviderEvaluation<T> dev.openfeature.sdk.multiprovider.FirstMatchStrategy::evaluate(===java.util.Map<java.lang.String, dev.openfeature.sdk.FeatureProvider>===, java.lang.String, T, dev.openfeature.sdk.EvaluationContext, java.util.function.Function<dev.openfeature.sdk.FeatureProvider, dev.openfeature.sdk.ProviderEvaluation<T>>)",
+          "new": "parameter <T> dev.openfeature.sdk.ProviderEvaluation<T> dev.openfeature.sdk.multiprovider.FirstMatchStrategy::evaluate(===java.util.List<dev.openfeature.sdk.FeatureProvider>===, java.lang.String, T, dev.openfeature.sdk.EvaluationContext, java.util.function.Function<dev.openfeature.sdk.FeatureProvider, dev.openfeature.sdk.ProviderEvaluation<T>>)",
+          "parameterIndex": "0"
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter <T> dev.openfeature.sdk.ProviderEvaluation<T> dev.openfeature.sdk.multiprovider.FirstSuccessfulStrategy::evaluate(===java.util.Map<java.lang.String, dev.openfeature.sdk.FeatureProvider>===, java.lang.String, T, dev.openfeature.sdk.EvaluationContext, java.util.function.Function<dev.openfeature.sdk.FeatureProvider, dev.openfeature.sdk.ProviderEvaluation<T>>)",
+          "new": "parameter <T> dev.openfeature.sdk.ProviderEvaluation<T> dev.openfeature.sdk.multiprovider.FirstSuccessfulStrategy::evaluate(===java.util.List<dev.openfeature.sdk.FeatureProvider>===, java.lang.String, T, dev.openfeature.sdk.EvaluationContext, java.util.function.Function<dev.openfeature.sdk.FeatureProvider, dev.openfeature.sdk.ProviderEvaluation<T>>)",
+          "parameterIndex": "0"
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter <T> dev.openfeature.sdk.ProviderEvaluation<T> dev.openfeature.sdk.multiprovider.Strategy::evaluate(===java.util.Map<java.lang.String, dev.openfeature.sdk.FeatureProvider>===, java.lang.String, T, dev.openfeature.sdk.EvaluationContext, java.util.function.Function<dev.openfeature.sdk.FeatureProvider, dev.openfeature.sdk.ProviderEvaluation<T>>)",
+          "new": "parameter <T> dev.openfeature.sdk.ProviderEvaluation<T> dev.openfeature.sdk.multiprovider.Strategy::evaluate(===java.util.List<dev.openfeature.sdk.FeatureProvider>===, java.lang.String, T, dev.openfeature.sdk.EvaluationContext, java.util.function.Function<dev.openfeature.sdk.FeatureProvider, dev.openfeature.sdk.ProviderEvaluation<T>>)",
+          "parameterIndex": "0"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method java.util.Map<java.lang.String, dev.openfeature.sdk.FeatureProvider> dev.openfeature.sdk.multiprovider.MultiProvider::buildProviders(java.util.List<dev.openfeature.sdk.FeatureProvider>)"
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter dev.openfeature.sdk.multiprovider.MultiProviderMetadata.MultiProviderMetadataBuilder dev.openfeature.sdk.multiprovider.MultiProviderMetadata.MultiProviderMetadataBuilder::originalMetadata(===java.util.Map<java.lang.String, dev.openfeature.sdk.Metadata>===)",
+          "new": "parameter dev.openfeature.sdk.multiprovider.MultiProviderMetadata.MultiProviderMetadataBuilder dev.openfeature.sdk.multiprovider.MultiProviderMetadata.MultiProviderMetadataBuilder::originalMetadata(===java.util.List<dev.openfeature.sdk.Metadata>===)",
+          "parameterIndex": "0"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Map<java.lang.String, dev.openfeature.sdk.Metadata> dev.openfeature.sdk.multiprovider.MultiProviderMetadata::getOriginalMetadata()",
+          "new": "method java.util.List<dev.openfeature.sdk.Metadata> dev.openfeature.sdk.multiprovider.MultiProviderMetadata::getOriginalMetadata()"
+        }
+      ]
+    }
   }
 ]

--- a/src/main/java/dev/openfeature/sdk/multiprovider/FirstMatchStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/FirstMatchStrategy.java
@@ -9,7 +9,6 @@ import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,16 +33,15 @@ public class FirstMatchStrategy implements Strategy {
 
     @Override
     public <T> ProviderEvaluation<T> evaluate(
-            Map<String, FeatureProvider> providers,
+            List<FeatureProvider> providers,
             String key,
             T defaultValue,
             EvaluationContext ctx,
             Function<FeatureProvider, ProviderEvaluation<T>> providerFunction) {
         List<ProviderError> collectedErrors = new ArrayList<>();
 
-        for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
-            String providerName = entry.getKey();
-            FeatureProvider provider = entry.getValue();
+        for (FeatureProvider provider : providers) {
+            String providerName = provider.getMetadata().getName();
             try {
                 ProviderEvaluation<T> res = providerFunction.apply(provider);
                 ErrorCode errorCode = res.getErrorCode();

--- a/src/main/java/dev/openfeature/sdk/multiprovider/FirstSuccessfulStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/FirstSuccessfulStrategy.java
@@ -6,7 +6,6 @@ import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.ProviderEvaluation;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,16 +24,15 @@ public class FirstSuccessfulStrategy implements Strategy {
 
     @Override
     public <T> ProviderEvaluation<T> evaluate(
-            Map<String, FeatureProvider> providers,
+            List<FeatureProvider> providers,
             String key,
             T defaultValue,
             EvaluationContext ctx,
             Function<FeatureProvider, ProviderEvaluation<T>> providerFunction) {
         List<ProviderError> collectedErrors = new ArrayList<>();
 
-        for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
-            String providerName = entry.getKey();
-            FeatureProvider provider = entry.getValue();
+        for (FeatureProvider provider : providers) {
+            String providerName = provider.getMetadata().getName();
             try {
                 ProviderEvaluation<T> res = providerFunction.apply(provider);
                 if (res.getErrorCode() == null) {

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -10,13 +10,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import lombok.Getter;
@@ -38,7 +34,7 @@ public class MultiProvider extends EventProvider {
     // Use CPU count as upper bound for init threads.
     public static final int INIT_THREADS_COUNT = Runtime.getRuntime().availableProcessors();
 
-    private final Map<String, FeatureProvider> providers;
+    private final List<FeatureProvider> providers;
     private final Strategy strategy;
     private MultiProviderMetadata metadata;
 
@@ -59,20 +55,8 @@ public class MultiProvider extends EventProvider {
      * @param strategy  the strategy (if {@code null}, {@link FirstMatchStrategy} is used)
      */
     public MultiProvider(List<FeatureProvider> providers, Strategy strategy) {
-        this.providers = buildProviders(providers);
+        this.providers = providers;
         this.strategy = Objects.requireNonNull(strategy, "strategy must not be null");
-    }
-
-    protected static Map<String, FeatureProvider> buildProviders(List<FeatureProvider> providers) {
-        Map<String, FeatureProvider> providersMap = new LinkedHashMap<>(providers.size());
-        for (FeatureProvider provider : providers) {
-            FeatureProvider prevProvider =
-                    providersMap.put(provider.getMetadata().getName(), provider);
-            if (prevProvider != null) {
-                log.info("duplicated provider name: {}", provider.getMetadata().getName());
-            }
-        }
-        return Collections.unmodifiableMap(providersMap);
     }
 
     /**
@@ -95,27 +79,27 @@ public class MultiProvider extends EventProvider {
     @Override
     public void initialize(EvaluationContext evaluationContext, String domain) throws Exception {
         var metadataBuilder = MultiProviderMetadata.builder().name(NAME);
-        HashMap<String, Metadata> providersMetadata = new HashMap<>();
 
         if (providers.isEmpty()) {
-            metadataBuilder.originalMetadata(Collections.unmodifiableMap(providersMetadata));
+            metadataBuilder.originalMetadata(Collections.emptyList());
             metadata = metadataBuilder.build();
             return;
         }
 
-        ExecutorService executorService = Executors.newFixedThreadPool(Math.min(INIT_THREADS_COUNT, providers.size()));
+        List<Metadata> providersMetadata = new ArrayList<>(providers.size());
+
+        var executorService = Executors.newFixedThreadPool(Math.min(INIT_THREADS_COUNT, providers.size()));
         try {
             Collection<Callable<Void>> tasks = new ArrayList<>(providers.size());
-            for (FeatureProvider provider : providers.values()) {
+            for (FeatureProvider provider : providers) {
                 tasks.add(() -> {
                     provider.initialize(evaluationContext, domain);
                     return null;
                 });
-                Metadata providerMetadata = provider.getMetadata();
-                providersMetadata.put(providerMetadata.getName(), providerMetadata);
+                providersMetadata.add(provider.getMetadata());
             }
 
-            metadataBuilder.originalMetadata(Collections.unmodifiableMap(providersMetadata));
+            metadataBuilder.originalMetadata(Collections.unmodifiableList(providersMetadata));
 
             List<Future<Void>> results = executorService.invokeAll(tasks);
             for (Future<Void> result : results) {
@@ -175,7 +159,7 @@ public class MultiProvider extends EventProvider {
     @Override
     public void shutdown() {
         log.debug("shutdown begin");
-        for (FeatureProvider provider : providers.values()) {
+        for (FeatureProvider provider : providers) {
             try {
                 provider.shutdown();
             } catch (Exception e) {

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -55,7 +55,7 @@ public class MultiProvider extends EventProvider {
      * @param strategy  the strategy (if {@code null}, {@link FirstMatchStrategy} is used)
      */
     public MultiProvider(List<FeatureProvider> providers, Strategy strategy) {
-        this.providers = providers;
+        this.providers = Collections.unmodifiableList(new ArrayList<>(providers));
         this.strategy = Objects.requireNonNull(strategy, "strategy must not be null");
     }
 

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProviderMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProviderMetadata.java
@@ -1,14 +1,14 @@
 package dev.openfeature.sdk.multiprovider;
 
 import dev.openfeature.sdk.Metadata;
-import java.util.Map;
+import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 
 /**
  * Metadata for {@link MultiProvider}.
  *
- * <p>Contains the multiprovider's own name and a map of the original metadata from each underlying
+ * <p>Contains the multiprovider's own name and a list of the original metadata from each underlying
  * provider.
  */
 @Value
@@ -16,5 +16,5 @@ import lombok.Value;
 public class MultiProviderMetadata implements Metadata {
 
     String name;
-    Map<String, Metadata> originalMetadata;
+    List<Metadata> originalMetadata;
 }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/Strategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/Strategy.java
@@ -3,7 +3,7 @@ package dev.openfeature.sdk.multiprovider;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.ProviderEvaluation;
-import java.util.Map;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -34,7 +34,7 @@ public interface Strategy {
      * @return the resolved {@link ProviderEvaluation}
      */
     <T> ProviderEvaluation<T> evaluate(
-            Map<String, FeatureProvider> providers,
+            List<FeatureProvider> providers,
             String key,
             T defaultValue,
             EvaluationContext ctx,

--- a/src/test/java/dev/openfeature/sdk/multiprovider/BaseStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/BaseStrategyTest.java
@@ -13,8 +13,9 @@ import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.providers.memory.Flag;
 import dev.openfeature.sdk.providers.memory.InMemoryProvider;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -31,7 +32,7 @@ public abstract class BaseStrategyTest {
     protected InMemoryProvider inMemoryProvider1;
     protected InMemoryProvider inMemoryProvider2;
 
-    protected Map<String, FeatureProvider> orderedProviders;
+    protected List<FeatureProvider> orderedProviders;
 
     protected EvaluationContext contextWithNewProvider;
 
@@ -84,10 +85,10 @@ public abstract class BaseStrategyTest {
     }
 
     protected void setupOrderedProviders() {
-        orderedProviders = new LinkedHashMap<>();
-        orderedProviders.put("provider1", mockProvider1);
-        orderedProviders.put("provider2", mockProvider2);
-        orderedProviders.put("provider3", mockProvider3);
+        orderedProviders = new ArrayList<>(3);
+        orderedProviders.add(mockProvider1);
+        orderedProviders.add(mockProvider2);
+        orderedProviders.add(mockProvider3);
     }
 
     protected void setupEvaluationContexts() {

--- a/src/test/java/dev/openfeature/sdk/multiprovider/FirstSuccessfulStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/FirstSuccessfulStrategyTest.java
@@ -134,8 +134,8 @@ class FirstSuccessfulStrategyTest extends BaseStrategyTest {
     @Test
     void shouldReturnMultiProviderEvaluationForNonExistentFlag() {
         orderedProviders.clear();
-        orderedProviders.put("old-provider", inMemoryProvider1);
-        orderedProviders.put("new-provider", inMemoryProvider2);
+        orderedProviders.add(inMemoryProvider1);
+        orderedProviders.add(inMemoryProvider2);
         ProviderEvaluation<String> result = strategy.evaluate(
                 orderedProviders,
                 FLAG_KEY,

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -53,9 +54,9 @@ class MultiProviderTest extends BaseStrategyTest {
         multiProvider.initialize(null);
 
         MultiProviderMetadata metadata = (MultiProviderMetadata) multiProvider.getMetadata();
-        Map<String, Metadata> map = metadata.getOriginalMetadata();
-        assertEquals(mockMetaData1, map.get(mockProvider1.getMetadata().getName()));
-        assertEquals(mockMetaData2, map.get(mockProvider2.getMetadata().getName()));
+        List<Metadata> list = metadata.getOriginalMetadata();
+        assertTrue(list.contains(mockMetaData1));
+        assertTrue(list.contains(mockMetaData2));
         assertEquals("multiprovider", multiProvider.getMetadata().getName());
     }
 
@@ -165,8 +166,8 @@ class MultiProviderTest extends BaseStrategyTest {
         MultiProvider multiProvider = new MultiProvider(providers, mockStrategy);
         multiProvider.initialize(null);
         MultiProviderMetadata metadata = (MultiProviderMetadata) multiProvider.getMetadata();
-        Map<String, Metadata> map = metadata.getOriginalMetadata();
-        assertEquals(mockMetaData1, map.get(mockProvider1.getMetadata().getName()));
+        List<Metadata> list = metadata.getOriginalMetadata();
+        assertTrue(list.contains(mockMetaData1));
     }
 
     @SneakyThrows
@@ -202,7 +203,7 @@ class MultiProviderTest extends BaseStrategyTest {
 
             @Override
             public <T> ProviderEvaluation<T> evaluate(
-                    Map<String, FeatureProvider> providers,
+                    List<FeatureProvider> providers,
                     String key,
                     T defaultValue,
                     EvaluationContext ctx,
@@ -214,7 +215,10 @@ class MultiProviderTest extends BaseStrategyTest {
                 }
 
                 if (contextProvider != null && "new-provider".equals(contextProvider.asString())) {
-                    return providerFunction.apply(providers.get("new-provider"));
+                    return providerFunction.apply(providers.stream()
+                            .filter(p -> "new-provider".equals(p.getMetadata().getName()))
+                            .findFirst()
+                            .orElseThrow());
                 }
                 return fallbackStrategy.evaluate(providers, key, defaultValue, ctx, providerFunction);
             }


### PR DESCRIPTION
## This PR

Adds support for different providers with the same name in the multi provider. Since the interface `Strategy` has changed, this would be a breaking change if the multiprovider was not experimental.

The downside is, that the providers are not passed to the `Strategy` in a map, which makes the retrieval of a provider per name more difficult, and, depending on the number of providers, slower. However, since there will only ever be a handfull of providers, this should make no difference in real scenarios. Furthermore, the current map based version may result in unexpected behavior when two or more providers have the same name.

### Related Issues

Fixes #1792
