### PR TITLE
fix: multiprovider parity gaps with JS SDK reference (#1882)

### DIFF
--- a/src/main/java/dev/openfeature/sdk/EventProvider.java
+++ b/src/main/java/dev/openfeature/sdk/EventProvider.java
@@ -3,10 +3,13 @@ package dev.openfeature.sdk;
 import dev.openfeature.sdk.internal.AutoCloseableReentrantReadWriteLock;
 import dev.openfeature.sdk.internal.ConfigurableThreadFactory;
 import dev.openfeature.sdk.internal.TriConsumer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -24,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class EventProvider implements FeatureProvider {
     private EventProviderListener eventProviderListener;
+    private final List<BiConsumer<ProviderEvent, ProviderEventDetails>> eventObservers = new CopyOnWriteArrayList<>();
     private final ExecutorService emitterExecutor =
             Executors.newCachedThreadPool(new ConfigurableThreadFactory("openfeature-event-emitter-thread", true));
 
@@ -71,6 +75,31 @@ public abstract class EventProvider implements FeatureProvider {
     }
 
     /**
+     * Add a provider event observer.
+     *
+     * <p>Observers are invoked whenever this provider emits an event and are intended for advanced
+     * provider composition scenarios.
+     *
+     * @param observer observer callback
+     */
+    public void addEventObserver(BiConsumer<ProviderEvent, ProviderEventDetails> observer) {
+        if (observer != null) {
+            eventObservers.add(observer);
+        }
+    }
+
+    /**
+     * Remove a previously registered provider event observer.
+     *
+     * @param observer observer callback
+     */
+    public void removeEventObserver(BiConsumer<ProviderEvent, ProviderEventDetails> observer) {
+        if (observer != null) {
+            eventObservers.remove(observer);
+        }
+    }
+
+    /**
      * Stop the event emitter executor and block until either termination has completed
      * or timeout period has elapsed.
      */
@@ -97,8 +126,9 @@ public abstract class EventProvider implements FeatureProvider {
     public Awaitable emit(final ProviderEvent event, final ProviderEventDetails details) {
         final var localEventProviderListener = this.eventProviderListener;
         final var localAttachment = this.attachment.get();
+        final var localEventObservers = this.eventObservers;
 
-        if (localEventProviderListener == null && localAttachment == null) {
+        if (localEventProviderListener == null && localAttachment == null && localEventObservers.isEmpty()) {
             return Awaitable.FINISHED;
         }
 
@@ -115,6 +145,13 @@ public abstract class EventProvider implements FeatureProvider {
                 }
                 if (localAttachment != null) {
                     localAttachment.onEmit.accept(this, event, details);
+                }
+                for (BiConsumer<ProviderEvent, ProviderEventDetails> observer : localEventObservers) {
+                    try {
+                        observer.accept(event, details);
+                    } catch (Exception e) {
+                        log.error("Exception in provider event observer {}", observer, e);
+                    }
                 }
             } finally {
                 awaitable.wakeup();

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -209,8 +209,9 @@ public class OpenFeatureClient implements Client {
                 throw new FatalError("Provider is in an irrecoverable error state");
             }
 
-            var providerEval = (ProviderEvaluation<T>)
-                    createProviderEvaluation(type, key, defaultValue, provider, hookSupportData.getEvaluationContext());
+            var providerEval = (ProviderEvaluation<T>) createProviderEvaluation(
+                    type, key, defaultValue, provider,
+                    hookSupportData.getEvaluationContext());
 
             details = FlagEvaluationDetails.from(providerEval, key);
             if (details.getErrorCode() != null) {

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -209,9 +209,8 @@ public class OpenFeatureClient implements Client {
                 throw new FatalError("Provider is in an irrecoverable error state");
             }
 
-            var providerEval = (ProviderEvaluation<T>) createProviderEvaluation(
-                    type, key, defaultValue, provider,
-                    hookSupportData.getEvaluationContext());
+            var providerEval = (ProviderEvaluation<T>)
+                    createProviderEvaluation(type, key, defaultValue, provider, hookSupportData.getEvaluationContext());
 
             details = FlagEvaluationDetails.from(providerEval, key);
             if (details.getErrorCode() != null) {

--- a/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
@@ -13,8 +13,9 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import lombok.Getter;
@@ -22,19 +23,32 @@ import lombok.Getter;
 /**
  * Comparison strategy.
  *
- * <p>Evaluates all providers and compares successful results.
+ * <p>Evaluates all providers in parallel and compares successful results.
+ * If all providers agree on the value, the fallback provider's result is returned.
+ * If providers disagree, the optional {@code onMismatch} callback is invoked
+ * and the fallback provider's result is returned.
+ * If any provider returns an error, all errors are collected and a
+ * {@link ErrorCode#GENERAL} error is returned.
  */
 public class ComparisonStrategy implements Strategy {
+
+    private static final long DEFAULT_TIMEOUT_MS = 30_000;
 
     @Getter
     private final String fallbackProvider;
 
     private final BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch;
+    private final ExecutorService executorService;
+    private final boolean ownsExecutorService;
+    private final long timeoutMs;
 
     /**
      * Constructs a comparison strategy with a fallback provider.
      *
-     * @param fallbackProvider provider name to use as fallback when successful providers disagree
+     * <p>Uses a shared {@link ForkJoinPool#commonPool()} for parallel evaluation.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful
+     *                         providers disagree
      */
     public ComparisonStrategy(String fallbackProvider) {
         this(fallbackProvider, null);
@@ -43,14 +57,53 @@ public class ComparisonStrategy implements Strategy {
     /**
      * Constructs a comparison strategy with fallback provider and mismatch callback.
      *
-     * @param fallbackProvider provider name to use as fallback when successful providers disagree
-     * @param onMismatch callback invoked with all successful evaluations when they disagree
+     * <p>Uses a shared {@link ForkJoinPool#commonPool()} for parallel evaluation.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful
+     *                         providers disagree
+     * @param onMismatch       callback invoked with all successful evaluations
+     *                         when they disagree
      */
     public ComparisonStrategy(
             String fallbackProvider,
             BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch) {
-        this.fallbackProvider = Objects.requireNonNull(fallbackProvider, "fallbackProvider must not be null");
+        this(fallbackProvider, onMismatch, ForkJoinPool.commonPool(),
+                false, DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * Constructs a comparison strategy with a caller-supplied executor.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful
+     *                         providers disagree
+     * @param onMismatch       callback invoked with all successful evaluations
+     *                         when they disagree (may be {@code null})
+     * @param executorService  executor to use for parallel evaluation
+     * @param timeoutMs        maximum time in milliseconds to wait for all
+     *                         providers to complete
+     */
+    public ComparisonStrategy(
+            String fallbackProvider,
+            BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch,
+            ExecutorService executorService,
+            long timeoutMs) {
+        this(fallbackProvider, onMismatch, executorService,
+                false, timeoutMs);
+    }
+
+    private ComparisonStrategy(
+            String fallbackProvider,
+            BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch,
+            ExecutorService executorService,
+            boolean ownsExecutorService,
+            long timeoutMs) {
+        this.fallbackProvider = Objects.requireNonNull(
+                fallbackProvider, "fallbackProvider must not be null");
         this.onMismatch = onMismatch;
+        this.executorService = Objects.requireNonNull(
+                executorService, "executorService must not be null");
+        this.ownsExecutorService = ownsExecutorService;
+        this.timeoutMs = timeoutMs;
     }
 
     @Override
@@ -67,60 +120,85 @@ public class ComparisonStrategy implements Strategy {
                     .build();
         }
         if (!providers.containsKey(fallbackProvider)) {
-            throw new IllegalArgumentException("fallbackProvider not found in providers: " + fallbackProvider);
+            throw new IllegalArgumentException(
+                    "fallbackProvider not found in providers: "
+                            + fallbackProvider);
         }
 
-        Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(providers.size());
-        Map<String, String> providerErrors = new ConcurrentHashMap<>(providers.size());
-        ExecutorService executorService = Executors.newFixedThreadPool(providers.size());
+        Map<String, ProviderEvaluation<T>> successfulResults =
+                new ConcurrentHashMap<>(providers.size());
+        Map<String, String> providerErrors =
+                new ConcurrentHashMap<>(providers.size());
+
         try {
             List<Callable<Void>> tasks = new ArrayList<>(providers.size());
-            for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
+            for (Map.Entry<String, FeatureProvider> entry
+                    : providers.entrySet()) {
                 String providerName = entry.getKey();
                 FeatureProvider provider = entry.getValue();
                 tasks.add(() -> {
                     try {
-                        ProviderEvaluation<T> evaluation = providerFunction.apply(provider);
+                        ProviderEvaluation<T> evaluation =
+                                providerFunction.apply(provider);
                         if (evaluation == null) {
-                            providerErrors.put(providerName, "null evaluation");
+                            providerErrors.put(
+                                    providerName, "null evaluation");
                         } else if (evaluation.getErrorCode() == null) {
-                            successfulResults.put(providerName, evaluation);
+                            successfulResults.put(
+                                    providerName, evaluation);
                         } else {
                             providerErrors.put(
                                     providerName,
-                                    evaluation.getErrorCode() + ": " + String.valueOf(evaluation.getErrorMessage()));
+                                    evaluation.getErrorCode() + ": "
+                                            + evaluation.getErrorMessage());
                         }
                     } catch (Exception e) {
-                        providerErrors.put(providerName, e.getClass().getSimpleName() + ": " + e.getMessage());
+                        providerErrors.put(
+                                providerName,
+                                e.getClass().getSimpleName() + ": "
+                                        + e.getMessage());
                     }
                     return null;
                 });
             }
-            List<Future<Void>> futures = executorService.invokeAll(tasks);
+            List<Future<Void>> futures =
+                    executorService.invokeAll(
+                            tasks, timeoutMs, TimeUnit.MILLISECONDS);
             for (Future<Void> future : futures) {
+                if (future.isCancelled()) {
+                    return ProviderEvaluation.<T>builder()
+                            .errorCode(ErrorCode.GENERAL)
+                            .errorMessage(
+                                    "Comparison strategy timed out after "
+                                            + timeoutMs + "ms")
+                            .build();
+                }
                 future.get();
             }
         } catch (Exception e) {
             return ProviderEvaluation.<T>builder()
                     .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Comparison strategy failed: " + e.getMessage())
+                    .errorMessage("Comparison strategy failed: "
+                            + e.getMessage())
                     .build();
-        } finally {
-            executorService.shutdown();
         }
 
         if (!providerErrors.isEmpty()) {
             return ProviderEvaluation.<T>builder()
                     .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Provider errors: " + buildErrorSummary(providerErrors))
+                    .errorMessage("Provider errors: "
+                            + buildErrorSummary(providerErrors))
                     .build();
         }
 
-        ProviderEvaluation<T> fallbackResult = successfulResults.get(fallbackProvider);
+        ProviderEvaluation<T> fallbackResult =
+                successfulResults.get(fallbackProvider);
         if (fallbackResult == null) {
             return ProviderEvaluation.<T>builder()
                     .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Fallback provider did not return a successful evaluation: " + fallbackProvider)
+                    .errorMessage(
+                            "Fallback provider did not return a successful "
+                                    + "evaluation: " + fallbackProvider)
                     .build();
         }
 
@@ -129,8 +207,10 @@ public class ComparisonStrategy implements Strategy {
         }
 
         if (onMismatch != null) {
-            Map<String, ProviderEvaluation<?>> mismatchPayload = new LinkedHashMap<>(successfulResults);
-            onMismatch.accept(key, Collections.unmodifiableMap(mismatchPayload));
+            Map<String, ProviderEvaluation<?>> mismatchPayload =
+                    new LinkedHashMap<>(successfulResults);
+            onMismatch.accept(
+                    key, Collections.unmodifiableMap(mismatchPayload));
         }
         return fallbackResult;
     }
@@ -143,19 +223,23 @@ public class ComparisonStrategy implements Strategy {
                 builder.append("; ");
             }
             first = false;
-            builder.append(entry.getKey()).append(" -> ").append(entry.getValue());
+            builder.append(entry.getKey())
+                    .append(" -> ")
+                    .append(entry.getValue());
         }
         return builder.toString();
     }
 
-    private <T> boolean allEvaluationsMatch(Map<String, ProviderEvaluation<T>> results) {
+    private <T> boolean allEvaluationsMatch(
+            Map<String, ProviderEvaluation<T>> results) {
         ProviderEvaluation<T> baseline = null;
         for (ProviderEvaluation<T> evaluation : results.values()) {
             if (baseline == null) {
                 baseline = evaluation;
                 continue;
             }
-            if (!Objects.equals(baseline.getValue(), evaluation.getValue())) {
+            if (!Objects.equals(
+                    baseline.getValue(), evaluation.getValue())) {
                 return false;
             }
         }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
@@ -1,0 +1,164 @@
+package dev.openfeature.sdk.multiprovider;
+
+import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.ProviderEvaluation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import lombok.Getter;
+
+/**
+ * Comparison strategy.
+ *
+ * <p>Evaluates all providers and compares successful results.
+ */
+public class ComparisonStrategy implements Strategy {
+
+    @Getter
+    private final String fallbackProvider;
+
+    private final BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch;
+
+    /**
+     * Constructs a comparison strategy with a fallback provider.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful providers disagree
+     */
+    public ComparisonStrategy(String fallbackProvider) {
+        this(fallbackProvider, null);
+    }
+
+    /**
+     * Constructs a comparison strategy with fallback provider and mismatch callback.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful providers disagree
+     * @param onMismatch callback invoked with all successful evaluations when they disagree
+     */
+    public ComparisonStrategy(
+            String fallbackProvider,
+            BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch) {
+        this.fallbackProvider = Objects.requireNonNull(fallbackProvider, "fallbackProvider must not be null");
+        this.onMismatch = onMismatch;
+    }
+
+    @Override
+    public <T> ProviderEvaluation<T> evaluate(
+            Map<String, FeatureProvider> providers,
+            String key,
+            T defaultValue,
+            EvaluationContext ctx,
+            Function<FeatureProvider, ProviderEvaluation<T>> providerFunction) {
+        if (providers.isEmpty()) {
+            return ProviderEvaluation.<T>builder()
+                    .errorCode(ErrorCode.GENERAL)
+                    .errorMessage("No providers configured")
+                    .build();
+        }
+        if (!providers.containsKey(fallbackProvider)) {
+            throw new IllegalArgumentException("fallbackProvider not found in providers: " + fallbackProvider);
+        }
+
+        Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(providers.size());
+        Map<String, String> providerErrors = new ConcurrentHashMap<>(providers.size());
+        ExecutorService executorService = Executors.newFixedThreadPool(providers.size());
+        try {
+            List<Callable<Void>> tasks = new ArrayList<>(providers.size());
+            for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
+                String providerName = entry.getKey();
+                FeatureProvider provider = entry.getValue();
+                tasks.add(() -> {
+                    try {
+                        ProviderEvaluation<T> evaluation = providerFunction.apply(provider);
+                        if (evaluation == null) {
+                            providerErrors.put(providerName, "null evaluation");
+                        } else if (evaluation.getErrorCode() == null) {
+                            successfulResults.put(providerName, evaluation);
+                        } else {
+                            providerErrors.put(
+                                    providerName,
+                                    evaluation.getErrorCode() + ": " + String.valueOf(evaluation.getErrorMessage()));
+                        }
+                    } catch (Exception e) {
+                        providerErrors.put(providerName, e.getClass().getSimpleName() + ": " + e.getMessage());
+                    }
+                    return null;
+                });
+            }
+            List<Future<Void>> futures = executorService.invokeAll(tasks);
+            for (Future<Void> future : futures) {
+                future.get();
+            }
+        } catch (Exception e) {
+            return ProviderEvaluation.<T>builder()
+                    .errorCode(ErrorCode.GENERAL)
+                    .errorMessage("Comparison strategy failed: " + e.getMessage())
+                    .build();
+        } finally {
+            executorService.shutdown();
+        }
+
+        if (!providerErrors.isEmpty()) {
+            return ProviderEvaluation.<T>builder()
+                    .errorCode(ErrorCode.GENERAL)
+                    .errorMessage("Provider errors: " + buildErrorSummary(providerErrors))
+                    .build();
+        }
+
+        ProviderEvaluation<T> fallbackResult = successfulResults.get(fallbackProvider);
+        if (fallbackResult == null) {
+            return ProviderEvaluation.<T>builder()
+                    .errorCode(ErrorCode.GENERAL)
+                    .errorMessage("Fallback provider did not return a successful evaluation: " + fallbackProvider)
+                    .build();
+        }
+
+        if (allEvaluationsMatch(successfulResults)) {
+            return fallbackResult;
+        }
+
+        if (onMismatch != null) {
+            Map<String, ProviderEvaluation<?>> mismatchPayload = new LinkedHashMap<>(successfulResults);
+            onMismatch.accept(key, Collections.unmodifiableMap(mismatchPayload));
+        }
+        return fallbackResult;
+    }
+
+    private String buildErrorSummary(Map<String, String> providerErrors) {
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : providerErrors.entrySet()) {
+            if (!first) {
+                builder.append("; ");
+            }
+            first = false;
+            builder.append(entry.getKey()).append(" -> ").append(entry.getValue());
+        }
+        return builder.toString();
+    }
+
+    private <T> boolean allEvaluationsMatch(Map<String, ProviderEvaluation<T>> results) {
+        ProviderEvaluation<T> baseline = null;
+        for (ProviderEvaluation<T> evaluation : results.values()) {
+            if (baseline == null) {
+                baseline = evaluation;
+                continue;
+            }
+            if (!Objects.equals(baseline.getValue(), evaluation.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
@@ -39,7 +39,6 @@ public class ComparisonStrategy implements Strategy {
 
     private final BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch;
     private final ExecutorService executorService;
-    private final boolean ownsExecutorService;
     private final long timeoutMs;
 
     /**
@@ -65,10 +64,8 @@ public class ComparisonStrategy implements Strategy {
      *                         when they disagree
      */
     public ComparisonStrategy(
-            String fallbackProvider,
-            BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch) {
-        this(fallbackProvider, onMismatch, ForkJoinPool.commonPool(),
-                false, DEFAULT_TIMEOUT_MS);
+            String fallbackProvider, BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch) {
+        this(fallbackProvider, onMismatch, ForkJoinPool.commonPool(), DEFAULT_TIMEOUT_MS);
     }
 
     /**
@@ -87,22 +84,9 @@ public class ComparisonStrategy implements Strategy {
             BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch,
             ExecutorService executorService,
             long timeoutMs) {
-        this(fallbackProvider, onMismatch, executorService,
-                false, timeoutMs);
-    }
-
-    private ComparisonStrategy(
-            String fallbackProvider,
-            BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch,
-            ExecutorService executorService,
-            boolean ownsExecutorService,
-            long timeoutMs) {
-        this.fallbackProvider = Objects.requireNonNull(
-                fallbackProvider, "fallbackProvider must not be null");
+        this.fallbackProvider = Objects.requireNonNull(fallbackProvider, "fallbackProvider must not be null");
         this.onMismatch = onMismatch;
-        this.executorService = Objects.requireNonNull(
-                executorService, "executorService must not be null");
-        this.ownsExecutorService = ownsExecutorService;
+        this.executorService = Objects.requireNonNull(executorService, "executorService must not be null");
         this.timeoutMs = timeoutMs;
     }
 
@@ -120,85 +104,69 @@ public class ComparisonStrategy implements Strategy {
                     .build();
         }
         if (!providers.containsKey(fallbackProvider)) {
-            throw new IllegalArgumentException(
-                    "fallbackProvider not found in providers: "
-                            + fallbackProvider);
+            throw new IllegalArgumentException("fallbackProvider not found in providers: " + fallbackProvider);
         }
 
-        Map<String, ProviderEvaluation<T>> successfulResults =
-                new ConcurrentHashMap<>(providers.size());
-        Map<String, String> providerErrors =
-                new ConcurrentHashMap<>(providers.size());
+        Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(providers.size());
+        Map<String, String> providerErrors = new ConcurrentHashMap<>(providers.size());
 
         try {
             List<Callable<Void>> tasks = new ArrayList<>(providers.size());
-            for (Map.Entry<String, FeatureProvider> entry
-                    : providers.entrySet()) {
+            for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
                 String providerName = entry.getKey();
                 FeatureProvider provider = entry.getValue();
                 tasks.add(() -> {
                     try {
-                        ProviderEvaluation<T> evaluation =
-                                providerFunction.apply(provider);
+                        ProviderEvaluation<T> evaluation = providerFunction.apply(provider);
                         if (evaluation == null) {
-                            providerErrors.put(
-                                    providerName, "null evaluation");
+                            providerErrors.put(providerName, "null evaluation");
                         } else if (evaluation.getErrorCode() == null) {
-                            successfulResults.put(
-                                    providerName, evaluation);
+                            successfulResults.put(providerName, evaluation);
                         } else {
                             providerErrors.put(
-                                    providerName,
-                                    evaluation.getErrorCode() + ": "
-                                            + evaluation.getErrorMessage());
+                                    providerName, evaluation.getErrorCode() + ": " + evaluation.getErrorMessage());
                         }
                     } catch (Exception e) {
-                        providerErrors.put(
-                                providerName,
-                                e.getClass().getSimpleName() + ": "
-                                        + e.getMessage());
+                        providerErrors.put(providerName, e.getClass().getSimpleName() + ": " + e.getMessage());
                     }
                     return null;
                 });
             }
-            List<Future<Void>> futures =
-                    executorService.invokeAll(
-                            tasks, timeoutMs, TimeUnit.MILLISECONDS);
+            List<Future<Void>> futures = executorService.invokeAll(tasks, timeoutMs, TimeUnit.MILLISECONDS);
             for (Future<Void> future : futures) {
                 if (future.isCancelled()) {
                     return ProviderEvaluation.<T>builder()
                             .errorCode(ErrorCode.GENERAL)
-                            .errorMessage(
-                                    "Comparison strategy timed out after "
-                                            + timeoutMs + "ms")
+                            .errorMessage("Comparison strategy timed out after " + timeoutMs + "ms")
                             .build();
                 }
                 future.get();
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return ProviderEvaluation.<T>builder()
+                    .errorCode(ErrorCode.GENERAL)
+                    .errorMessage("Comparison strategy interrupted: " + e.getMessage())
+                    .build();
         } catch (Exception e) {
             return ProviderEvaluation.<T>builder()
                     .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Comparison strategy failed: "
-                            + e.getMessage())
+                    .errorMessage("Comparison strategy failed: " + e.getMessage())
                     .build();
         }
 
         if (!providerErrors.isEmpty()) {
             return ProviderEvaluation.<T>builder()
                     .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Provider errors: "
-                            + buildErrorSummary(providerErrors))
+                    .errorMessage("Provider errors: " + buildErrorSummary(providerErrors))
                     .build();
         }
 
-        ProviderEvaluation<T> fallbackResult =
-                successfulResults.get(fallbackProvider);
+        ProviderEvaluation<T> fallbackResult = successfulResults.get(fallbackProvider);
         if (fallbackResult == null) {
             return ProviderEvaluation.<T>builder()
                     .errorCode(ErrorCode.GENERAL)
-                    .errorMessage(
-                            "Fallback provider did not return a successful "
-                                    + "evaluation: " + fallbackProvider)
+                    .errorMessage("Fallback provider did not return a successful " + "evaluation: " + fallbackProvider)
                     .build();
         }
 
@@ -207,10 +175,8 @@ public class ComparisonStrategy implements Strategy {
         }
 
         if (onMismatch != null) {
-            Map<String, ProviderEvaluation<?>> mismatchPayload =
-                    new LinkedHashMap<>(successfulResults);
-            onMismatch.accept(
-                    key, Collections.unmodifiableMap(mismatchPayload));
+            Map<String, ProviderEvaluation<?>> mismatchPayload = new LinkedHashMap<>(successfulResults);
+            onMismatch.accept(key, Collections.unmodifiableMap(mismatchPayload));
         }
         return fallbackResult;
     }
@@ -223,23 +189,19 @@ public class ComparisonStrategy implements Strategy {
                 builder.append("; ");
             }
             first = false;
-            builder.append(entry.getKey())
-                    .append(" -> ")
-                    .append(entry.getValue());
+            builder.append(entry.getKey()).append(" -> ").append(entry.getValue());
         }
         return builder.toString();
     }
 
-    private <T> boolean allEvaluationsMatch(
-            Map<String, ProviderEvaluation<T>> results) {
+    private <T> boolean allEvaluationsMatch(Map<String, ProviderEvaluation<T>> results) {
         ProviderEvaluation<T> baseline = null;
         for (ProviderEvaluation<T> evaluation : results.values()) {
             if (baseline == null) {
                 baseline = evaluation;
                 continue;
             }
-            if (!Objects.equals(
-                    baseline.getValue(), evaluation.getValue())) {
+            if (!Objects.equals(baseline.getValue(), evaluation.getValue())) {
                 return false;
             }
         }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 /**
@@ -107,8 +108,9 @@ public class ComparisonStrategy implements Strategy {
             throw new IllegalArgumentException("fallbackProvider not found in providers: " + fallbackProvider);
         }
 
-        Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(providers.size());
-        Map<String, String> providerErrors = new ConcurrentHashMap<>(providers.size());
+        int capacity = providers.size() * 4 / 3 + 1;
+        Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(capacity);
+        Map<String, String> providerErrors = new ConcurrentHashMap<>(capacity);
 
         try {
             List<Callable<Void>> tasks = new ArrayList<>(providers.size());
@@ -166,7 +168,7 @@ public class ComparisonStrategy implements Strategy {
         if (fallbackResult == null) {
             return ProviderEvaluation.<T>builder()
                     .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Fallback provider did not return a successful " + "evaluation: " + fallbackProvider)
+                    .errorMessage("Fallback provider did not return a successful evaluation: " + fallbackProvider)
                     .build();
         }
 
@@ -181,17 +183,10 @@ public class ComparisonStrategy implements Strategy {
         return fallbackResult;
     }
 
-    private String buildErrorSummary(Map<String, String> providerErrors) {
-        StringBuilder builder = new StringBuilder();
-        boolean first = true;
-        for (Map.Entry<String, String> entry : providerErrors.entrySet()) {
-            if (!first) {
-                builder.append("; ");
-            }
-            first = false;
-            builder.append(entry.getKey()).append(" -> ").append(entry.getValue());
-        }
-        return builder.toString();
+    private String buildErrorSummary(Map<String, String> errors) {
+        return errors.entrySet().stream()
+                .map(e -> e.getKey() + " -> " + e.getValue())
+                .collect(Collectors.joining("; "));
     }
 
     private <T> boolean allEvaluationsMatch(Map<String, ProviderEvaluation<T>> results) {

--- a/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.Getter;
 
 /**
@@ -28,8 +27,8 @@ import lombok.Getter;
  * If all providers agree on the value, the fallback provider's result is returned.
  * If providers disagree, the optional {@code onMismatch} callback is invoked
  * and the fallback provider's result is returned.
- * If any provider returns an error, all errors are collected and a
- * {@link ErrorCode#GENERAL} error is returned.
+ * If any provider returns an error, all errors are collected and a {@link MultiProviderEvaluation}
+ * with {@link ErrorCode#GENERAL} and per-provider {@link ProviderError} details is returned.
  */
 public class ComparisonStrategy implements Strategy {
 
@@ -110,7 +109,7 @@ public class ComparisonStrategy implements Strategy {
 
         int capacity = providers.size() * 4 / 3 + 1;
         Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(capacity);
-        Map<String, String> providerErrors = new ConcurrentHashMap<>(capacity);
+        Map<String, ProviderError> providerErrors = new ConcurrentHashMap<>(capacity);
 
         try {
             List<Callable<Void>> tasks = new ArrayList<>(providers.size());
@@ -121,15 +120,19 @@ public class ComparisonStrategy implements Strategy {
                     try {
                         ProviderEvaluation<T> evaluation = providerFunction.apply(provider);
                         if (evaluation == null) {
-                            providerErrors.put(providerName, "null evaluation");
+                            providerErrors.put(
+                                    providerName,
+                                    ProviderError.fromResult(providerName, ErrorCode.GENERAL, "null evaluation"));
                         } else if (evaluation.getErrorCode() == null) {
                             successfulResults.put(providerName, evaluation);
                         } else {
                             providerErrors.put(
-                                    providerName, evaluation.getErrorCode() + ": " + evaluation.getErrorMessage());
+                                    providerName,
+                                    ProviderError.fromResult(
+                                            providerName, evaluation.getErrorCode(), evaluation.getErrorMessage()));
                         }
                     } catch (Exception e) {
-                        providerErrors.put(providerName, e.getClass().getSimpleName() + ": " + e.getMessage());
+                        providerErrors.put(providerName, ProviderError.fromException(providerName, e));
                     }
                     return null;
                 });
@@ -137,39 +140,28 @@ public class ComparisonStrategy implements Strategy {
             List<Future<Void>> futures = executorService.invokeAll(tasks, timeoutMs, TimeUnit.MILLISECONDS);
             for (Future<Void> future : futures) {
                 if (future.isCancelled()) {
-                    return ProviderEvaluation.<T>builder()
-                            .errorCode(ErrorCode.GENERAL)
-                            .errorMessage("Comparison strategy timed out after " + timeoutMs + "ms")
-                            .build();
+                    return errorResult(
+                            "Comparison strategy timed out after " + timeoutMs + "ms", providers, providerErrors);
                 }
                 future.get();
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            return ProviderEvaluation.<T>builder()
-                    .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Comparison strategy interrupted: " + e.getMessage())
-                    .build();
+            return errorResult("Comparison strategy interrupted: " + e.getMessage(), providers, providerErrors);
         } catch (Exception e) {
-            return ProviderEvaluation.<T>builder()
-                    .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Comparison strategy failed: " + e.getMessage())
-                    .build();
+            return errorResult("Comparison strategy failed: " + e.getMessage(), providers, providerErrors);
         }
 
         if (!providerErrors.isEmpty()) {
-            return ProviderEvaluation.<T>builder()
-                    .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Provider errors: " + buildErrorSummary(providerErrors))
-                    .build();
+            return errorResult("Provider errors during comparison", providers, providerErrors);
         }
 
         ProviderEvaluation<T> fallbackResult = successfulResults.get(fallbackProvider);
         if (fallbackResult == null) {
-            return ProviderEvaluation.<T>builder()
-                    .errorCode(ErrorCode.GENERAL)
-                    .errorMessage("Fallback provider did not return a successful evaluation: " + fallbackProvider)
-                    .build();
+            return errorResult(
+                    "Fallback provider did not return a successful evaluation: " + fallbackProvider,
+                    providers,
+                    providerErrors);
         }
 
         if (allEvaluationsMatch(successfulResults)) {
@@ -177,16 +169,42 @@ public class ComparisonStrategy implements Strategy {
         }
 
         if (onMismatch != null) {
-            Map<String, ProviderEvaluation<?>> mismatchPayload = new LinkedHashMap<>(successfulResults);
-            onMismatch.accept(key, Collections.unmodifiableMap(mismatchPayload));
+            onMismatch.accept(key, orderedResults(providers, successfulResults));
         }
         return fallbackResult;
     }
 
-    private String buildErrorSummary(Map<String, String> errors) {
-        return errors.entrySet().stream()
-                .map(e -> e.getKey() + " -> " + e.getValue())
-                .collect(Collectors.joining("; "));
+    /**
+     * Builds a {@link MultiProviderEvaluation} carrying per-provider error details, ordered by the
+     * provider registration order so the aggregate message is stable across runs.
+     */
+    private <T> ProviderEvaluation<T> errorResult(
+            String baseMessage, Map<String, FeatureProvider> providers, Map<String, ProviderError> providerErrors) {
+        List<ProviderError> orderedErrors = new ArrayList<>(providerErrors.size());
+        for (String providerName : providers.keySet()) {
+            ProviderError error = providerErrors.get(providerName);
+            if (error != null) {
+                orderedErrors.add(error);
+            }
+        }
+        return MultiProviderEvaluation.<T>builder()
+                .errorCode(ErrorCode.GENERAL)
+                .errorMessage(ProviderError.buildAggregateMessage(baseMessage, orderedErrors))
+                .providerErrors(orderedErrors)
+                .build();
+    }
+
+    /** Returns the successful evaluations in provider registration order. */
+    private <T> Map<String, ProviderEvaluation<?>> orderedResults(
+            Map<String, FeatureProvider> providers, Map<String, ProviderEvaluation<T>> successfulResults) {
+        Map<String, ProviderEvaluation<?>> ordered = new LinkedHashMap<>();
+        for (String providerName : providers.keySet()) {
+            ProviderEvaluation<T> evaluation = successfulResults.get(providerName);
+            if (evaluation != null) {
+                ordered.put(providerName, evaluation);
+            }
+        }
+        return Collections.unmodifiableMap(ordered);
     }
 
     private <T> boolean allEvaluationsMatch(Map<String, ProviderEvaluation<T>> results) {

--- a/src/main/java/dev/openfeature/sdk/multiprovider/HookExecutionContext.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/HookExecutionContext.java
@@ -1,0 +1,15 @@
+package dev.openfeature.sdk.multiprovider;
+
+import dev.openfeature.sdk.ClientMetadata;
+import java.util.Map;
+
+/** Captures hook lifecycle context (client metadata and hints) for per-provider hook execution. */
+final class HookExecutionContext {
+    final ClientMetadata clientMetadata;
+    final Map<String, Object> hints;
+
+    HookExecutionContext(ClientMetadata clientMetadata, Map<String, Object> hints) {
+        this.clientMetadata = clientMetadata;
+        this.hints = hints;
+    }
+}

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -1,11 +1,26 @@
 package dev.openfeature.sdk.multiprovider;
 
+import dev.openfeature.sdk.ClientMetadata;
+import dev.openfeature.sdk.DefaultHookData;
+import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.FlagValueType;
+import dev.openfeature.sdk.Hook;
+import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.HookData;
+import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.ProviderEvent;
+import dev.openfeature.sdk.ProviderEventDetails;
+import dev.openfeature.sdk.ProviderState;
+import dev.openfeature.sdk.TrackingEventDetails;
 import dev.openfeature.sdk.Value;
+import dev.openfeature.sdk.exceptions.ExceptionUtils;
+import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -16,9 +31,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,6 +58,12 @@ public class MultiProvider extends EventProvider {
 
     private final Map<String, FeatureProvider> providers;
     private final Strategy strategy;
+    private final Map<String, ProviderState> providerStates = new ConcurrentHashMap<>();
+    private final Map<String, BiConsumer<ProviderEvent, ProviderEventDetails>> providerEventObservers =
+            new ConcurrentHashMap<>();
+    private final ClientMetadata hookClientMetadata = MultiProvider::getNAME;
+    private final Map<String, Object> emptyHookHints = Collections.emptyMap();
+    private ProviderState aggregateState;
     private MultiProviderMetadata metadata;
 
     /**
@@ -61,18 +85,59 @@ public class MultiProvider extends EventProvider {
     public MultiProvider(List<FeatureProvider> providers, Strategy strategy) {
         this.providers = buildProviders(providers);
         this.strategy = Objects.requireNonNull(strategy, "strategy must not be null");
+        initializeProviderStates();
+        this.aggregateState = determineAggregateState();
     }
 
     protected static Map<String, FeatureProvider> buildProviders(List<FeatureProvider> providers) {
+        Objects.requireNonNull(providers, "providers must not be null");
         Map<String, FeatureProvider> providersMap = new LinkedHashMap<>(providers.size());
+        Map<String, Integer> suffixesByBaseName = new HashMap<>(providers.size());
         for (FeatureProvider provider : providers) {
-            FeatureProvider prevProvider =
-                    providersMap.put(provider.getMetadata().getName(), provider);
-            if (prevProvider != null) {
-                log.info("duplicated provider name: {}", provider.getMetadata().getName());
+            Objects.requireNonNull(provider, "provider must not be null");
+            String baseName = getProviderBaseName(provider);
+            String resolvedName = resolveUniqueProviderName(baseName, providersMap, suffixesByBaseName);
+            if (!baseName.equals(resolvedName)) {
+                log.info("deduplicated provider name from {} to {}", baseName, resolvedName);
             }
+            providersMap.put(resolvedName, provider);
         }
         return Collections.unmodifiableMap(providersMap);
+    }
+
+    private static String getProviderBaseName(FeatureProvider provider) {
+        Metadata providerMetadata = provider.getMetadata();
+        if (providerMetadata == null || providerMetadata.getName() == null || providerMetadata.getName().isEmpty()) {
+            return "provider";
+        }
+        return providerMetadata.getName();
+    }
+
+    private static String resolveUniqueProviderName(
+            String baseName,
+            Map<String, FeatureProvider> providersMap,
+            Map<String, Integer> suffixesByBaseName) {
+        if (!providersMap.containsKey(baseName)) {
+            suffixesByBaseName.putIfAbsent(baseName, 1);
+            return baseName;
+        }
+        int suffix = suffixesByBaseName.getOrDefault(baseName, 1);
+        String resolvedName = baseName + "-" + suffix;
+        while (providersMap.containsKey(resolvedName)) {
+            suffix++;
+            resolvedName = baseName + "-" + suffix;
+        }
+        suffixesByBaseName.put(baseName, suffix + 1);
+        return resolvedName;
+    }
+
+    private void initializeProviderStates() {
+        providerStates.clear();
+        if (!providers.isEmpty()) {
+            for (String providerName : providers.keySet()) {
+                providerStates.put(providerName, ProviderState.NOT_READY);
+            }
+        }
     }
 
     /**
@@ -95,7 +160,11 @@ public class MultiProvider extends EventProvider {
     @Override
     public void initialize(EvaluationContext evaluationContext, String domain) throws Exception {
         var metadataBuilder = MultiProviderMetadata.builder().name(NAME);
-        HashMap<String, Metadata> providersMetadata = new HashMap<>();
+        Map<String, Metadata> providersMetadata = new LinkedHashMap<>();
+        initializeProviderStates();
+        synchronized (this) {
+            emitAggregateStateChange(determineAggregateState(), ProviderEventDetails.builder().build());
+        }
 
         if (providers.isEmpty()) {
             metadataBuilder.originalMetadata(Collections.unmodifiableMap(providersMetadata));
@@ -106,13 +175,22 @@ public class MultiProvider extends EventProvider {
         ExecutorService executorService = Executors.newFixedThreadPool(Math.min(INIT_THREADS_COUNT, providers.size()));
         try {
             Collection<Callable<Void>> tasks = new ArrayList<>(providers.size());
-            for (FeatureProvider provider : providers.values()) {
+            for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
+                String providerName = entry.getKey();
+                FeatureProvider provider = entry.getValue();
+                registerChildProviderObserver(providerName, provider);
                 tasks.add(() -> {
-                    provider.initialize(evaluationContext, domain);
-                    return null;
+                    try {
+                        provider.initialize(evaluationContext, domain);
+                        setProviderState(providerName, ProviderState.READY, ProviderEventDetails.builder().build());
+                        return null;
+                    } catch (Exception e) {
+                        setProviderState(providerName, toStateFromException(e), providerErrorDetails(e));
+                        throw e;
+                    }
                 });
                 Metadata providerMetadata = provider.getMetadata();
-                providersMetadata.put(providerMetadata.getName(), providerMetadata);
+                providersMetadata.put(providerName, providerMetadata);
             }
 
             metadataBuilder.originalMetadata(Collections.unmodifiableMap(providersMetadata));
@@ -148,42 +226,470 @@ public class MultiProvider extends EventProvider {
     @Override
     public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
         return strategy.evaluate(
-                providers, key, defaultValue, ctx, p -> p.getBooleanEvaluation(key, defaultValue, ctx));
+                providers,
+                key,
+                defaultValue,
+                ctx,
+                provider -> evaluateWithProviderHooks(
+                        provider,
+                        key,
+                        defaultValue,
+                        ctx,
+                        FlagValueType.BOOLEAN,
+                        (p, evaluationContext) -> p.getBooleanEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
-        return strategy.evaluate(providers, key, defaultValue, ctx, p -> p.getStringEvaluation(key, defaultValue, ctx));
+        return strategy.evaluate(
+                providers,
+                key,
+                defaultValue,
+                ctx,
+                provider -> evaluateWithProviderHooks(
+                        provider,
+                        key,
+                        defaultValue,
+                        ctx,
+                        FlagValueType.STRING,
+                        (p, evaluationContext) -> p.getStringEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
         return strategy.evaluate(
-                providers, key, defaultValue, ctx, p -> p.getIntegerEvaluation(key, defaultValue, ctx));
+                providers,
+                key,
+                defaultValue,
+                ctx,
+                provider -> evaluateWithProviderHooks(
+                        provider,
+                        key,
+                        defaultValue,
+                        ctx,
+                        FlagValueType.INTEGER,
+                        (p, evaluationContext) -> p.getIntegerEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
-        return strategy.evaluate(providers, key, defaultValue, ctx, p -> p.getDoubleEvaluation(key, defaultValue, ctx));
+        return strategy.evaluate(
+                providers,
+                key,
+                defaultValue,
+                ctx,
+                provider -> evaluateWithProviderHooks(
+                        provider,
+                        key,
+                        defaultValue,
+                        ctx,
+                        FlagValueType.DOUBLE,
+                        (p, evaluationContext) -> p.getDoubleEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
-        return strategy.evaluate(providers, key, defaultValue, ctx, p -> p.getObjectEvaluation(key, defaultValue, ctx));
+        return strategy.evaluate(
+                providers,
+                key,
+                defaultValue,
+                ctx,
+                provider -> evaluateWithProviderHooks(
+                        provider,
+                        key,
+                        defaultValue,
+                        ctx,
+                        FlagValueType.OBJECT,
+                        (p, evaluationContext) -> p.getObjectEvaluation(key, defaultValue, evaluationContext)));
+    }
+
+    @Override
+    public void track(String eventName, EvaluationContext context, TrackingEventDetails details) {
+        for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
+            String providerName = entry.getKey();
+            FeatureProvider provider = entry.getValue();
+            if (!shouldTrackProvider(providerName)) {
+                continue;
+            }
+            try {
+                provider.track(eventName, context, details);
+            } catch (Exception e) {
+                log.error("error forwarding track to provider {}", providerName, e);
+            }
+        }
     }
 
     @Override
     public void shutdown() {
         log.debug("shutdown begin");
-        for (FeatureProvider provider : providers.values()) {
+        for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
+            String providerName = entry.getKey();
+            FeatureProvider provider = entry.getValue();
             try {
+                unregisterChildProviderObserver(providerName, provider);
                 provider.shutdown();
             } catch (Exception e) {
-                log.error("error shutdown provider {}", provider.getMetadata().getName(), e);
+                log.error("error shutdown provider {}", providerName, e);
             }
         }
+        synchronized (this) {
+            initializeProviderStates();
+            emitAggregateStateChange(ProviderState.NOT_READY, ProviderEventDetails.builder().build());
+        }
         log.debug("shutdown end");
-        // Important: ensure EventProvider's executor is also shut down
         super.shutdown();
+    }
+
+    private void registerChildProviderObserver(String providerName, FeatureProvider provider) {
+        if (provider instanceof EventProvider) {
+            BiConsumer<ProviderEvent, ProviderEventDetails> observer =
+                    (event, details) -> onChildProviderEvent(providerName, event, details);
+            ((EventProvider) provider).addEventObserver(observer);
+            providerEventObservers.put(providerName, observer);
+        }
+    }
+
+    private void unregisterChildProviderObserver(String providerName, FeatureProvider provider) {
+        if (provider instanceof EventProvider) {
+            BiConsumer<ProviderEvent, ProviderEventDetails> observer = providerEventObservers.remove(providerName);
+            if (observer != null) {
+                ((EventProvider) provider).removeEventObserver(observer);
+            }
+        }
+    }
+
+    private void onChildProviderEvent(String providerName, ProviderEvent event, ProviderEventDetails details) {
+        if (ProviderEvent.PROVIDER_CONFIGURATION_CHANGED.equals(event)) {
+            emitProviderConfigurationChanged(details);
+            return;
+        }
+        ProviderState state = toStateFromEvent(event, details);
+        if (state != null) {
+            setProviderState(providerName, state, details);
+        }
+    }
+
+    private synchronized void setProviderState(
+            String providerName,
+            ProviderState providerState,
+            ProviderEventDetails details) {
+        providerStates.put(providerName, providerState);
+        ProviderState aggregate = determineAggregateState();
+        emitAggregateStateChange(aggregate, details);
+    }
+
+    private void emitAggregateStateChange(ProviderState aggregate, ProviderEventDetails details) {
+        ProviderState previous = aggregateState;
+        if (previous == aggregate) {
+            return;
+        }
+        aggregateState = aggregate;
+        switch (aggregate) {
+            case READY:
+                emitProviderReady(detailsOrEmpty(details));
+                break;
+            case STALE:
+                emitProviderStale(detailsOrEmpty(details));
+                break;
+            case ERROR:
+                emitProviderError(ensureErrorDetails(details, ErrorCode.GENERAL));
+                break;
+            case FATAL:
+                emitProviderError(ensureErrorDetails(details, ErrorCode.PROVIDER_FATAL));
+                break;
+            case NOT_READY:
+                break;
+            default:
+                break;
+        }
+    }
+
+    private ProviderState determineAggregateState() {
+        if (providerStates.isEmpty()) {
+            return ProviderState.READY;
+        }
+        ProviderState aggregate = ProviderState.READY;
+        for (ProviderState state : providerStates.values()) {
+            if (stateSeverity(state) > stateSeverity(aggregate)) {
+                aggregate = state;
+            }
+        }
+        return aggregate;
+    }
+
+    private int stateSeverity(ProviderState state) {
+        if (state == null) {
+            return 0;
+        }
+        switch (state) {
+            case FATAL:
+                return 5;
+            case NOT_READY:
+                return 4;
+            case ERROR:
+                return 3;
+            case STALE:
+                return 2;
+            case READY:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+
+    private ProviderEventDetails detailsOrEmpty(ProviderEventDetails details) {
+        if (details == null) {
+            return ProviderEventDetails.builder().build();
+        }
+        return details;
+    }
+
+    private ProviderEventDetails ensureErrorDetails(ProviderEventDetails details, ErrorCode defaultErrorCode) {
+        if (details == null) {
+            return ProviderEventDetails.builder().errorCode(defaultErrorCode).build();
+        }
+        if (details.getErrorCode() == null) {
+            return details.toBuilder().errorCode(defaultErrorCode).build();
+        }
+        return details;
+    }
+
+    private ProviderState toStateFromEvent(ProviderEvent event, ProviderEventDetails details) {
+        if (ProviderEvent.PROVIDER_READY.equals(event)) {
+            return ProviderState.READY;
+        }
+        if (ProviderEvent.PROVIDER_STALE.equals(event)) {
+            return ProviderState.STALE;
+        }
+        if (ProviderEvent.PROVIDER_ERROR.equals(event)) {
+            if (details != null && ErrorCode.PROVIDER_FATAL.equals(details.getErrorCode())) {
+                return ProviderState.FATAL;
+            }
+            return ProviderState.ERROR;
+        }
+        return null;
+    }
+
+    private ProviderState toStateFromException(Exception exception) {
+        if (exception instanceof OpenFeatureError
+                && ErrorCode.PROVIDER_FATAL.equals(((OpenFeatureError) exception).getErrorCode())) {
+            return ProviderState.FATAL;
+        }
+        return ProviderState.ERROR;
+    }
+
+    private ProviderEventDetails providerErrorDetails(Exception exception) {
+        if (exception instanceof OpenFeatureError) {
+            ErrorCode errorCode = ((OpenFeatureError) exception).getErrorCode();
+            return ProviderEventDetails.builder()
+                    .errorCode(errorCode)
+                    .message(exception.getMessage())
+                    .build();
+        }
+        return ProviderEventDetails.builder()
+                .errorCode(ErrorCode.GENERAL)
+                .message(exception.getMessage())
+                .build();
+    }
+
+    private boolean shouldTrackProvider(String providerName) {
+        ProviderState providerState = providerStates.getOrDefault(providerName, ProviderState.READY);
+        return !ProviderState.NOT_READY.equals(providerState) && !ProviderState.FATAL.equals(providerState);
+    }
+
+    private EvaluationContext copyEvaluationContext(EvaluationContext context) {
+        if (context == null) {
+            return ImmutableContext.EMPTY;
+        }
+        String targetingKey = context.getTargetingKey();
+        if (targetingKey == null) {
+            return new ImmutableContext(context.asMap());
+        }
+        return new ImmutableContext(targetingKey, context.asMap());
+    }
+
+    private EvaluationContext toProviderContext(EvaluationContext originalContext, EvaluationContext evaluatedContext) {
+        if (originalContext == null && (evaluatedContext == null || evaluatedContext.isEmpty())) {
+            return null;
+        }
+        return evaluatedContext;
+    }
+
+    private Exception toEvaluationException(ProviderEvaluation<?> providerEvaluation) {
+        if (providerEvaluation == null || providerEvaluation.getErrorCode() == null) {
+            return new RuntimeException("Provider evaluation returned an error");
+        }
+        return ExceptionUtils.instantiateErrorByErrorCode(
+                providerEvaluation.getErrorCode(),
+                providerEvaluation.getErrorMessage());
+    }
+
+    private <T> HookContext<T> createHookContext(
+            String key,
+            FlagValueType valueType,
+            T defaultValue,
+            EvaluationContext evaluationContext,
+            FeatureProvider provider,
+            HookData hookData) {
+        return HookContext.<T>builder()
+                .flagKey(key)
+                .type(valueType)
+                .defaultValue(normalizeDefaultValue(valueType, defaultValue))
+                .ctx(evaluationContext)
+                .clientMetadata(hookClientMetadata)
+                .providerMetadata(provider.getMetadata())
+                .hookData(hookData)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T normalizeDefaultValue(FlagValueType valueType, T defaultValue) {
+        if (defaultValue != null) {
+            return defaultValue;
+        }
+        switch (valueType) {
+            case BOOLEAN:
+                return (T) Boolean.FALSE;
+            case STRING:
+                return (T) "";
+            case INTEGER:
+                return (T) Integer.valueOf(0);
+            case DOUBLE:
+                return (T) Double.valueOf(0d);
+            case OBJECT:
+                return (T) new Value();
+            default:
+                return defaultValue;
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private <T> ProviderEvaluation<T> evaluateWithProviderHooks(
+            FeatureProvider provider,
+            String key,
+            T defaultValue,
+            EvaluationContext ctx,
+            FlagValueType valueType,
+            BiFunction<FeatureProvider, EvaluationContext, ProviderEvaluation<T>> providerFunction) {
+        List<Hook> providerHooks = provider.getProviderHooks();
+        if (providerHooks == null || providerHooks.isEmpty()) {
+            return providerFunction.apply(provider, ctx);
+        }
+
+        List<HookExecution<T>> hooks = new ArrayList<>(providerHooks.size());
+        for (Hook hook : providerHooks) {
+            if (hook.supportsFlagValueType(valueType)) {
+                hooks.add(new HookExecution<>(hook, new DefaultHookData()));
+            }
+        }
+
+        if (hooks.isEmpty()) {
+            return providerFunction.apply(provider, ctx);
+        }
+
+        EvaluationContext evaluatedContext = copyEvaluationContext(ctx);
+        ProviderEvaluation<T> providerEvaluation = null;
+        FlagEvaluationDetails<T> details = null;
+
+        try {
+            for (int i = hooks.size() - 1; i >= 0; i--) {
+                HookExecution<T> execution = hooks.get(i);
+                HookContext<T> hookContext =
+                        createHookContext(key, valueType, defaultValue, evaluatedContext, provider, execution.hookData);
+                var contextUpdate = execution.hook.before(hookContext, emptyHookHints);
+                if (contextUpdate != null
+                        && contextUpdate.isPresent()
+                        && contextUpdate.get() != hookContext.getCtx()
+                        && !contextUpdate.get().isEmpty()) {
+                    evaluatedContext = evaluatedContext.merge(contextUpdate.get());
+                }
+            }
+
+            providerEvaluation = providerFunction.apply(provider, toProviderContext(ctx, evaluatedContext));
+            details = FlagEvaluationDetails.from(providerEvaluation, key);
+
+            if (providerEvaluation.getErrorCode() == null) {
+                for (HookExecution<T> execution : hooks) {
+                    execution.hook.after(
+                            createHookContext(
+                                    key,
+                                    valueType,
+                                    defaultValue,
+                                    evaluatedContext,
+                                    provider,
+                                    execution.hookData),
+                            details,
+                            emptyHookHints);
+                }
+            } else {
+                Exception providerException = toEvaluationException(providerEvaluation);
+                for (HookExecution<T> execution : hooks) {
+                    try {
+                        execution.hook.error(
+                                createHookContext(
+                                        key,
+                                        valueType,
+                                        defaultValue,
+                                        evaluatedContext,
+                                        provider,
+                                        execution.hookData),
+                                providerException,
+                                emptyHookHints);
+                    } catch (Exception e) {
+                        log.error("error executing provider hook error stage", e);
+                    }
+                }
+            }
+
+            return providerEvaluation;
+        } catch (Exception e) {
+            for (HookExecution<T> execution : hooks) {
+                try {
+                    execution.hook.error(
+                            createHookContext(
+                                    key,
+                                    valueType,
+                                    defaultValue,
+                                    evaluatedContext,
+                                    provider,
+                                    execution.hookData),
+                            e,
+                            emptyHookHints);
+                } catch (Exception hookError) {
+                    log.error("error executing provider hook error stage", hookError);
+                }
+            }
+            throw e;
+        } finally {
+            FlagEvaluationDetails<T> finalDetails = details == null
+                    ? FlagEvaluationDetails.<T>builder().flagKey(key).value(defaultValue).build()
+                    : details;
+            for (HookExecution<T> execution : hooks) {
+                try {
+                    execution.hook.finallyAfter(
+                            createHookContext(
+                                    key,
+                                    valueType,
+                                    defaultValue,
+                                    evaluatedContext,
+                                    provider,
+                                    execution.hookData),
+                            finalDetails,
+                            emptyHookHints);
+                } catch (Exception e) {
+                    log.error("error executing provider hook finally stage", e);
+                }
+            }
+        }
+    }
+
+    private static final class HookExecution<T> {
+        private final Hook<T> hook;
+        private final HookData hookData;
+
+        private HookExecution(Hook<T> hook, HookData hookData) {
+            this.hook = hook;
+            this.hookData = hookData;
+        }
     }
 }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -86,6 +86,21 @@ public class MultiProvider extends EventProvider {
         this.aggregateState = determineAggregateState();
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private final List<Hook> providerHooks = List.of(new Hook() {
+        @Override
+        public Optional before(HookContext ctx, Map hints) {
+            hookExecutionContextThreadLocal.set(
+                    new HookExecutionContext(ctx.getClientMetadata(), snapshotHints(hints)));
+            return Optional.empty();
+        }
+
+        @Override
+        public void finallyAfter(HookContext ctx, FlagEvaluationDetails details, Map hints) {
+            hookExecutionContextThreadLocal.remove();
+        }
+    });
+
     /**
      * Returns provider-level hooks for this MultiProvider.
      *
@@ -96,24 +111,22 @@ public class MultiProvider extends EventProvider {
      *
      * @return the list of provider hooks
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private final List<Hook> providerHooks = List.of(new Hook() {
-        @Override
-        public Optional before(HookContext ctx, Map hints) {
-            hookExecutionContextThreadLocal.set(
-                    new HookExecutionContext(ctx.getClientMetadata(), hints != null ? hints : Collections.emptyMap()));
-            return Optional.empty();
-        }
-
-        @Override
-        public void finallyAfter(HookContext ctx, FlagEvaluationDetails details, Map hints) {
-            hookExecutionContextThreadLocal.remove();
-        }
-    });
-
     @Override
     public List<Hook> getProviderHooks() {
         return providerHooks;
+    }
+
+    /**
+     * Defensively copies the hook hints. {@code FlagEvaluationOptions.hookHints} is backed by a
+     * mutable map, and the captured hints may be read from other threads when a strategy evaluates
+     * providers in parallel. A plain copy (rather than {@code Map.copyOf}) is used so that hints
+     * containing null values are still supported.
+     */
+    private static Map<String, Object> snapshotHints(Map<String, Object> hints) {
+        if (hints == null || hints.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(new HashMap<>(hints));
     }
 
     protected static Map<String, FeatureProvider> buildProviders(List<FeatureProvider> providers) {

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -63,8 +63,7 @@ public class MultiProvider extends EventProvider {
     private final Map<String, ProviderState> providerStates = new ConcurrentHashMap<>();
     private final Map<String, BiConsumer<ProviderEvent, ProviderEventDetails>> providerEventObservers =
             new ConcurrentHashMap<>();
-    private final ThreadLocal<HookExecutionContext> hookExecutionContextThreadLocal =
-            new ThreadLocal<>();
+    private final ThreadLocal<HookExecutionContext> hookExecutionContextThreadLocal = new ThreadLocal<>();
     private final ClientMetadata hookClientMetadata = MultiProvider::getNAME;
     private final Map<String, Object> emptyHookHints = Collections.emptyMap();
     private ProviderState aggregateState;
@@ -110,15 +109,12 @@ public class MultiProvider extends EventProvider {
             @Override
             public Optional before(HookContext ctx, Map hints) {
                 hookExecutionContextThreadLocal.set(
-                        new HookExecutionContext(
-                                ctx.getClientMetadata(),
-                                hints != null ? hints : emptyHookHints));
+                        new HookExecutionContext(ctx.getClientMetadata(), hints != null ? hints : emptyHookHints));
                 return Optional.empty();
             }
 
             @Override
-            public void finallyAfter(HookContext ctx, FlagEvaluationDetails details,
-                    Map hints) {
+            public void finallyAfter(HookContext ctx, FlagEvaluationDetails details, Map hints) {
                 hookExecutionContextThreadLocal.remove();
             }
         };
@@ -143,16 +139,16 @@ public class MultiProvider extends EventProvider {
 
     private static String getProviderBaseName(FeatureProvider provider) {
         Metadata providerMetadata = provider.getMetadata();
-        if (providerMetadata == null || providerMetadata.getName() == null || providerMetadata.getName().isEmpty()) {
+        if (providerMetadata == null
+                || providerMetadata.getName() == null
+                || providerMetadata.getName().isEmpty()) {
             return "provider";
         }
         return providerMetadata.getName();
     }
 
     private static String resolveUniqueProviderName(
-            String baseName,
-            Map<String, FeatureProvider> providersMap,
-            Map<String, Integer> suffixesByBaseName) {
+            String baseName, Map<String, FeatureProvider> providersMap, Map<String, Integer> suffixesByBaseName) {
         if (!providersMap.containsKey(baseName)) {
             suffixesByBaseName.putIfAbsent(baseName, 1);
             return baseName;
@@ -199,7 +195,8 @@ public class MultiProvider extends EventProvider {
         Map<String, Metadata> providersMetadata = new LinkedHashMap<>();
         initializeProviderStates();
         synchronized (this) {
-            emitAggregateStateChange(determineAggregateState(), ProviderEventDetails.builder().build());
+            emitAggregateStateChange(
+                    determineAggregateState(), ProviderEventDetails.builder().build());
         }
 
         if (providers.isEmpty()) {
@@ -380,7 +377,8 @@ public class MultiProvider extends EventProvider {
         }
         synchronized (this) {
             initializeProviderStates();
-            emitAggregateStateChange(ProviderState.NOT_READY, ProviderEventDetails.builder().build());
+            emitAggregateStateChange(
+                    ProviderState.NOT_READY, ProviderEventDetails.builder().build());
         }
         log.debug("shutdown end");
         super.shutdown();
@@ -416,9 +414,7 @@ public class MultiProvider extends EventProvider {
     }
 
     private synchronized void setProviderState(
-            String providerName,
-            ProviderState providerState,
-            ProviderEventDetails details) {
+            String providerName, ProviderState providerState, ProviderEventDetails details) {
         providerStates.put(providerName, providerState);
         ProviderState aggregate = determineAggregateState();
         emitAggregateStateChange(aggregate, details);
@@ -575,8 +571,7 @@ public class MultiProvider extends EventProvider {
             return new RuntimeException("Provider evaluation returned an error");
         }
         return ExceptionUtils.instantiateErrorByErrorCode(
-                providerEvaluation.getErrorCode(),
-                providerEvaluation.getErrorMessage());
+                providerEvaluation.getErrorCode(), providerEvaluation.getErrorMessage());
     }
 
     @SuppressWarnings("deprecation")
@@ -667,12 +662,16 @@ public class MultiProvider extends EventProvider {
             for (int i = hooks.size() - 1; i >= 0; i--) {
                 HookExecution<T> execution = hooks.get(i);
                 HookContext<T> hookContext = createHookContext(
-                        key, valueType, defaultValue,
-                        evaluatedContext, provider,
-                        hookExecutionContext, execution.hookData);
+                        key,
+                        valueType,
+                        defaultValue,
+                        evaluatedContext,
+                        provider,
+                        hookExecutionContext,
+                        execution.hookData);
                 var contextUpdate = execution.hook.before(hookContext, hookHints);
                 if (contextUpdate != null
-                        && contextUpdate.isPresent()
+                        && contextUpdate.isPresent() // NOSONAR: hooks may return null instead of Optional.empty()
                         && contextUpdate.get() != hookContext.getCtx()
                         && !contextUpdate.get().isEmpty()) {
                     evaluatedContext = evaluatedContext.merge(contextUpdate.get());
@@ -741,7 +740,10 @@ public class MultiProvider extends EventProvider {
             throw e;
         } finally {
             FlagEvaluationDetails<T> finalDetails = details == null
-                    ? FlagEvaluationDetails.<T>builder().flagKey(key).value(defaultValue).build()
+                    ? FlagEvaluationDetails.<T>builder()
+                            .flagKey(key)
+                            .value(defaultValue)
+                            .build()
                     : details;
             for (HookExecution<T> execution : hooks) {
                 try {

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -17,6 +17,7 @@ import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEvent;
 import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.ProviderState;
+import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.TrackingEventDetails;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.ExceptionUtils;
@@ -30,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -61,6 +63,8 @@ public class MultiProvider extends EventProvider {
     private final Map<String, ProviderState> providerStates = new ConcurrentHashMap<>();
     private final Map<String, BiConsumer<ProviderEvent, ProviderEventDetails>> providerEventObservers =
             new ConcurrentHashMap<>();
+    private final ThreadLocal<HookExecutionContext> hookExecutionContextThreadLocal =
+            new ThreadLocal<>();
     private final ClientMetadata hookClientMetadata = MultiProvider::getNAME;
     private final Map<String, Object> emptyHookHints = Collections.emptyMap();
     private ProviderState aggregateState;
@@ -87,6 +91,38 @@ public class MultiProvider extends EventProvider {
         this.strategy = Objects.requireNonNull(strategy, "strategy must not be null");
         initializeProviderStates();
         this.aggregateState = determineAggregateState();
+    }
+
+    /**
+     * Returns provider-level hooks for this MultiProvider.
+     *
+     * <p>Includes a {@code before} hook that captures the {@link ClientMetadata}
+     * and hook hints from the SDK's hook lifecycle. This context is then available
+     * during per-child-provider hook execution, matching the JS SDK's WeakMap-based
+     * approach for passing hook context into the provider evaluation.
+     *
+     * @return the list of provider hooks
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public List<Hook> getProviderHooks() {
+        Hook contextCapturingHook = new Hook() {
+            @Override
+            public Optional before(HookContext ctx, Map hints) {
+                hookExecutionContextThreadLocal.set(
+                        new HookExecutionContext(
+                                ctx.getClientMetadata(),
+                                hints != null ? hints : emptyHookHints));
+                return Optional.empty();
+            }
+
+            @Override
+            public void finallyAfter(HookContext ctx, FlagEvaluationDetails details,
+                    Map hints) {
+                hookExecutionContextThreadLocal.remove();
+            }
+        };
+        return List.of(contextCapturingHook);
     }
 
     protected static Map<String, FeatureProvider> buildProviders(List<FeatureProvider> providers) {
@@ -182,7 +218,7 @@ public class MultiProvider extends EventProvider {
                 tasks.add(() -> {
                     try {
                         provider.initialize(evaluationContext, domain);
-                        setProviderState(providerName, ProviderState.READY, ProviderEventDetails.builder().build());
+                        setProviderReadyIfStillNotReady(providerName);
                         return null;
                     } catch (Exception e) {
                         setProviderState(providerName, toStateFromException(e), providerErrorDetails(e));
@@ -225,6 +261,7 @@ public class MultiProvider extends EventProvider {
 
     @Override
     public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
+        HookExecutionContext hookExecutionContext = currentHookExecutionContext();
         return strategy.evaluate(
                 providers,
                 key,
@@ -235,12 +272,14 @@ public class MultiProvider extends EventProvider {
                         key,
                         defaultValue,
                         ctx,
+                        hookExecutionContext,
                         FlagValueType.BOOLEAN,
                         (p, evaluationContext) -> p.getBooleanEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
+        HookExecutionContext hookExecutionContext = currentHookExecutionContext();
         return strategy.evaluate(
                 providers,
                 key,
@@ -251,12 +290,14 @@ public class MultiProvider extends EventProvider {
                         key,
                         defaultValue,
                         ctx,
+                        hookExecutionContext,
                         FlagValueType.STRING,
                         (p, evaluationContext) -> p.getStringEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
+        HookExecutionContext hookExecutionContext = currentHookExecutionContext();
         return strategy.evaluate(
                 providers,
                 key,
@@ -267,12 +308,14 @@ public class MultiProvider extends EventProvider {
                         key,
                         defaultValue,
                         ctx,
+                        hookExecutionContext,
                         FlagValueType.INTEGER,
                         (p, evaluationContext) -> p.getIntegerEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
+        HookExecutionContext hookExecutionContext = currentHookExecutionContext();
         return strategy.evaluate(
                 providers,
                 key,
@@ -283,12 +326,14 @@ public class MultiProvider extends EventProvider {
                         key,
                         defaultValue,
                         ctx,
+                        hookExecutionContext,
                         FlagValueType.DOUBLE,
                         (p, evaluationContext) -> p.getDoubleEvaluation(key, defaultValue, evaluationContext)));
     }
 
     @Override
     public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
+        HookExecutionContext hookExecutionContext = currentHookExecutionContext();
         return strategy.evaluate(
                 providers,
                 key,
@@ -299,6 +344,7 @@ public class MultiProvider extends EventProvider {
                         key,
                         defaultValue,
                         ctx,
+                        hookExecutionContext,
                         FlagValueType.OBJECT,
                         (p, evaluationContext) -> p.getObjectEvaluation(key, defaultValue, evaluationContext)));
     }
@@ -376,6 +422,15 @@ public class MultiProvider extends EventProvider {
         providerStates.put(providerName, providerState);
         ProviderState aggregate = determineAggregateState();
         emitAggregateStateChange(aggregate, details);
+    }
+
+    private synchronized void setProviderReadyIfStillNotReady(String providerName) {
+        if (!ProviderState.NOT_READY.equals(providerStates.get(providerName))) {
+            return;
+        }
+        providerStates.put(providerName, ProviderState.READY);
+        ProviderState aggregate = determineAggregateState();
+        emitAggregateStateChange(aggregate, ProviderEventDetails.builder().build());
     }
 
     private void emitAggregateStateChange(ProviderState aggregate, ProviderEventDetails details) {
@@ -524,43 +579,58 @@ public class MultiProvider extends EventProvider {
                 providerEvaluation.getErrorMessage());
     }
 
+    @SuppressWarnings("deprecation")
     private <T> HookContext<T> createHookContext(
             String key,
             FlagValueType valueType,
             T defaultValue,
             EvaluationContext evaluationContext,
             FeatureProvider provider,
+            HookExecutionContext hookExecutionContext,
             HookData hookData) {
         return HookContext.<T>builder()
                 .flagKey(key)
                 .type(valueType)
                 .defaultValue(normalizeDefaultValue(valueType, defaultValue))
                 .ctx(evaluationContext)
-                .clientMetadata(hookClientMetadata)
+                .clientMetadata(resolveClientMetadata(hookExecutionContext))
                 .providerMetadata(provider.getMetadata())
                 .hookData(hookData)
                 .build();
     }
 
+    /**
+     * Returns a non-null default value for use in hook contexts when the caller
+     * passes {@code null}. The returned object is always assignment-compatible
+     * with the expected type for {@code valueType}.
+     */
     @SuppressWarnings("unchecked")
     private <T> T normalizeDefaultValue(FlagValueType valueType, T defaultValue) {
         if (defaultValue != null) {
             return defaultValue;
         }
+        Object fallback;
         switch (valueType) {
             case BOOLEAN:
-                return (T) Boolean.FALSE;
+                fallback = Boolean.FALSE;
+                break;
             case STRING:
-                return (T) "";
+                fallback = "";
+                break;
             case INTEGER:
-                return (T) Integer.valueOf(0);
+                fallback = Integer.valueOf(0);
+                break;
             case DOUBLE:
-                return (T) Double.valueOf(0d);
+                fallback = Double.valueOf(0d);
+                break;
             case OBJECT:
-                return (T) new Value();
+                fallback = new Value();
+                break;
             default:
                 return defaultValue;
         }
+        // Safe: the SDK guarantees T matches the valueType enum.
+        return (T) fallback;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -569,6 +639,7 @@ public class MultiProvider extends EventProvider {
             String key,
             T defaultValue,
             EvaluationContext ctx,
+            HookExecutionContext hookExecutionContext,
             FlagValueType valueType,
             BiFunction<FeatureProvider, EvaluationContext, ProviderEvaluation<T>> providerFunction) {
         List<Hook> providerHooks = provider.getProviderHooks();
@@ -590,13 +661,16 @@ public class MultiProvider extends EventProvider {
         EvaluationContext evaluatedContext = copyEvaluationContext(ctx);
         ProviderEvaluation<T> providerEvaluation = null;
         FlagEvaluationDetails<T> details = null;
+        Map<String, Object> hookHints = resolveHookHints(hookExecutionContext);
 
         try {
             for (int i = hooks.size() - 1; i >= 0; i--) {
                 HookExecution<T> execution = hooks.get(i);
-                HookContext<T> hookContext =
-                        createHookContext(key, valueType, defaultValue, evaluatedContext, provider, execution.hookData);
-                var contextUpdate = execution.hook.before(hookContext, emptyHookHints);
+                HookContext<T> hookContext = createHookContext(
+                        key, valueType, defaultValue,
+                        evaluatedContext, provider,
+                        hookExecutionContext, execution.hookData);
+                var contextUpdate = execution.hook.before(hookContext, hookHints);
                 if (contextUpdate != null
                         && contextUpdate.isPresent()
                         && contextUpdate.get() != hookContext.getCtx()
@@ -617,11 +691,13 @@ public class MultiProvider extends EventProvider {
                                     defaultValue,
                                     evaluatedContext,
                                     provider,
+                                    hookExecutionContext,
                                     execution.hookData),
                             details,
-                            emptyHookHints);
+                            hookHints);
                 }
             } else {
+                enrichDetailsWithErrorDefaults(defaultValue, details);
                 Exception providerException = toEvaluationException(providerEvaluation);
                 for (HookExecution<T> execution : hooks) {
                     try {
@@ -632,9 +708,10 @@ public class MultiProvider extends EventProvider {
                                         defaultValue,
                                         evaluatedContext,
                                         provider,
+                                        hookExecutionContext,
                                         execution.hookData),
                                 providerException,
-                                emptyHookHints);
+                                hookHints);
                     } catch (Exception e) {
                         log.error("error executing provider hook error stage", e);
                     }
@@ -643,6 +720,7 @@ public class MultiProvider extends EventProvider {
 
             return providerEvaluation;
         } catch (Exception e) {
+            details = buildErrorDetails(key, defaultValue, details, e);
             for (HookExecution<T> execution : hooks) {
                 try {
                     execution.hook.error(
@@ -652,9 +730,10 @@ public class MultiProvider extends EventProvider {
                                     defaultValue,
                                     evaluatedContext,
                                     provider,
+                                    hookExecutionContext,
                                     execution.hookData),
                             e,
-                            emptyHookHints);
+                            hookHints);
                 } catch (Exception hookError) {
                     log.error("error executing provider hook error stage", hookError);
                 }
@@ -673,14 +752,53 @@ public class MultiProvider extends EventProvider {
                                     defaultValue,
                                     evaluatedContext,
                                     provider,
+                                    hookExecutionContext,
                                     execution.hookData),
                             finalDetails,
-                            emptyHookHints);
+                            hookHints);
                 } catch (Exception e) {
                     log.error("error executing provider hook finally stage", e);
                 }
             }
         }
+    }
+
+    private HookExecutionContext currentHookExecutionContext() {
+        return hookExecutionContextThreadLocal.get();
+    }
+
+    private ClientMetadata resolveClientMetadata(HookExecutionContext hookExecutionContext) {
+        if (hookExecutionContext == null || hookExecutionContext.clientMetadata == null) {
+            return hookClientMetadata;
+        }
+        return hookExecutionContext.clientMetadata;
+    }
+
+    private Map<String, Object> resolveHookHints(HookExecutionContext hookExecutionContext) {
+        if (hookExecutionContext == null || hookExecutionContext.hints == null) {
+            return emptyHookHints;
+        }
+        return hookExecutionContext.hints;
+    }
+
+    private <T> FlagEvaluationDetails<T> buildErrorDetails(
+            String key, T defaultValue, FlagEvaluationDetails<T> details, Exception error) {
+        FlagEvaluationDetails<T> errorDetails = details == null
+                ? FlagEvaluationDetails.<T>builder().flagKey(key).build()
+                : details;
+        if (error instanceof OpenFeatureError) {
+            errorDetails.setErrorCode(((OpenFeatureError) error).getErrorCode());
+        } else {
+            errorDetails.setErrorCode(ErrorCode.GENERAL);
+        }
+        errorDetails.setErrorMessage(error.getMessage());
+        enrichDetailsWithErrorDefaults(defaultValue, errorDetails);
+        return errorDetails;
+    }
+
+    private <T> void enrichDetailsWithErrorDefaults(T defaultValue, FlagEvaluationDetails<T> details) {
+        details.setValue(defaultValue);
+        details.setReason(Reason.ERROR.toString());
     }
 
     private static final class HookExecution<T> {
@@ -690,6 +808,16 @@ public class MultiProvider extends EventProvider {
         private HookExecution(Hook<T> hook, HookData hookData) {
             this.hook = hook;
             this.hookData = hookData;
+        }
+    }
+
+    private static final class HookExecutionContext {
+        private final ClientMetadata clientMetadata;
+        private final Map<String, Object> hints;
+
+        private HookExecutionContext(ClientMetadata clientMetadata, Map<String, Object> hints) {
+            this.clientMetadata = clientMetadata;
+            this.hints = hints;
         }
     }
 }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -65,7 +65,6 @@ public class MultiProvider extends EventProvider {
             new ConcurrentHashMap<>();
     private final ThreadLocal<HookExecutionContext> hookExecutionContextThreadLocal = new ThreadLocal<>();
     private final ClientMetadata hookClientMetadata = MultiProvider::getNAME;
-    private final Map<String, Object> emptyHookHints = Collections.emptyMap();
     private ProviderState aggregateState;
     private MultiProviderMetadata metadata;
 
@@ -103,22 +102,23 @@ public class MultiProvider extends EventProvider {
      * @return the list of provider hooks
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
+    private final List<Hook> providerHooks = List.of(new Hook() {
+        @Override
+        public Optional before(HookContext ctx, Map hints) {
+            hookExecutionContextThreadLocal.set(
+                    new HookExecutionContext(ctx.getClientMetadata(), hints != null ? hints : Collections.emptyMap()));
+            return Optional.empty();
+        }
+
+        @Override
+        public void finallyAfter(HookContext ctx, FlagEvaluationDetails details, Map hints) {
+            hookExecutionContextThreadLocal.remove();
+        }
+    });
+
     @Override
     public List<Hook> getProviderHooks() {
-        Hook contextCapturingHook = new Hook() {
-            @Override
-            public Optional before(HookContext ctx, Map hints) {
-                hookExecutionContextThreadLocal.set(
-                        new HookExecutionContext(ctx.getClientMetadata(), hints != null ? hints : emptyHookHints));
-                return Optional.empty();
-            }
-
-            @Override
-            public void finallyAfter(HookContext ctx, FlagEvaluationDetails details, Map hints) {
-                hookExecutionContextThreadLocal.remove();
-            }
-        };
-        return List.of(contextCapturingHook);
+        return providerHooks;
     }
 
     protected static Map<String, FeatureProvider> buildProviders(List<FeatureProvider> providers) {
@@ -230,13 +230,10 @@ public class MultiProvider extends EventProvider {
 
             List<Future<Void>> results = executorService.invokeAll(tasks);
             for (Future<Void> result : results) {
-                // This will re-throw any exception from the provider's initialize method,
-                // wrapped in an ExecutionException.
                 result.get();
             }
         } catch (Exception e) {
-            // If initialization fails for any provider, attempt to shut down via the
-            // standard shutdown path to avoid a partial/limbo state.
+            // Clean up to avoid leaving child providers in a partially initialised state.
             try {
                 shutdown();
             } catch (Exception shutdownEx) {
@@ -670,8 +667,9 @@ public class MultiProvider extends EventProvider {
                         hookExecutionContext,
                         execution.hookData);
                 var contextUpdate = execution.hook.before(hookContext, hookHints);
-                if (contextUpdate != null
-                        && contextUpdate.isPresent() // NOSONAR: hooks may return null instead of Optional.empty()
+                // Raw-type invocation: third-party hooks predating Optional may return null.
+                if (contextUpdate != null // NOSONAR
+                        && contextUpdate.isPresent()
                         && contextUpdate.get() != hookContext.getCtx()
                         && !contextUpdate.get().isEmpty()) {
                     evaluatedContext = evaluatedContext.merge(contextUpdate.get());
@@ -778,7 +776,7 @@ public class MultiProvider extends EventProvider {
 
     private Map<String, Object> resolveHookHints(HookExecutionContext hookExecutionContext) {
         if (hookExecutionContext == null || hookExecutionContext.hints == null) {
-            return emptyHookHints;
+            return Collections.emptyMap();
         }
         return hookExecutionContext.hints;
     }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -1,7 +1,6 @@
 package dev.openfeature.sdk.multiprovider;
 
 import dev.openfeature.sdk.ClientMetadata;
-import dev.openfeature.sdk.DefaultHookData;
 import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
@@ -10,17 +9,13 @@ import dev.openfeature.sdk.FlagEvaluationDetails;
 import dev.openfeature.sdk.FlagValueType;
 import dev.openfeature.sdk.Hook;
 import dev.openfeature.sdk.HookContext;
-import dev.openfeature.sdk.HookData;
-import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEvent;
 import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.ProviderState;
-import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.TrackingEventDetails;
 import dev.openfeature.sdk.Value;
-import dev.openfeature.sdk.exceptions.ExceptionUtils;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
@@ -38,7 +33,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -65,6 +59,7 @@ public class MultiProvider extends EventProvider {
             new ConcurrentHashMap<>();
     private final ThreadLocal<HookExecutionContext> hookExecutionContextThreadLocal = new ThreadLocal<>();
     private final ClientMetadata hookClientMetadata = MultiProvider::getNAME;
+    private final MultiProviderHookExecutor hookExecutor = new MultiProviderHookExecutor(hookClientMetadata);
     private ProviderState aggregateState;
     private MultiProviderMetadata metadata;
 
@@ -261,7 +256,7 @@ public class MultiProvider extends EventProvider {
                 key,
                 defaultValue,
                 ctx,
-                provider -> evaluateWithProviderHooks(
+                provider -> hookExecutor.evaluate(
                         provider,
                         key,
                         defaultValue,
@@ -279,7 +274,7 @@ public class MultiProvider extends EventProvider {
                 key,
                 defaultValue,
                 ctx,
-                provider -> evaluateWithProviderHooks(
+                provider -> hookExecutor.evaluate(
                         provider,
                         key,
                         defaultValue,
@@ -297,7 +292,7 @@ public class MultiProvider extends EventProvider {
                 key,
                 defaultValue,
                 ctx,
-                provider -> evaluateWithProviderHooks(
+                provider -> hookExecutor.evaluate(
                         provider,
                         key,
                         defaultValue,
@@ -315,7 +310,7 @@ public class MultiProvider extends EventProvider {
                 key,
                 defaultValue,
                 ctx,
-                provider -> evaluateWithProviderHooks(
+                provider -> hookExecutor.evaluate(
                         provider,
                         key,
                         defaultValue,
@@ -333,7 +328,7 @@ public class MultiProvider extends EventProvider {
                 key,
                 defaultValue,
                 ctx,
-                provider -> evaluateWithProviderHooks(
+                provider -> hookExecutor.evaluate(
                         provider,
                         key,
                         defaultValue,
@@ -545,279 +540,7 @@ public class MultiProvider extends EventProvider {
         return !ProviderState.NOT_READY.equals(providerState) && !ProviderState.FATAL.equals(providerState);
     }
 
-    private EvaluationContext copyEvaluationContext(EvaluationContext context) {
-        if (context == null) {
-            return ImmutableContext.EMPTY;
-        }
-        String targetingKey = context.getTargetingKey();
-        if (targetingKey == null) {
-            return new ImmutableContext(context.asMap());
-        }
-        return new ImmutableContext(targetingKey, context.asMap());
-    }
-
-    private EvaluationContext toProviderContext(EvaluationContext originalContext, EvaluationContext evaluatedContext) {
-        if (originalContext == null && (evaluatedContext == null || evaluatedContext.isEmpty())) {
-            return null;
-        }
-        return evaluatedContext;
-    }
-
-    private Exception toEvaluationException(ProviderEvaluation<?> providerEvaluation) {
-        if (providerEvaluation == null || providerEvaluation.getErrorCode() == null) {
-            return new RuntimeException("Provider evaluation returned an error");
-        }
-        return ExceptionUtils.instantiateErrorByErrorCode(
-                providerEvaluation.getErrorCode(), providerEvaluation.getErrorMessage());
-    }
-
-    @SuppressWarnings("deprecation")
-    private <T> HookContext<T> createHookContext(
-            String key,
-            FlagValueType valueType,
-            T defaultValue,
-            EvaluationContext evaluationContext,
-            FeatureProvider provider,
-            HookExecutionContext hookExecutionContext,
-            HookData hookData) {
-        return HookContext.<T>builder()
-                .flagKey(key)
-                .type(valueType)
-                .defaultValue(normalizeDefaultValue(valueType, defaultValue))
-                .ctx(evaluationContext)
-                .clientMetadata(resolveClientMetadata(hookExecutionContext))
-                .providerMetadata(provider.getMetadata())
-                .hookData(hookData)
-                .build();
-    }
-
-    /**
-     * Returns a non-null default value for use in hook contexts when the caller
-     * passes {@code null}. The returned object is always assignment-compatible
-     * with the expected type for {@code valueType}.
-     */
-    @SuppressWarnings("unchecked")
-    private <T> T normalizeDefaultValue(FlagValueType valueType, T defaultValue) {
-        if (defaultValue != null) {
-            return defaultValue;
-        }
-        Object fallback;
-        switch (valueType) {
-            case BOOLEAN:
-                fallback = Boolean.FALSE;
-                break;
-            case STRING:
-                fallback = "";
-                break;
-            case INTEGER:
-                fallback = Integer.valueOf(0);
-                break;
-            case DOUBLE:
-                fallback = Double.valueOf(0d);
-                break;
-            case OBJECT:
-                fallback = new Value();
-                break;
-            default:
-                return defaultValue;
-        }
-        // Safe: the SDK guarantees T matches the valueType enum.
-        return (T) fallback;
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private <T> ProviderEvaluation<T> evaluateWithProviderHooks(
-            FeatureProvider provider,
-            String key,
-            T defaultValue,
-            EvaluationContext ctx,
-            HookExecutionContext hookExecutionContext,
-            FlagValueType valueType,
-            BiFunction<FeatureProvider, EvaluationContext, ProviderEvaluation<T>> providerFunction) {
-        List<Hook> providerHooks = provider.getProviderHooks();
-        if (providerHooks == null || providerHooks.isEmpty()) {
-            return providerFunction.apply(provider, ctx);
-        }
-
-        List<HookExecution<T>> hooks = new ArrayList<>(providerHooks.size());
-        for (Hook hook : providerHooks) {
-            if (hook.supportsFlagValueType(valueType)) {
-                hooks.add(new HookExecution<>(hook, new DefaultHookData()));
-            }
-        }
-
-        if (hooks.isEmpty()) {
-            return providerFunction.apply(provider, ctx);
-        }
-
-        EvaluationContext evaluatedContext = copyEvaluationContext(ctx);
-        ProviderEvaluation<T> providerEvaluation = null;
-        FlagEvaluationDetails<T> details = null;
-        Map<String, Object> hookHints = resolveHookHints(hookExecutionContext);
-
-        try {
-            for (int i = hooks.size() - 1; i >= 0; i--) {
-                HookExecution<T> execution = hooks.get(i);
-                HookContext<T> hookContext = createHookContext(
-                        key,
-                        valueType,
-                        defaultValue,
-                        evaluatedContext,
-                        provider,
-                        hookExecutionContext,
-                        execution.hookData);
-                var contextUpdate = execution.hook.before(hookContext, hookHints);
-                // Raw-type invocation: third-party hooks predating Optional may return null.
-                if (contextUpdate != null // NOSONAR
-                        && contextUpdate.isPresent()
-                        && contextUpdate.get() != hookContext.getCtx()
-                        && !contextUpdate.get().isEmpty()) {
-                    evaluatedContext = evaluatedContext.merge(contextUpdate.get());
-                }
-            }
-
-            providerEvaluation = providerFunction.apply(provider, toProviderContext(ctx, evaluatedContext));
-            details = FlagEvaluationDetails.from(providerEvaluation, key);
-
-            if (providerEvaluation.getErrorCode() == null) {
-                for (HookExecution<T> execution : hooks) {
-                    execution.hook.after(
-                            createHookContext(
-                                    key,
-                                    valueType,
-                                    defaultValue,
-                                    evaluatedContext,
-                                    provider,
-                                    hookExecutionContext,
-                                    execution.hookData),
-                            details,
-                            hookHints);
-                }
-            } else {
-                enrichDetailsWithErrorDefaults(defaultValue, details);
-                Exception providerException = toEvaluationException(providerEvaluation);
-                for (HookExecution<T> execution : hooks) {
-                    try {
-                        execution.hook.error(
-                                createHookContext(
-                                        key,
-                                        valueType,
-                                        defaultValue,
-                                        evaluatedContext,
-                                        provider,
-                                        hookExecutionContext,
-                                        execution.hookData),
-                                providerException,
-                                hookHints);
-                    } catch (Exception e) {
-                        log.error("error executing provider hook error stage", e);
-                    }
-                }
-            }
-
-            return providerEvaluation;
-        } catch (Exception e) {
-            details = buildErrorDetails(key, defaultValue, details, e);
-            for (HookExecution<T> execution : hooks) {
-                try {
-                    execution.hook.error(
-                            createHookContext(
-                                    key,
-                                    valueType,
-                                    defaultValue,
-                                    evaluatedContext,
-                                    provider,
-                                    hookExecutionContext,
-                                    execution.hookData),
-                            e,
-                            hookHints);
-                } catch (Exception hookError) {
-                    log.error("error executing provider hook error stage", hookError);
-                }
-            }
-            throw e;
-        } finally {
-            FlagEvaluationDetails<T> finalDetails = details == null
-                    ? FlagEvaluationDetails.<T>builder()
-                            .flagKey(key)
-                            .value(defaultValue)
-                            .build()
-                    : details;
-            for (HookExecution<T> execution : hooks) {
-                try {
-                    execution.hook.finallyAfter(
-                            createHookContext(
-                                    key,
-                                    valueType,
-                                    defaultValue,
-                                    evaluatedContext,
-                                    provider,
-                                    hookExecutionContext,
-                                    execution.hookData),
-                            finalDetails,
-                            hookHints);
-                } catch (Exception e) {
-                    log.error("error executing provider hook finally stage", e);
-                }
-            }
-        }
-    }
-
     private HookExecutionContext currentHookExecutionContext() {
         return hookExecutionContextThreadLocal.get();
-    }
-
-    private ClientMetadata resolveClientMetadata(HookExecutionContext hookExecutionContext) {
-        if (hookExecutionContext == null || hookExecutionContext.clientMetadata == null) {
-            return hookClientMetadata;
-        }
-        return hookExecutionContext.clientMetadata;
-    }
-
-    private Map<String, Object> resolveHookHints(HookExecutionContext hookExecutionContext) {
-        if (hookExecutionContext == null || hookExecutionContext.hints == null) {
-            return Collections.emptyMap();
-        }
-        return hookExecutionContext.hints;
-    }
-
-    private <T> FlagEvaluationDetails<T> buildErrorDetails(
-            String key, T defaultValue, FlagEvaluationDetails<T> details, Exception error) {
-        FlagEvaluationDetails<T> errorDetails = details == null
-                ? FlagEvaluationDetails.<T>builder().flagKey(key).build()
-                : details;
-        if (error instanceof OpenFeatureError) {
-            errorDetails.setErrorCode(((OpenFeatureError) error).getErrorCode());
-        } else {
-            errorDetails.setErrorCode(ErrorCode.GENERAL);
-        }
-        errorDetails.setErrorMessage(error.getMessage());
-        enrichDetailsWithErrorDefaults(defaultValue, errorDetails);
-        return errorDetails;
-    }
-
-    private <T> void enrichDetailsWithErrorDefaults(T defaultValue, FlagEvaluationDetails<T> details) {
-        details.setValue(defaultValue);
-        details.setReason(Reason.ERROR.toString());
-    }
-
-    private static final class HookExecution<T> {
-        private final Hook<T> hook;
-        private final HookData hookData;
-
-        private HookExecution(Hook<T> hook, HookData hookData) {
-            this.hook = hook;
-            this.hookData = hookData;
-        }
-    }
-
-    private static final class HookExecutionContext {
-        private final ClientMetadata clientMetadata;
-        private final Map<String, Object> hints;
-
-        private HookExecutionContext(ClientMetadata clientMetadata, Map<String, Object> hints) {
-            this.clientMetadata = clientMetadata;
-            this.hints = hints;
-        }
     }
 }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutor.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutor.java
@@ -1,0 +1,302 @@
+package dev.openfeature.sdk.multiprovider;
+
+import dev.openfeature.sdk.ClientMetadata;
+import dev.openfeature.sdk.DefaultHookData;
+import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.FlagValueType;
+import dev.openfeature.sdk.Hook;
+import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.HookData;
+import dev.openfeature.sdk.ImmutableContext;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Reason;
+import dev.openfeature.sdk.Value;
+import dev.openfeature.sdk.exceptions.ExceptionUtils;
+import dev.openfeature.sdk.exceptions.OpenFeatureError;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Runs per-provider hook lifecycles during flag evaluation.
+ *
+ * <p>Mirrors the role of {@code HookExecutor} in the JS SDK: executes the before/after/error/finally
+ * stages for each child provider's own hooks, using context captured by {@link MultiProvider}'s
+ * provider-level hook.
+ */
+@Slf4j
+class MultiProviderHookExecutor {
+
+    private final ClientMetadata fallbackClientMetadata;
+
+    MultiProviderHookExecutor(ClientMetadata fallbackClientMetadata) {
+        this.fallbackClientMetadata = fallbackClientMetadata;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    <T> ProviderEvaluation<T> evaluate(
+            FeatureProvider provider,
+            String key,
+            T defaultValue,
+            EvaluationContext ctx,
+            HookExecutionContext hookExecutionContext,
+            FlagValueType valueType,
+            BiFunction<FeatureProvider, EvaluationContext, ProviderEvaluation<T>> providerFunction) {
+        List<Hook> rawHooks = provider.getProviderHooks();
+        if (rawHooks == null || rawHooks.isEmpty()) {
+            return providerFunction.apply(provider, ctx);
+        }
+
+        List<HookExecution<T>> hooks = new ArrayList<>(rawHooks.size());
+        for (Hook hook : rawHooks) {
+            if (hook.supportsFlagValueType(valueType)) {
+                hooks.add(new HookExecution<>(hook, new DefaultHookData()));
+            }
+        }
+
+        if (hooks.isEmpty()) {
+            return providerFunction.apply(provider, ctx);
+        }
+
+        EvaluationContext evaluatedContext = copyEvaluationContext(ctx);
+        ProviderEvaluation<T> providerEvaluation = null;
+        FlagEvaluationDetails<T> details = null;
+        Map<String, Object> hookHints = resolveHookHints(hookExecutionContext);
+
+        try {
+            for (int i = hooks.size() - 1; i >= 0; i--) {
+                HookExecution<T> execution = hooks.get(i);
+                HookContext<T> hookContext = createHookContext(
+                        key,
+                        valueType,
+                        defaultValue,
+                        evaluatedContext,
+                        provider,
+                        hookExecutionContext,
+                        execution.hookData);
+                var contextUpdate = execution.hook.before(hookContext, hookHints);
+                // Raw-type invocation: third-party hooks predating Optional may return null.
+                if (contextUpdate != null // NOSONAR
+                        && contextUpdate.isPresent()
+                        && contextUpdate.get() != hookContext.getCtx()
+                        && !contextUpdate.get().isEmpty()) {
+                    evaluatedContext = evaluatedContext.merge(contextUpdate.get());
+                }
+            }
+
+            providerEvaluation = providerFunction.apply(provider, toProviderContext(ctx, evaluatedContext));
+            details = FlagEvaluationDetails.from(providerEvaluation, key);
+
+            if (providerEvaluation.getErrorCode() == null) {
+                for (HookExecution<T> execution : hooks) {
+                    execution.hook.after(
+                            createHookContext(
+                                    key,
+                                    valueType,
+                                    defaultValue,
+                                    evaluatedContext,
+                                    provider,
+                                    hookExecutionContext,
+                                    execution.hookData),
+                            details,
+                            hookHints);
+                }
+            } else {
+                enrichDetailsWithErrorDefaults(defaultValue, details);
+                Exception providerException = toEvaluationException(providerEvaluation);
+                for (HookExecution<T> execution : hooks) {
+                    try {
+                        execution.hook.error(
+                                createHookContext(
+                                        key,
+                                        valueType,
+                                        defaultValue,
+                                        evaluatedContext,
+                                        provider,
+                                        hookExecutionContext,
+                                        execution.hookData),
+                                providerException,
+                                hookHints);
+                    } catch (Exception e) {
+                        log.error("error executing provider hook error stage", e);
+                    }
+                }
+            }
+
+            return providerEvaluation;
+        } catch (Exception e) {
+            details = buildErrorDetails(key, defaultValue, details, e);
+            for (HookExecution<T> execution : hooks) {
+                try {
+                    execution.hook.error(
+                            createHookContext(
+                                    key,
+                                    valueType,
+                                    defaultValue,
+                                    evaluatedContext,
+                                    provider,
+                                    hookExecutionContext,
+                                    execution.hookData),
+                            e,
+                            hookHints);
+                } catch (Exception hookError) {
+                    log.error("error executing provider hook error stage", hookError);
+                }
+            }
+            throw e;
+        } finally {
+            FlagEvaluationDetails<T> finalDetails = details == null
+                    ? FlagEvaluationDetails.<T>builder()
+                            .flagKey(key)
+                            .value(defaultValue)
+                            .build()
+                    : details;
+            for (HookExecution<T> execution : hooks) {
+                try {
+                    execution.hook.finallyAfter(
+                            createHookContext(
+                                    key,
+                                    valueType,
+                                    defaultValue,
+                                    evaluatedContext,
+                                    provider,
+                                    hookExecutionContext,
+                                    execution.hookData),
+                            finalDetails,
+                            hookHints);
+                } catch (Exception e) {
+                    log.error("error executing provider hook finally stage", e);
+                }
+            }
+        }
+    }
+
+    private EvaluationContext copyEvaluationContext(EvaluationContext context) {
+        if (context == null) {
+            return ImmutableContext.EMPTY;
+        }
+        String targetingKey = context.getTargetingKey();
+        if (targetingKey == null) {
+            return new ImmutableContext(context.asMap());
+        }
+        return new ImmutableContext(targetingKey, context.asMap());
+    }
+
+    private EvaluationContext toProviderContext(EvaluationContext originalContext, EvaluationContext evaluatedContext) {
+        if (originalContext == null && (evaluatedContext == null || evaluatedContext.isEmpty())) {
+            return null;
+        }
+        return evaluatedContext;
+    }
+
+    private Exception toEvaluationException(ProviderEvaluation<?> providerEvaluation) {
+        if (providerEvaluation == null || providerEvaluation.getErrorCode() == null) {
+            return new RuntimeException("Provider evaluation returned an error");
+        }
+        return ExceptionUtils.instantiateErrorByErrorCode(
+                providerEvaluation.getErrorCode(), providerEvaluation.getErrorMessage());
+    }
+
+    @SuppressWarnings("deprecation")
+    private <T> HookContext<T> createHookContext(
+            String key,
+            FlagValueType valueType,
+            T defaultValue,
+            EvaluationContext evaluationContext,
+            FeatureProvider provider,
+            HookExecutionContext hookExecutionContext,
+            HookData hookData) {
+        return HookContext.<T>builder()
+                .flagKey(key)
+                .type(valueType)
+                .defaultValue(normalizeDefaultValue(valueType, defaultValue))
+                .ctx(evaluationContext)
+                .clientMetadata(resolveClientMetadata(hookExecutionContext))
+                .providerMetadata(provider.getMetadata())
+                .hookData(hookData)
+                .build();
+    }
+
+    /**
+     * Returns a non-null default value for use in hook contexts when the caller passes {@code null}.
+     * The returned object is always assignment-compatible with the expected type for {@code valueType}.
+     */
+    @SuppressWarnings("unchecked")
+    private <T> T normalizeDefaultValue(FlagValueType valueType, T defaultValue) {
+        if (defaultValue != null) {
+            return defaultValue;
+        }
+        Object fallback;
+        switch (valueType) {
+            case BOOLEAN:
+                fallback = Boolean.FALSE;
+                break;
+            case STRING:
+                fallback = "";
+                break;
+            case INTEGER:
+                fallback = Integer.valueOf(0);
+                break;
+            case DOUBLE:
+                fallback = Double.valueOf(0d);
+                break;
+            case OBJECT:
+                fallback = new Value();
+                break;
+            default:
+                return defaultValue;
+        }
+        // Safe: the SDK guarantees T matches the valueType enum.
+        return (T) fallback;
+    }
+
+    private ClientMetadata resolveClientMetadata(HookExecutionContext hookExecutionContext) {
+        if (hookExecutionContext == null || hookExecutionContext.clientMetadata == null) {
+            return fallbackClientMetadata;
+        }
+        return hookExecutionContext.clientMetadata;
+    }
+
+    private Map<String, Object> resolveHookHints(HookExecutionContext hookExecutionContext) {
+        if (hookExecutionContext == null || hookExecutionContext.hints == null) {
+            return Collections.emptyMap();
+        }
+        return hookExecutionContext.hints;
+    }
+
+    private <T> FlagEvaluationDetails<T> buildErrorDetails(
+            String key, T defaultValue, FlagEvaluationDetails<T> details, Exception error) {
+        FlagEvaluationDetails<T> errorDetails = details == null
+                ? FlagEvaluationDetails.<T>builder().flagKey(key).build()
+                : details;
+        if (error instanceof OpenFeatureError) {
+            errorDetails.setErrorCode(((OpenFeatureError) error).getErrorCode());
+        } else {
+            errorDetails.setErrorCode(ErrorCode.GENERAL);
+        }
+        errorDetails.setErrorMessage(error.getMessage());
+        enrichDetailsWithErrorDefaults(defaultValue, errorDetails);
+        return errorDetails;
+    }
+
+    private <T> void enrichDetailsWithErrorDefaults(T defaultValue, FlagEvaluationDetails<T> details) {
+        details.setValue(defaultValue);
+        details.setReason(Reason.ERROR.toString());
+    }
+
+    private static final class HookExecution<T> {
+        private final Hook<T> hook;
+        private final HookData hookData;
+
+        private HookExecution(Hook<T> hook, HookData hookData) {
+            this.hook = hook;
+            this.hookData = hookData;
+        }
+    }
+}

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutor.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutor.java
@@ -69,9 +69,12 @@ class MultiProviderHookExecutor {
         FlagEvaluationDetails<T> details = null;
         Map<String, Object> hookHints = resolveHookHints(hookExecutionContext);
 
+        // Per spec, before hooks run in registration order; after/error/finally run in reverse.
+        List<HookExecution<T>> reversedHooks = new ArrayList<>(hooks);
+        Collections.reverse(reversedHooks);
+
         try {
-            for (int i = hooks.size() - 1; i >= 0; i--) {
-                HookExecution<T> execution = hooks.get(i);
+            for (HookExecution<T> execution : hooks) {
                 HookContext<T> hookContext = createHookContext(
                         key,
                         valueType,
@@ -94,7 +97,7 @@ class MultiProviderHookExecutor {
             details = FlagEvaluationDetails.from(providerEvaluation, key);
 
             if (providerEvaluation.getErrorCode() == null) {
-                for (HookExecution<T> execution : hooks) {
+                for (HookExecution<T> execution : reversedHooks) {
                     execution.hook.after(
                             createHookContext(
                                     key,
@@ -110,7 +113,7 @@ class MultiProviderHookExecutor {
             } else {
                 enrichDetailsWithErrorDefaults(defaultValue, details);
                 Exception providerException = toEvaluationException(providerEvaluation);
-                for (HookExecution<T> execution : hooks) {
+                for (HookExecution<T> execution : reversedHooks) {
                     try {
                         execution.hook.error(
                                 createHookContext(
@@ -132,7 +135,7 @@ class MultiProviderHookExecutor {
             return providerEvaluation;
         } catch (Exception e) {
             details = buildErrorDetails(key, defaultValue, details, e);
-            for (HookExecution<T> execution : hooks) {
+            for (HookExecution<T> execution : reversedHooks) {
                 try {
                     execution.hook.error(
                             createHookContext(
@@ -157,7 +160,7 @@ class MultiProviderHookExecutor {
                             .value(defaultValue)
                             .build()
                     : details;
-            for (HookExecution<T> execution : hooks) {
+            for (HookExecution<T> execution : reversedHooks) {
                 try {
                     execution.hook.finallyAfter(
                             createHookContext(

--- a/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
@@ -11,6 +11,12 @@ import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.ProviderEvaluation;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +54,9 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         providers.put("provider2", mockProvider2);
 
         AtomicInteger callbackCount = new AtomicInteger();
-        ComparisonStrategy strategy = new ComparisonStrategy("provider2", (key, evaluations) -> callbackCount.incrementAndGet());
+        ComparisonStrategy strategy = new ComparisonStrategy(
+                "provider2",
+                (key, evaluations) -> callbackCount.incrementAndGet());
 
         ProviderEvaluation<String> result = strategy.evaluate(
                 providers,
@@ -99,5 +107,114 @@ class ComparisonStrategyTest extends BaseStrategyTest {
                         DEFAULT_STRING,
                         null,
                         p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null)));
+    }
+
+    @Test
+    void shouldEvaluateProvidersConcurrently() throws InterruptedException {
+        // Use a latch to prove that providers run in parallel:
+        // both providers block on the latch, so they must be on
+        // separate threads for the test to complete.
+        CountDownLatch bothStarted = new CountDownLatch(2);
+        CountDownLatch proceed = new CountDownLatch(1);
+        Set<String> threadNames = ConcurrentHashMap.newKeySet();
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        setupProviderSuccess(mockProvider1, "val");
+        setupProviderSuccess(mockProvider2, "val");
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers,
+                FLAG_KEY,
+                DEFAULT_STRING,
+                null,
+                provider -> {
+                    threadNames.add(Thread.currentThread().getName());
+                    bothStarted.countDown();
+                    try {
+                        // Wait for both providers to signal they've started
+                        bothStarted.await(5, TimeUnit.SECONDS);
+                        proceed.countDown();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return provider.getStringEvaluation(
+                            FLAG_KEY, DEFAULT_STRING, null);
+                });
+
+        assertNotNull(result);
+        assertEquals("val", result.getValue());
+        assertNull(result.getErrorCode());
+        // Verify that at least 2 different threads were used
+        assertTrue(
+                threadNames.size() >= 2,
+                "Expected concurrent execution on multiple threads, "
+                        + "but only saw: " + threadNames);
+    }
+
+    @Test
+    void shouldReuseProvidedExecutorService() {
+        ExecutorService customExecutor = Executors.newFixedThreadPool(2);
+        try {
+            setupProviderSuccess(mockProvider1, "ok");
+            setupProviderSuccess(mockProvider2, "ok");
+
+            Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+            providers.put("provider1", mockProvider1);
+            providers.put("provider2", mockProvider2);
+
+            ComparisonStrategy strategy = new ComparisonStrategy(
+                    "provider1", null, customExecutor, 5000);
+
+            // Execute twice to confirm the same executor is reused
+            for (int i = 0; i < 2; i++) {
+                ProviderEvaluation<String> result = strategy.evaluate(
+                        providers,
+                        FLAG_KEY,
+                        DEFAULT_STRING,
+                        null,
+                        p -> p.getStringEvaluation(
+                                FLAG_KEY, DEFAULT_STRING, null));
+                assertNotNull(result);
+                assertEquals("ok", result.getValue());
+                assertNull(result.getErrorCode());
+            }
+
+            // Executor should still be usable (not shut down)
+            assertTrue(
+                    !customExecutor.isShutdown(),
+                    "Executor should not be shut down by the strategy");
+        } finally {
+            customExecutor.shutdown();
+        }
+    }
+
+    @Test
+    void shouldCollectAllProviderErrorsWhenMultipleFail() {
+        setupProviderError(mockProvider1, ErrorCode.PARSE_ERROR);
+        setupProviderError(mockProvider2, ErrorCode.FLAG_NOT_FOUND);
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers,
+                FLAG_KEY,
+                DEFAULT_STRING,
+                null,
+                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        assertTrue(
+                result.getErrorMessage().contains("provider1"),
+                "Error should mention provider1");
+        assertTrue(
+                result.getErrorMessage().contains("provider2"),
+                "Error should mention provider2");
     }
 }

--- a/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
@@ -1,0 +1,103 @@
+package dev.openfeature.sdk.multiprovider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.ProviderEvaluation;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ComparisonStrategyTest extends BaseStrategyTest {
+
+    @Test
+    void shouldReturnFallbackResultWhenAllProvidersAgree() {
+        setupProviderSuccess(mockProvider1, "same");
+        setupProviderSuccess(mockProvider2, "same");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider2");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers,
+                FLAG_KEY,
+                DEFAULT_STRING,
+                null,
+                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertNotNull(result);
+        assertEquals("same", result.getValue());
+        assertNull(result.getErrorCode());
+    }
+
+    @Test
+    void shouldCallMismatchCallbackAndReturnFallbackResult() {
+        setupProviderSuccess(mockProvider1, "first");
+        setupProviderSuccess(mockProvider2, "second");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        AtomicInteger callbackCount = new AtomicInteger();
+        ComparisonStrategy strategy = new ComparisonStrategy("provider2", (key, evaluations) -> callbackCount.incrementAndGet());
+
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers,
+                FLAG_KEY,
+                DEFAULT_STRING,
+                null,
+                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals("second", result.getValue());
+        assertNull(result.getErrorCode());
+        assertEquals(1, callbackCount.get());
+    }
+
+    @Test
+    void shouldReturnGeneralErrorWhenAnyProviderFails() {
+        setupProviderSuccess(mockProvider1, "ok");
+        setupProviderError(mockProvider2, ErrorCode.PARSE_ERROR);
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers,
+                FLAG_KEY,
+                DEFAULT_STRING,
+                null,
+                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        assertTrue(result.getErrorMessage().contains("provider2"));
+    }
+
+    @Test
+    void shouldThrowWhenFallbackProviderIsMissing() {
+        setupProviderSuccess(mockProvider1, "ok");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider2");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> strategy.evaluate(
+                        providers,
+                        FLAG_KEY,
+                        DEFAULT_STRING,
+                        null,
+                        p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null)));
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
@@ -14,8 +14,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -133,39 +131,6 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         assertTrue(
                 threadNames.size() >= 2,
                 "Expected concurrent execution on multiple threads, " + "but only saw: " + threadNames);
-    }
-
-    @Test
-    void shouldReuseProvidedExecutorService() {
-        ExecutorService customExecutor = Executors.newFixedThreadPool(2);
-        try {
-            setupProviderSuccess(mockProvider1, "ok");
-            setupProviderSuccess(mockProvider2, "ok");
-
-            Map<String, FeatureProvider> providers = new LinkedHashMap<>();
-            providers.put("provider1", mockProvider1);
-            providers.put("provider2", mockProvider2);
-
-            ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, customExecutor, 5000);
-
-            // Execute twice to confirm the same executor is reused
-            for (int i = 0; i < 2; i++) {
-                ProviderEvaluation<String> result = strategy.evaluate(
-                        providers,
-                        FLAG_KEY,
-                        DEFAULT_STRING,
-                        null,
-                        p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
-                assertNotNull(result);
-                assertEquals("ok", result.getValue());
-                assertNull(result.getErrorCode());
-            }
-
-            // Executor should still be usable (not shut down)
-            assertTrue(!customExecutor.isShutdown(), "Executor should not be shut down by the strategy");
-        } finally {
-            customExecutor.shutdown();
-        }
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
@@ -33,11 +33,7 @@ class ComparisonStrategyTest extends BaseStrategyTest {
 
         ComparisonStrategy strategy = new ComparisonStrategy("provider2");
         ProviderEvaluation<String> result = strategy.evaluate(
-                providers,
-                FLAG_KEY,
-                DEFAULT_STRING,
-                null,
-                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
 
         assertNotNull(result);
         assertEquals("same", result.getValue());
@@ -54,16 +50,11 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         providers.put("provider2", mockProvider2);
 
         AtomicInteger callbackCount = new AtomicInteger();
-        ComparisonStrategy strategy = new ComparisonStrategy(
-                "provider2",
-                (key, evaluations) -> callbackCount.incrementAndGet());
+        ComparisonStrategy strategy =
+                new ComparisonStrategy("provider2", (key, evaluations) -> callbackCount.incrementAndGet());
 
         ProviderEvaluation<String> result = strategy.evaluate(
-                providers,
-                FLAG_KEY,
-                DEFAULT_STRING,
-                null,
-                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
 
         assertEquals("second", result.getValue());
         assertNull(result.getErrorCode());
@@ -81,11 +72,7 @@ class ComparisonStrategyTest extends BaseStrategyTest {
 
         ComparisonStrategy strategy = new ComparisonStrategy("provider1");
         ProviderEvaluation<String> result = strategy.evaluate(
-                providers,
-                FLAG_KEY,
-                DEFAULT_STRING,
-                null,
-                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
 
         assertEquals(ErrorCode.GENERAL, result.getErrorCode());
         assertTrue(result.getErrorMessage().contains("provider2"));
@@ -126,24 +113,18 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         setupProviderSuccess(mockProvider2, "val");
 
         ComparisonStrategy strategy = new ComparisonStrategy("provider1");
-        ProviderEvaluation<String> result = strategy.evaluate(
-                providers,
-                FLAG_KEY,
-                DEFAULT_STRING,
-                null,
-                provider -> {
-                    threadNames.add(Thread.currentThread().getName());
-                    bothStarted.countDown();
-                    try {
-                        // Wait for both providers to signal they've started
-                        bothStarted.await(5, TimeUnit.SECONDS);
-                        proceed.countDown();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                    return provider.getStringEvaluation(
-                            FLAG_KEY, DEFAULT_STRING, null);
-                });
+        ProviderEvaluation<String> result = strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
+            threadNames.add(Thread.currentThread().getName());
+            bothStarted.countDown();
+            try {
+                // Wait for both providers to signal they've started
+                bothStarted.await(5, TimeUnit.SECONDS);
+                proceed.countDown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
+        });
 
         assertNotNull(result);
         assertEquals("val", result.getValue());
@@ -151,8 +132,7 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         // Verify that at least 2 different threads were used
         assertTrue(
                 threadNames.size() >= 2,
-                "Expected concurrent execution on multiple threads, "
-                        + "but only saw: " + threadNames);
+                "Expected concurrent execution on multiple threads, " + "but only saw: " + threadNames);
     }
 
     @Test
@@ -166,8 +146,7 @@ class ComparisonStrategyTest extends BaseStrategyTest {
             providers.put("provider1", mockProvider1);
             providers.put("provider2", mockProvider2);
 
-            ComparisonStrategy strategy = new ComparisonStrategy(
-                    "provider1", null, customExecutor, 5000);
+            ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, customExecutor, 5000);
 
             // Execute twice to confirm the same executor is reused
             for (int i = 0; i < 2; i++) {
@@ -176,17 +155,14 @@ class ComparisonStrategyTest extends BaseStrategyTest {
                         FLAG_KEY,
                         DEFAULT_STRING,
                         null,
-                        p -> p.getStringEvaluation(
-                                FLAG_KEY, DEFAULT_STRING, null));
+                        p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
                 assertNotNull(result);
                 assertEquals("ok", result.getValue());
                 assertNull(result.getErrorCode());
             }
 
             // Executor should still be usable (not shut down)
-            assertTrue(
-                    !customExecutor.isShutdown(),
-                    "Executor should not be shut down by the strategy");
+            assertTrue(!customExecutor.isShutdown(), "Executor should not be shut down by the strategy");
         } finally {
             customExecutor.shutdown();
         }
@@ -203,18 +179,10 @@ class ComparisonStrategyTest extends BaseStrategyTest {
 
         ComparisonStrategy strategy = new ComparisonStrategy("provider1");
         ProviderEvaluation<String> result = strategy.evaluate(
-                providers,
-                FLAG_KEY,
-                DEFAULT_STRING,
-                null,
-                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
 
         assertEquals(ErrorCode.GENERAL, result.getErrorCode());
-        assertTrue(
-                result.getErrorMessage().contains("provider1"),
-                "Error should mention provider1");
-        assertTrue(
-                result.getErrorMessage().contains("provider2"),
-                "Error should mention provider2");
+        assertTrue(result.getErrorMessage().contains("provider1"), "Error should mention provider1");
+        assertTrue(result.getErrorMessage().contains("provider2"), "Error should mention provider2");
     }
 }

--- a/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
@@ -10,12 +10,16 @@ import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.ProviderEvaluation;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class ComparisonStrategyTest extends BaseStrategyTest {
@@ -74,6 +78,11 @@ class ComparisonStrategyTest extends BaseStrategyTest {
 
         assertEquals(ErrorCode.GENERAL, result.getErrorCode());
         assertTrue(result.getErrorMessage().contains("provider2"));
+
+        List<ProviderError> providerErrors = ((MultiProviderEvaluation<String>) result).getProviderErrors();
+        assertEquals(1, providerErrors.size());
+        assertEquals("provider2", providerErrors.get(0).getProviderName());
+        assertEquals(ErrorCode.PARSE_ERROR, providerErrors.get(0).getErrorCode());
     }
 
     @Test
@@ -95,12 +104,11 @@ class ComparisonStrategyTest extends BaseStrategyTest {
     }
 
     @Test
-    void shouldEvaluateProvidersConcurrently() throws InterruptedException {
+    void shouldEvaluateProvidersConcurrently() {
         // Use a latch to prove that providers run in parallel:
         // both providers block on the latch, so they must be on
         // separate threads for the test to complete.
         CountDownLatch bothStarted = new CountDownLatch(2);
-        CountDownLatch proceed = new CountDownLatch(1);
         Set<String> threadNames = ConcurrentHashMap.newKeySet();
 
         Map<String, FeatureProvider> providers = new LinkedHashMap<>();
@@ -110,27 +118,34 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         setupProviderSuccess(mockProvider1, "val");
         setupProviderSuccess(mockProvider2, "val");
 
-        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
-        ProviderEvaluation<String> result = strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
-            threadNames.add(Thread.currentThread().getName());
-            bothStarted.countDown();
-            try {
-                // Wait for both providers to signal they've started
-                bothStarted.await(5, TimeUnit.SECONDS);
-                proceed.countDown();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
-        });
+        // A dedicated pool of two threads: the default ForkJoinPool.commonPool() can have a
+        // parallelism of 1 on single-core runners, which would make this assertion flaky.
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, executor, 5_000);
+            ProviderEvaluation<String> result =
+                    strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
+                        threadNames.add(Thread.currentThread().getName());
+                        bothStarted.countDown();
+                        try {
+                            // Wait for both providers to signal they've started
+                            bothStarted.await(5, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
+                    });
 
-        assertNotNull(result);
-        assertEquals("val", result.getValue());
-        assertNull(result.getErrorCode());
-        // Verify that at least 2 different threads were used
-        assertTrue(
-                threadNames.size() >= 2,
-                "Expected concurrent execution on multiple threads, " + "but only saw: " + threadNames);
+            assertNotNull(result);
+            assertEquals("val", result.getValue());
+            assertNull(result.getErrorCode());
+            // Verify that at least 2 different threads were used
+            assertTrue(
+                    threadNames.size() >= 2,
+                    "Expected concurrent execution on multiple threads, but only saw: " + threadNames);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test
@@ -149,5 +164,34 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         assertEquals(ErrorCode.GENERAL, result.getErrorCode());
         assertTrue(result.getErrorMessage().contains("provider1"), "Error should mention provider1");
         assertTrue(result.getErrorMessage().contains("provider2"), "Error should mention provider2");
+
+        // Errors follow the provider registration order, not the internal concurrent map order.
+        List<ProviderError> providerErrors = ((MultiProviderEvaluation<String>) result).getProviderErrors();
+        assertEquals(2, providerErrors.size());
+        assertEquals("provider1", providerErrors.get(0).getProviderName());
+        assertEquals(ErrorCode.PARSE_ERROR, providerErrors.get(0).getErrorCode());
+        assertEquals("provider2", providerErrors.get(1).getProviderName());
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, providerErrors.get(1).getErrorCode());
+    }
+
+    @Test
+    void shouldPassSuccessfulEvaluationsInRegistrationOrderToMismatchCallback() {
+        setupProviderSuccess(mockProvider1, "first");
+        setupProviderSuccess(mockProvider2, "second");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        AtomicReference<Map<String, ProviderEvaluation<?>>> captured = new AtomicReference<>();
+        ComparisonStrategy strategy =
+                new ComparisonStrategy("provider2", (key, evaluations) -> captured.set(evaluations));
+
+        strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertNotNull(captured.get());
+        assertEquals(
+                List.of("provider1", "provider2"), List.copyOf(captured.get().keySet()));
     }
 }

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
@@ -9,12 +9,14 @@ import dev.openfeature.sdk.EventProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.ProviderEvent;
 import dev.openfeature.sdk.ProviderEventDetails;
 import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.TrackingEventDetails;
 import dev.openfeature.sdk.Value;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +65,20 @@ class MultiProviderEventsAndTrackingTest {
         } finally {
             api.shutdown();
         }
+    }
+
+    @Test
+    void shouldPreserveChildStateEmittedDuringInitialize() throws Exception {
+        TrackingProvider provider1 = new InitializingStateProvider("provider1", ProviderState.STALE);
+        TrackingProvider provider2 = new TrackingProvider("provider2");
+        MultiProvider multiProvider = new MultiProvider(List.of(provider1, provider2));
+        List<ProviderEvent> emittedEvents = new CopyOnWriteArrayList<>();
+        multiProvider.addEventObserver((event, details) -> emittedEvents.add(event));
+
+        multiProvider.initialize(null);
+
+        await().atMost(Duration.ofSeconds(2)).until(() -> emittedEvents.contains(ProviderEvent.PROVIDER_STALE));
+        assertEquals(List.of(ProviderEvent.PROVIDER_STALE), emittedEvents);
     }
 
     @Test
@@ -134,6 +150,34 @@ class MultiProviderEventsAndTrackingTest {
         @Override
         public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Value>builder().value(new Value("value")).build();
+        }
+    }
+
+    static class InitializingStateProvider extends TrackingProvider {
+        private final ProviderState initializeState;
+
+        InitializingStateProvider(String name, ProviderState initializeState) {
+            super(name);
+            this.initializeState = initializeState;
+        }
+
+        @Override
+        public void initialize(EvaluationContext evaluationContext) throws Exception {
+            if (ProviderState.STALE.equals(initializeState)) {
+                emitProviderStale(ProviderEventDetails.builder().message("stale during init").build()).await();
+            } else if (ProviderState.FATAL.equals(initializeState)) {
+                emitProviderError(ProviderEventDetails.builder()
+                                .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)
+                                .message("fatal during init")
+                                .build())
+                        .await();
+            } else if (ProviderState.ERROR.equals(initializeState)) {
+                emitProviderError(ProviderEventDetails.builder()
+                                .errorCode(dev.openfeature.sdk.ErrorCode.GENERAL)
+                                .message("error during init")
+                                .build())
+                        .await();
+            }
         }
     }
 

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
@@ -1,0 +1,145 @@
+package dev.openfeature.sdk.multiprovider;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.EventProvider;
+import dev.openfeature.sdk.Metadata;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.ProviderEventDetails;
+import dev.openfeature.sdk.ProviderState;
+import dev.openfeature.sdk.TrackingEventDetails;
+import dev.openfeature.sdk.Value;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class MultiProviderEventsAndTrackingTest {
+
+    @Test
+    void shouldAggregateChildProviderStateAndForwardConfigurationEvents() throws Exception {
+        TrackingProvider provider1 = new TrackingProvider("provider1");
+        TrackingProvider provider2 = new TrackingProvider("provider2");
+        MultiProvider multiProvider = new MultiProvider(List.of(provider1, provider2));
+
+        OpenFeatureAPI api = new TestOpenFeatureAPI();
+        api.shutdown();
+        try {
+            api.setProviderAndWait("multiProviderEvents", multiProvider);
+            Client client = api.getClient("multiProviderEvents");
+
+            await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.READY);
+
+            AtomicInteger configurationChangedCount = new AtomicInteger();
+            client.onProviderConfigurationChanged(details -> configurationChangedCount.incrementAndGet());
+
+            provider1.emitProviderConfigurationChanged(ProviderEventDetails.builder().message("changed").build()).await();
+            await().atMost(Duration.ofSeconds(2)).until(() -> configurationChangedCount.get() == 1);
+
+            provider1.emitProviderStale(ProviderEventDetails.builder().message("stale").build()).await();
+            await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.STALE);
+
+            provider2.emitProviderError(
+                            ProviderEventDetails.builder().errorCode(dev.openfeature.sdk.ErrorCode.GENERAL).build())
+                    .await();
+            await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.ERROR);
+
+            provider2.emitProviderReady(ProviderEventDetails.builder().build()).await();
+            await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.STALE);
+
+            provider1.emitProviderReady(ProviderEventDetails.builder().build()).await();
+            await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.READY);
+
+            provider1.emitProviderError(
+                            ProviderEventDetails.builder()
+                                    .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)
+                                    .build())
+                    .await();
+            await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.FATAL);
+        } finally {
+            api.shutdown();
+        }
+    }
+
+    @Test
+    void shouldForwardTrackToReadyProvidersAndSkipFatalProviders() throws Exception {
+        TrackingProvider provider1 = new TrackingProvider("provider1");
+        TrackingProvider provider2 = new TrackingProvider("provider2");
+        provider2.throwOnTrack = true;
+
+        MultiProvider multiProvider = new MultiProvider(List.of(provider1, provider2));
+        multiProvider.initialize(null);
+
+        multiProvider.track("event1", null, null);
+        assertEquals(1, provider1.trackCount.get());
+        assertEquals(1, provider2.trackCount.get());
+
+        provider1.emitProviderError(
+                        ProviderEventDetails.builder()
+                                .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)
+                                .build())
+                .await();
+
+        multiProvider.track("event2", null, null);
+        assertEquals(1, provider1.trackCount.get());
+        assertEquals(2, provider2.trackCount.get());
+    }
+
+    static class TrackingProvider extends EventProvider {
+        private final String name;
+        private final AtomicInteger trackCount = new AtomicInteger();
+        private boolean throwOnTrack;
+
+        TrackingProvider(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public Metadata getMetadata() {
+            return () -> name;
+        }
+
+        @Override
+        public void track(String eventName, EvaluationContext context, TrackingEventDetails details) {
+            trackCount.incrementAndGet();
+            if (throwOnTrack) {
+                throw new RuntimeException("track failure");
+            }
+        }
+
+        @Override
+        public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Boolean>builder().value(Boolean.TRUE).build();
+        }
+
+        @Override
+        public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<String>builder().value("value").build();
+        }
+
+        @Override
+        public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Integer>builder().value(1).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Double>builder().value(1d).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Value>builder().value(new Value("value")).build();
+        }
+    }
+
+    static class TestOpenFeatureAPI extends OpenFeatureAPI {
+        TestOpenFeatureAPI() {
+            super();
+        }
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
@@ -39,14 +39,22 @@ class MultiProviderEventsAndTrackingTest {
             AtomicInteger configurationChangedCount = new AtomicInteger();
             client.onProviderConfigurationChanged(details -> configurationChangedCount.incrementAndGet());
 
-            provider1.emitProviderConfigurationChanged(ProviderEventDetails.builder().message("changed").build()).await();
+            provider1
+                    .emitProviderConfigurationChanged(
+                            ProviderEventDetails.builder().message("changed").build())
+                    .await();
             await().atMost(Duration.ofSeconds(2)).until(() -> configurationChangedCount.get() == 1);
 
-            provider1.emitProviderStale(ProviderEventDetails.builder().message("stale").build()).await();
+            provider1
+                    .emitProviderStale(
+                            ProviderEventDetails.builder().message("stale").build())
+                    .await();
             await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.STALE);
 
-            provider2.emitProviderError(
-                            ProviderEventDetails.builder().errorCode(dev.openfeature.sdk.ErrorCode.GENERAL).build())
+            provider2
+                    .emitProviderError(ProviderEventDetails.builder()
+                            .errorCode(dev.openfeature.sdk.ErrorCode.GENERAL)
+                            .build())
                     .await();
             await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.ERROR);
 
@@ -56,10 +64,10 @@ class MultiProviderEventsAndTrackingTest {
             provider1.emitProviderReady(ProviderEventDetails.builder().build()).await();
             await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.READY);
 
-            provider1.emitProviderError(
-                            ProviderEventDetails.builder()
-                                    .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)
-                                    .build())
+            provider1
+                    .emitProviderError(ProviderEventDetails.builder()
+                            .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)
+                            .build())
                     .await();
             await().atMost(Duration.ofSeconds(2)).until(() -> client.getProviderState() == ProviderState.FATAL);
         } finally {
@@ -94,10 +102,10 @@ class MultiProviderEventsAndTrackingTest {
         assertEquals(1, provider1.trackCount.get());
         assertEquals(1, provider2.trackCount.get());
 
-        provider1.emitProviderError(
-                        ProviderEventDetails.builder()
-                                .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)
-                                .build())
+        provider1
+                .emitProviderError(ProviderEventDetails.builder()
+                        .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)
+                        .build())
                 .await();
 
         multiProvider.track("event2", null, null);
@@ -128,7 +136,8 @@ class MultiProviderEventsAndTrackingTest {
         }
 
         @Override
-        public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
+        public ProviderEvaluation<Boolean> getBooleanEvaluation(
+                String key, Boolean defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Boolean>builder().value(Boolean.TRUE).build();
         }
 
@@ -138,7 +147,8 @@ class MultiProviderEventsAndTrackingTest {
         }
 
         @Override
-        public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
+        public ProviderEvaluation<Integer> getIntegerEvaluation(
+                String key, Integer defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Integer>builder().value(1).build();
         }
 
@@ -164,7 +174,10 @@ class MultiProviderEventsAndTrackingTest {
         @Override
         public void initialize(EvaluationContext evaluationContext) throws Exception {
             if (ProviderState.STALE.equals(initializeState)) {
-                emitProviderStale(ProviderEventDetails.builder().message("stale during init").build()).await();
+                emitProviderStale(ProviderEventDetails.builder()
+                                .message("stale during init")
+                                .build())
+                        .await();
             } else if (ProviderState.FATAL.equals(initializeState)) {
                 emitProviderError(ProviderEventDetails.builder()
                                 .errorCode(dev.openfeature.sdk.ErrorCode.PROVIDER_FATAL)

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderEventsAndTrackingTest.java
@@ -28,8 +28,7 @@ class MultiProviderEventsAndTrackingTest {
         TrackingProvider provider2 = new TrackingProvider("provider2");
         MultiProvider multiProvider = new MultiProvider(List.of(provider1, provider2));
 
-        OpenFeatureAPI api = new TestOpenFeatureAPI();
-        api.shutdown();
+        OpenFeatureAPI api = OpenFeatureAPI.createIsolated();
         try {
             api.setProviderAndWait("multiProviderEvents", multiProvider);
             Client client = api.getClient("multiProviderEvents");
@@ -191,12 +190,6 @@ class MultiProviderEventsAndTrackingTest {
                                 .build())
                         .await();
             }
-        }
-    }
-
-    static class TestOpenFeatureAPI extends OpenFeatureAPI {
-        TestOpenFeatureAPI() {
-            super();
         }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutorTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutorTest.java
@@ -1,0 +1,287 @@
+package dev.openfeature.sdk.multiprovider;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.EventProvider;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.FlagValueType;
+import dev.openfeature.sdk.Hook;
+import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.Metadata;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Value;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class MultiProviderHookExecutorTest {
+
+    private final MultiProviderHookExecutor executor = new MultiProviderHookExecutor(() -> "test");
+
+    @Test
+    void shortCircuitsDirectlyWhenProviderHasNoHooks() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        ProviderEvaluation<String> result = executor.evaluate(
+                stubProvider("p", Collections.emptyList()),
+                "flag",
+                "default",
+                null,
+                null,
+                FlagValueType.STRING,
+                (p, ctx) -> {
+                    called.set(true);
+                    return ProviderEvaluation.<String>builder().value("direct").build();
+                });
+
+        assertTrue(called.get());
+        assertEquals("direct", result.getValue());
+    }
+
+    @Test
+    void shortCircuitsWhenNoHooksSupportTheFlagType() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        Hook<Boolean> boolOnlyHook = new Hook<Boolean>() {
+            @Override
+            public boolean supportsFlagValueType(FlagValueType type) {
+                return type == FlagValueType.BOOLEAN;
+            }
+        };
+        ProviderEvaluation<String> result = executor.evaluate(
+                stubProvider("p", List.of(boolOnlyHook)),
+                "flag",
+                "default",
+                null,
+                null,
+                FlagValueType.STRING,
+                (p, ctx) -> {
+                    called.set(true);
+                    return ProviderEvaluation.<String>builder().value("direct").build();
+                });
+
+        assertTrue(called.get());
+        assertEquals("direct", result.getValue());
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void toleratesNullReturnedFromBeforeHook() {
+        Hook nullBeforeHook = new Hook() {
+            @Override
+            public Optional before(HookContext ctx, Map hints) {
+                return null;
+            }
+        };
+        ProviderEvaluation<String> result = executor.evaluate(
+                stubProvider("p", List.of(nullBeforeHook)),
+                "flag",
+                "default",
+                null,
+                null,
+                FlagValueType.STRING,
+                (p, ctx) -> ProviderEvaluation.<String>builder().value("ok").build());
+
+        assertEquals("ok", result.getValue());
+    }
+
+    @Test
+    void swallowsExceptionThrownFromErrorHook() {
+        AtomicBoolean errorHookCalled = new AtomicBoolean(false);
+        Hook<String> throwingErrorHook = new Hook<String>() {
+            @Override
+            public void error(HookContext<String> ctx, Exception error, Map<String, Object> hints) {
+                errorHookCalled.set(true);
+                throw new RuntimeException("error hook exploded");
+            }
+        };
+        RuntimeException providerEx = new RuntimeException("provider failed");
+
+        RuntimeException thrown = assertThrows(
+                RuntimeException.class,
+                () -> executor.evaluate(
+                        stubProvider("p", List.of(throwingErrorHook)),
+                        "flag",
+                        "default",
+                        null,
+                        null,
+                        FlagValueType.STRING,
+                        (p, ctx) -> {
+                            throw providerEx;
+                        }));
+
+        assertTrue(errorHookCalled.get(), "error() hook should have been called");
+        assertEquals(providerEx, thrown, "original provider exception must propagate");
+    }
+
+    @Test
+    void swallowsExceptionThrownFromFinallyAfterHook() {
+        Hook<String> throwingFinallyHook = new Hook<String>() {
+            @Override
+            public void finallyAfter(
+                    HookContext<String> ctx, FlagEvaluationDetails<String> details, Map<String, Object> hints) {
+                throw new RuntimeException("finallyAfter exploded");
+            }
+        };
+
+        assertDoesNotThrow(() -> executor.evaluate(
+                stubProvider("p", List.of(throwingFinallyHook)),
+                "flag",
+                "default",
+                null,
+                null,
+                FlagValueType.STRING,
+                (p, ctx) -> ProviderEvaluation.<String>builder().value("ok").build()));
+    }
+
+    @Test
+    void finallyAfterReceivesSyntheticDetailsWhenBeforeThrows() {
+        AtomicReference<FlagEvaluationDetails<String>> captured = new AtomicReference<>();
+        Hook<String> hook = new Hook<String>() {
+            @Override
+            public Optional<EvaluationContext> before(HookContext<String> ctx, Map<String, Object> hints) {
+                throw new RuntimeException("before failed");
+            }
+
+            @Override
+            public void finallyAfter(
+                    HookContext<String> ctx, FlagEvaluationDetails<String> details, Map<String, Object> hints) {
+                captured.set(details);
+            }
+        };
+
+        assertThrows(
+                RuntimeException.class,
+                () -> executor.evaluate(
+                        stubProvider("p", List.of(hook)),
+                        "flag",
+                        "fallback",
+                        null,
+                        null,
+                        FlagValueType.STRING,
+                        (p, ctx) ->
+                                ProviderEvaluation.<String>builder().value("ok").build()));
+
+        assertNotNull(captured.get(), "finallyAfter must be called even when before() throws");
+        assertEquals("flag", captured.get().getFlagKey());
+        assertEquals("fallback", captured.get().getValue());
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void normalizesNullDefaultValueForEachFlagType() {
+        AtomicReference<Object> capturedDefault = new AtomicReference<>();
+        Hook capturingHook = new Hook() {
+            @Override
+            public Optional before(HookContext ctx, Map hints) {
+                capturedDefault.set(ctx.getDefaultValue());
+                return Optional.empty();
+            }
+        };
+        FeatureProvider provider = stubProvider("p", List.of(capturingHook));
+
+        executor.evaluate(
+                provider,
+                "f",
+                (Boolean) null,
+                null,
+                null,
+                FlagValueType.BOOLEAN,
+                (p, ctx) -> ProviderEvaluation.<Boolean>builder().value(false).build());
+        assertEquals(Boolean.FALSE, capturedDefault.get());
+
+        executor.evaluate(
+                provider,
+                "f",
+                (String) null,
+                null,
+                null,
+                FlagValueType.STRING,
+                (p, ctx) -> ProviderEvaluation.<String>builder().value("").build());
+        assertEquals("", capturedDefault.get());
+
+        executor.evaluate(
+                provider,
+                "f",
+                (Integer) null,
+                null,
+                null,
+                FlagValueType.INTEGER,
+                (p, ctx) -> ProviderEvaluation.<Integer>builder().value(0).build());
+        assertEquals(0, capturedDefault.get());
+
+        executor.evaluate(
+                provider,
+                "f",
+                (Double) null,
+                null,
+                null,
+                FlagValueType.DOUBLE,
+                (p, ctx) -> ProviderEvaluation.<Double>builder().value(0d).build());
+        assertEquals(0d, capturedDefault.get());
+
+        executor.evaluate(
+                provider,
+                "f",
+                (Value) null,
+                null,
+                null,
+                FlagValueType.OBJECT,
+                (p, ctx) ->
+                        ProviderEvaluation.<Value>builder().value(new Value()).build());
+        assertNotNull(capturedDefault.get());
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static FeatureProvider stubProvider(String name, List<Hook> hooks) {
+        return new EventProvider() {
+            @Override
+            public Metadata getMetadata() {
+                return () -> name;
+            }
+
+            @Override
+            public List<Hook> getProviderHooks() {
+                return hooks;
+            }
+
+            @Override
+            public ProviderEvaluation<Boolean> getBooleanEvaluation(
+                    String key, Boolean defaultValue, EvaluationContext ctx) {
+                return ProviderEvaluation.<Boolean>builder().value(defaultValue).build();
+            }
+
+            @Override
+            public ProviderEvaluation<String> getStringEvaluation(
+                    String key, String defaultValue, EvaluationContext ctx) {
+                return ProviderEvaluation.<String>builder().value(defaultValue).build();
+            }
+
+            @Override
+            public ProviderEvaluation<Integer> getIntegerEvaluation(
+                    String key, Integer defaultValue, EvaluationContext ctx) {
+                return ProviderEvaluation.<Integer>builder().value(defaultValue).build();
+            }
+
+            @Override
+            public ProviderEvaluation<Double> getDoubleEvaluation(
+                    String key, Double defaultValue, EvaluationContext ctx) {
+                return ProviderEvaluation.<Double>builder().value(defaultValue).build();
+            }
+
+            @Override
+            public ProviderEvaluation<Value> getObjectEvaluation(
+                    String key, Value defaultValue, EvaluationContext ctx) {
+                return ProviderEvaluation.<Value>builder().value(defaultValue).build();
+            }
+        };
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutorTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHookExecutorTest.java
@@ -16,6 +16,7 @@ import dev.openfeature.sdk.HookContext;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,32 @@ class MultiProviderHookExecutorTest {
 
         assertTrue(called.get());
         assertEquals("direct", result.getValue());
+    }
+
+    @Test
+    void runsBeforeInRegistrationOrderAndRemainingStagesInReverse() {
+        List<String> calls = new ArrayList<>();
+        Hook<String> first = orderRecordingHook(calls, "first");
+        Hook<String> second = orderRecordingHook(calls, "second");
+
+        executor.evaluate(
+                stubProvider("p", List.of(first, second)),
+                "flag",
+                "default",
+                null,
+                null,
+                FlagValueType.STRING,
+                (p, ctx) -> ProviderEvaluation.<String>builder().value("ok").build());
+
+        assertEquals(
+                List.of(
+                        "before:first",
+                        "before:second",
+                        "after:second",
+                        "after:first",
+                        "finally:second",
+                        "finally:first"),
+                calls);
     }
 
     @Test
@@ -238,6 +265,28 @@ class MultiProviderHookExecutorTest {
                 (p, ctx) ->
                         ProviderEvaluation.<Value>builder().value(new Value()).build());
         assertNotNull(capturedDefault.get());
+    }
+
+    private static Hook<String> orderRecordingHook(List<String> calls, String name) {
+        return new Hook<String>() {
+            @Override
+            public Optional<EvaluationContext> before(HookContext<String> ctx, Map<String, Object> hints) {
+                calls.add("before:" + name);
+                return Optional.empty();
+            }
+
+            @Override
+            public void after(
+                    HookContext<String> ctx, FlagEvaluationDetails<String> details, Map<String, Object> hints) {
+                calls.add("after:" + name);
+            }
+
+            @Override
+            public void finallyAfter(
+                    HookContext<String> ctx, FlagEvaluationDetails<String> details, Map<String, Object> hints) {
+                calls.add("finally:" + name);
+            }
+        };
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
@@ -1,17 +1,24 @@
 package dev.openfeature.sdk.multiprovider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventProvider;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.FlagEvaluationOptions;
 import dev.openfeature.sdk.Hook;
 import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.MutableContext;
+import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Reason;
 import dev.openfeature.sdk.Value;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,9 +63,73 @@ class MultiProviderHooksTest {
 
         assertEquals("provider1", provider1.lastEvaluationContext.getValue("hookOwner").asString());
         assertNull(provider1.lastEvaluationContext.getValue("provider2Marker"));
+        assertNotNull(firstHook.lastFinallyDetails);
+        assertEquals(ErrorCode.GENERAL, firstHook.lastFinallyDetails.getErrorCode());
+        assertEquals(Reason.ERROR.toString(), firstHook.lastFinallyDetails.getReason());
+        assertEquals("default", firstHook.lastFinallyDetails.getValue());
+        assertEquals("failed", firstHook.lastFinallyDetails.getErrorMessage());
 
         assertEquals("provider2", provider2.lastEvaluationContext.getValue("hookOwner").asString());
         assertNull(provider2.lastEvaluationContext.getValue("provider1Marker"));
+    }
+
+    @Test
+    void shouldExposeContextCapturingProviderHook() throws Exception {
+        HookedStringProvider provider1 = new HookedStringProvider(
+                "provider1",
+                List.of(),
+                ProviderEvaluation.<String>builder().value("ok").build());
+
+        MultiProvider multiProvider = new MultiProvider(
+                List.of(provider1), new FirstSuccessfulStrategy());
+        multiProvider.initialize(null);
+
+        // MultiProvider should expose a provider hook for context capture
+        var providerHooks = multiProvider.getProviderHooks();
+        assertNotNull(providerHooks);
+        assertEquals(1, providerHooks.size(), "Should have exactly one context-capturing hook");
+    }
+
+    @Test
+    void shouldPassHookHintsAndClientMetadataAndEnrichThrownProviderErrors() throws Exception {
+        RecordingHook firstHook = new RecordingHook("provider1");
+        RecordingHook secondHook = new RecordingHook("provider2");
+
+        HookedStringProvider provider1 = new HookedStringProvider("provider1", List.of(firstHook), new RuntimeException("boom"));
+        HookedStringProvider provider2 = new HookedStringProvider(
+                "provider2",
+                List.of(secondHook),
+                ProviderEvaluation.<String>builder().value("ok").build());
+
+        MultiProvider multiProvider = new MultiProvider(List.of(provider1, provider2), new FirstSuccessfulStrategy());
+
+        OpenFeatureAPI api = new TestOpenFeatureAPI();
+        api.shutdown();
+        try {
+            api.setProviderAndWait("multiProviderHooks", multiProvider);
+            Client client = api.getClient("multiProviderHooks");
+
+            var evaluation = client.getStringDetails(
+                    "flag",
+                    "default",
+                    new ImmutableContext(),
+                    FlagEvaluationOptions.builder().hookHints(Map.of("hintKey", "hintValue")).build());
+
+            assertEquals("ok", evaluation.getValue());
+
+            assertEquals("hintValue", firstHook.lastHints.get("hintKey"));
+            assertEquals("hintValue", secondHook.lastHints.get("hintKey"));
+            assertEquals("multiProviderHooks", firstHook.lastClientDomain);
+            assertEquals("multiProviderHooks", secondHook.lastClientDomain);
+
+            assertNotNull(firstHook.lastFinallyDetails);
+            assertEquals(ErrorCode.GENERAL, firstHook.lastFinallyDetails.getErrorCode());
+            assertEquals(Reason.ERROR.toString(), firstHook.lastFinallyDetails.getReason());
+            assertEquals("default", firstHook.lastFinallyDetails.getValue());
+            assertEquals("boom", firstHook.lastFinallyDetails.getErrorMessage());
+        } finally {
+            api.shutdown();
+        }
     }
 
     static class RecordingHook implements Hook<String> {
@@ -67,6 +138,9 @@ class MultiProviderHooksTest {
         private final AtomicInteger afterCount = new AtomicInteger();
         private final AtomicInteger errorCount = new AtomicInteger();
         private final AtomicInteger finallyCount = new AtomicInteger();
+        private Map<String, Object> lastHints = Map.of();
+        private String lastClientDomain;
+        private FlagEvaluationDetails<String> lastFinallyDetails;
 
         RecordingHook(String providerName) {
             this.providerName = providerName;
@@ -76,6 +150,8 @@ class MultiProviderHooksTest {
         public Optional<EvaluationContext> before(HookContext<String> ctx, Map<String, Object> hints) {
             beforeCount.incrementAndGet();
             ctx.getHookData().set("provider", providerName);
+            lastHints = hints;
+            lastClientDomain = ctx.getClientMetadata().getDomain();
             return Optional.of(new MutableContext()
                     .add("hookOwner", providerName)
                     .add(providerName + "Marker", providerName));
@@ -88,12 +164,16 @@ class MultiProviderHooksTest {
                 Map<String, Object> hints) {
             afterCount.incrementAndGet();
             assertEquals(providerName, ctx.getHookData().get("provider"));
+            lastHints = hints;
+            lastClientDomain = ctx.getClientMetadata().getDomain();
         }
 
         @Override
         public void error(HookContext<String> ctx, Exception error, Map<String, Object> hints) {
             errorCount.incrementAndGet();
             assertEquals(providerName, ctx.getHookData().get("provider"));
+            lastHints = hints;
+            lastClientDomain = ctx.getClientMetadata().getDomain();
         }
 
         @Override
@@ -103,19 +183,31 @@ class MultiProviderHooksTest {
                 Map<String, Object> hints) {
             finallyCount.incrementAndGet();
             assertEquals(providerName, ctx.getHookData().get("provider"));
+            lastHints = hints;
+            lastClientDomain = ctx.getClientMetadata().getDomain();
+            lastFinallyDetails = details;
         }
     }
 
     static class HookedStringProvider extends EventProvider {
         private final String name;
-        private final List<Hook> hooks;
+        private final List<Hook<String>> hooks;
         private final ProviderEvaluation<String> evaluation;
+        private final RuntimeException evaluationException;
         private EvaluationContext lastEvaluationContext;
 
-        HookedStringProvider(String name, List<Hook> hooks, ProviderEvaluation<String> evaluation) {
+        HookedStringProvider(String name, List<Hook<String>> hooks, ProviderEvaluation<String> evaluation) {
             this.name = name;
             this.hooks = hooks;
             this.evaluation = evaluation;
+            this.evaluationException = null;
+        }
+
+        HookedStringProvider(String name, List<Hook<String>> hooks, RuntimeException evaluationException) {
+            this.name = name;
+            this.hooks = hooks;
+            this.evaluation = null;
+            this.evaluationException = evaluationException;
         }
 
         @Override
@@ -124,8 +216,9 @@ class MultiProviderHooksTest {
         }
 
         @Override
+        @SuppressWarnings("rawtypes")
         public List<Hook> getProviderHooks() {
-            return hooks;
+            return List.copyOf(hooks);
         }
 
         @Override
@@ -136,6 +229,9 @@ class MultiProviderHooksTest {
         @Override
         public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
             lastEvaluationContext = ctx == null ? new MutableContext() : ctx;
+            if (evaluationException != null) {
+                throw evaluationException;
+            }
             return evaluation;
         }
 
@@ -152,6 +248,12 @@ class MultiProviderHooksTest {
         @Override
         public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Value>builder().value(defaultValue).build();
+        }
+    }
+
+    static class TestOpenFeatureAPI extends OpenFeatureAPI {
+        TestOpenFeatureAPI() {
+            super();
         }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
@@ -1,0 +1,157 @@
+package dev.openfeature.sdk.multiprovider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.EventProvider;
+import dev.openfeature.sdk.Hook;
+import dev.openfeature.sdk.HookContext;
+import dev.openfeature.sdk.Metadata;
+import dev.openfeature.sdk.MutableContext;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Value;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class MultiProviderHooksTest {
+
+    @Test
+    void shouldExecuteProviderHooksAndKeepPerProviderContextIsolation() throws Exception {
+        RecordingHook firstHook = new RecordingHook("provider1");
+        RecordingHook secondHook = new RecordingHook("provider2");
+
+        HookedStringProvider provider1 = new HookedStringProvider(
+                "provider1",
+                List.of(firstHook),
+                ProviderEvaluation.<String>builder()
+                        .errorCode(dev.openfeature.sdk.ErrorCode.GENERAL)
+                        .errorMessage("failed")
+                        .build());
+        HookedStringProvider provider2 = new HookedStringProvider(
+                "provider2",
+                List.of(secondHook),
+                ProviderEvaluation.<String>builder().value("ok").build());
+
+        MultiProvider multiProvider = new MultiProvider(List.of(provider1, provider2), new FirstSuccessfulStrategy());
+        multiProvider.initialize(null);
+
+        ProviderEvaluation<String> evaluation = multiProvider.getStringEvaluation("flag", "default", null);
+
+        assertEquals("ok", evaluation.getValue());
+
+        assertEquals(1, firstHook.beforeCount.get());
+        assertEquals(0, firstHook.afterCount.get());
+        assertEquals(1, firstHook.errorCount.get());
+        assertEquals(1, firstHook.finallyCount.get());
+
+        assertEquals(1, secondHook.beforeCount.get());
+        assertEquals(1, secondHook.afterCount.get());
+        assertEquals(0, secondHook.errorCount.get());
+        assertEquals(1, secondHook.finallyCount.get());
+
+        assertEquals("provider1", provider1.lastEvaluationContext.getValue("hookOwner").asString());
+        assertNull(provider1.lastEvaluationContext.getValue("provider2Marker"));
+
+        assertEquals("provider2", provider2.lastEvaluationContext.getValue("hookOwner").asString());
+        assertNull(provider2.lastEvaluationContext.getValue("provider1Marker"));
+    }
+
+    static class RecordingHook implements Hook<String> {
+        private final String providerName;
+        private final AtomicInteger beforeCount = new AtomicInteger();
+        private final AtomicInteger afterCount = new AtomicInteger();
+        private final AtomicInteger errorCount = new AtomicInteger();
+        private final AtomicInteger finallyCount = new AtomicInteger();
+
+        RecordingHook(String providerName) {
+            this.providerName = providerName;
+        }
+
+        @Override
+        public Optional<EvaluationContext> before(HookContext<String> ctx, Map<String, Object> hints) {
+            beforeCount.incrementAndGet();
+            ctx.getHookData().set("provider", providerName);
+            return Optional.of(new MutableContext()
+                    .add("hookOwner", providerName)
+                    .add(providerName + "Marker", providerName));
+        }
+
+        @Override
+        public void after(
+                HookContext<String> ctx,
+                dev.openfeature.sdk.FlagEvaluationDetails<String> details,
+                Map<String, Object> hints) {
+            afterCount.incrementAndGet();
+            assertEquals(providerName, ctx.getHookData().get("provider"));
+        }
+
+        @Override
+        public void error(HookContext<String> ctx, Exception error, Map<String, Object> hints) {
+            errorCount.incrementAndGet();
+            assertEquals(providerName, ctx.getHookData().get("provider"));
+        }
+
+        @Override
+        public void finallyAfter(
+                HookContext<String> ctx,
+                dev.openfeature.sdk.FlagEvaluationDetails<String> details,
+                Map<String, Object> hints) {
+            finallyCount.incrementAndGet();
+            assertEquals(providerName, ctx.getHookData().get("provider"));
+        }
+    }
+
+    static class HookedStringProvider extends EventProvider {
+        private final String name;
+        private final List<Hook> hooks;
+        private final ProviderEvaluation<String> evaluation;
+        private EvaluationContext lastEvaluationContext;
+
+        HookedStringProvider(String name, List<Hook> hooks, ProviderEvaluation<String> evaluation) {
+            this.name = name;
+            this.hooks = hooks;
+            this.evaluation = evaluation;
+        }
+
+        @Override
+        public Metadata getMetadata() {
+            return () -> name;
+        }
+
+        @Override
+        public List<Hook> getProviderHooks() {
+            return hooks;
+        }
+
+        @Override
+        public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Boolean>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
+            lastEvaluationContext = ctx == null ? new MutableContext() : ctx;
+            return evaluation;
+        }
+
+        @Override
+        public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Integer>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Double>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Value>builder().value(defaultValue).build();
+        }
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
@@ -78,22 +78,6 @@ class MultiProviderHooksTest {
     }
 
     @Test
-    void shouldExposeContextCapturingProviderHook() throws Exception {
-        HookedStringProvider provider1 = new HookedStringProvider(
-                "provider1",
-                List.of(),
-                ProviderEvaluation.<String>builder().value("ok").build());
-
-        MultiProvider multiProvider = new MultiProvider(List.of(provider1), new FirstSuccessfulStrategy());
-        multiProvider.initialize(null);
-
-        // MultiProvider should expose a provider hook for context capture
-        var providerHooks = multiProvider.getProviderHooks();
-        assertNotNull(providerHooks);
-        assertEquals(1, providerHooks.size(), "Should have exactly one context-capturing hook");
-    }
-
-    @Test
     void shouldPassHookHintsAndClientMetadataAndEnrichThrownProviderErrors() throws Exception {
         RecordingHook firstHook = new RecordingHook("provider1");
         RecordingHook secondHook = new RecordingHook("provider2");

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
@@ -61,7 +61,9 @@ class MultiProviderHooksTest {
         assertEquals(0, secondHook.errorCount.get());
         assertEquals(1, secondHook.finallyCount.get());
 
-        assertEquals("provider1", provider1.lastEvaluationContext.getValue("hookOwner").asString());
+        assertEquals(
+                "provider1",
+                provider1.lastEvaluationContext.getValue("hookOwner").asString());
         assertNull(provider1.lastEvaluationContext.getValue("provider2Marker"));
         assertNotNull(firstHook.lastFinallyDetails);
         assertEquals(ErrorCode.GENERAL, firstHook.lastFinallyDetails.getErrorCode());
@@ -69,7 +71,9 @@ class MultiProviderHooksTest {
         assertEquals("default", firstHook.lastFinallyDetails.getValue());
         assertEquals("failed", firstHook.lastFinallyDetails.getErrorMessage());
 
-        assertEquals("provider2", provider2.lastEvaluationContext.getValue("hookOwner").asString());
+        assertEquals(
+                "provider2",
+                provider2.lastEvaluationContext.getValue("hookOwner").asString());
         assertNull(provider2.lastEvaluationContext.getValue("provider1Marker"));
     }
 
@@ -80,8 +84,7 @@ class MultiProviderHooksTest {
                 List.of(),
                 ProviderEvaluation.<String>builder().value("ok").build());
 
-        MultiProvider multiProvider = new MultiProvider(
-                List.of(provider1), new FirstSuccessfulStrategy());
+        MultiProvider multiProvider = new MultiProvider(List.of(provider1), new FirstSuccessfulStrategy());
         multiProvider.initialize(null);
 
         // MultiProvider should expose a provider hook for context capture
@@ -95,7 +98,8 @@ class MultiProviderHooksTest {
         RecordingHook firstHook = new RecordingHook("provider1");
         RecordingHook secondHook = new RecordingHook("provider2");
 
-        HookedStringProvider provider1 = new HookedStringProvider("provider1", List.of(firstHook), new RuntimeException("boom"));
+        HookedStringProvider provider1 =
+                new HookedStringProvider("provider1", List.of(firstHook), new RuntimeException("boom"));
         HookedStringProvider provider2 = new HookedStringProvider(
                 "provider2",
                 List.of(secondHook),
@@ -113,7 +117,9 @@ class MultiProviderHooksTest {
                     "flag",
                     "default",
                     new ImmutableContext(),
-                    FlagEvaluationOptions.builder().hookHints(Map.of("hintKey", "hintValue")).build());
+                    FlagEvaluationOptions.builder()
+                            .hookHints(Map.of("hintKey", "hintValue"))
+                            .build());
 
             assertEquals("ok", evaluation.getValue());
 
@@ -152,9 +158,8 @@ class MultiProviderHooksTest {
             ctx.getHookData().set("provider", providerName);
             lastHints = hints;
             lastClientDomain = ctx.getClientMetadata().getDomain();
-            return Optional.of(new MutableContext()
-                    .add("hookOwner", providerName)
-                    .add(providerName + "Marker", providerName));
+            return Optional.of(
+                    new MutableContext().add("hookOwner", providerName).add(providerName + "Marker", providerName));
         }
 
         @Override
@@ -222,7 +227,8 @@ class MultiProviderHooksTest {
         }
 
         @Override
-        public ProviderEvaluation<Boolean> getBooleanEvaluation(String key, Boolean defaultValue, EvaluationContext ctx) {
+        public ProviderEvaluation<Boolean> getBooleanEvaluation(
+                String key, Boolean defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Boolean>builder().value(defaultValue).build();
         }
 
@@ -236,7 +242,8 @@ class MultiProviderHooksTest {
         }
 
         @Override
-        public ProviderEvaluation<Integer> getIntegerEvaluation(String key, Integer defaultValue, EvaluationContext ctx) {
+        public ProviderEvaluation<Integer> getIntegerEvaluation(
+                String key, Integer defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Integer>builder().value(defaultValue).build();
         }
 

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderHooksTest.java
@@ -91,8 +91,7 @@ class MultiProviderHooksTest {
 
         MultiProvider multiProvider = new MultiProvider(List.of(provider1, provider2), new FirstSuccessfulStrategy());
 
-        OpenFeatureAPI api = new TestOpenFeatureAPI();
-        api.shutdown();
+        OpenFeatureAPI api = OpenFeatureAPI.createIsolated();
         try {
             api.setProviderAndWait("multiProviderHooks", multiProvider);
             Client client = api.getClient("multiProviderHooks");
@@ -239,12 +238,6 @@ class MultiProviderHooksTest {
         @Override
         public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Value>builder().value(defaultValue).build();
-        }
-    }
-
-    static class TestOpenFeatureAPI extends OpenFeatureAPI {
-        TestOpenFeatureAPI() {
-            super();
         }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
@@ -145,7 +145,12 @@ class MultiProviderTest extends BaseStrategyTest {
         List<FeatureProvider> providers = new ArrayList<>(2);
         providers.add(mockProvider1);
         providers.add(mockProvider2);
-        assertDoesNotThrow(() -> new MultiProvider(providers).initialize(null));
+        MultiProvider multiProvider = new MultiProvider(providers);
+        assertDoesNotThrow(() -> multiProvider.initialize(null));
+        MultiProviderMetadata metadata = (MultiProviderMetadata) multiProvider.getMetadata();
+        assertEquals(2, metadata.getOriginalMetadata().size());
+        assertNotNull(metadata.getOriginalMetadata().get("provider"));
+        assertNotNull(metadata.getOriginalMetadata().get("provider-1"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fixes multiprovider parity gaps identified in cross-SDK comparison against the js-sdk reference
- Decouples `OpenFeatureClient` from `MultiProvider` for hook context capture, uses a provider-level `before` hook with a `ThreadLocal`, matching the JS SDK's `WeakMap` pattern
- Adds provider state tracking, child provider event observation, and `track()` delegation to `MultiProvider`
- Adds `ComparisonStrategy`, parallel evaluation across all providers with configurable fallback and mismatch callback
- Adds test coverage for concurrent evaluation, provider hook lifecycle ordering, event/state aggregation, and `track()` forwarding

## Implementation

| Change | Details |
|--------|---------|
| **Context capture** | `MultiProvider.getProviderHooks()` returns a `before` hook that captures `ClientMetadata` and a defensive copy of the hook hints into a `ThreadLocal`; a `finallyAfter` hook cleans it up. Removes the `OpenFeatureClient` → `MultiProvider` import dependency. |
| **Provider state tracking** | Per-child `ProviderState` map with severity-based aggregate state (`FATAL > NOT_READY > ERROR > STALE > READY`). Registers/deregisters `EventProvider` observers to react to child provider state changes. `PROVIDER_CONFIGURATION_CHANGED` is always forwarded. |
| **Per-provider hooks** | `MultiProviderHookExecutor` runs each child provider's own hooks around its evaluation: `before` in registration order, `after`/`error`/`finallyAfter` in reverse, with an isolated context copy per provider. |
| **`ComparisonStrategy`** | Evaluates all providers in parallel via `ForkJoinPool.commonPool()` (or a caller-supplied executor). Returns the fallback provider's result on agreement; invokes the optional `onMismatch` callback on disagreement. On failure returns a `MultiProviderEvaluation` carrying per-provider `ProviderError` details, consistent with `FirstMatchStrategy` / `FirstSuccessfulStrategy`. |
| **`track()`** | Forwards to all child providers, skipping `NOT_READY` / `FATAL` ones. Per-provider errors are logged, not propagated. |
| **Provider deduplication** | `buildProviders` now appends `-1`, `-2` suffixes instead of silently dropping duplicates. |
| **`EventProvider`** | Adds `addEventObserver` / `removeEventObserver` for composite provider patterns. |

### Notes

- Rebased on current main. This picks up `initialize(ctx, domain)` from #1982 (forwarded to child providers) and `OpenFeatureAPI.createIsolated()` from #1928 (used by the new tests).
- Gap 5 in #1882 also asked that an explicit name conflict throw. Java's `MultiProvider` only accepts `List<FeatureProvider>` with no explicit-naming API, so there's nothing to conflict with; only the metadata-derived auto-dedup applies here.

### Related Issues

Fixes #1882
Replaces #1883