### PR TITLE
docs: fix inaccuracies in README code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,15 +217,15 @@ If the flag management system you're using supports targeting, you can provide t
 // set a value to the global context
 OpenFeatureAPI api = OpenFeatureAPI.getInstance();
 Map<String, Value> apiAttrs = new HashMap<>();
-apiAttrs.put("region", new Value(System.getEnv("us-east-1")));
+apiAttrs.put("region", new Value(System.getenv("AWS_REGION")));
 EvaluationContext apiCtx = new ImmutableContext(apiAttrs);
 api.setEvaluationContext(apiCtx);
 
 // set a value to the client context
 Map<String, Value> clientAttrs = new HashMap<>();
-clientAttrs.put("region", new Value(System.getEnv("us-east-1")));
+clientAttrs.put("region", new Value(System.getenv("AWS_REGION")));
 EvaluationContext clientCtx = new ImmutableContext(clientAttrs);
-Client client = api.getInstance().getClient();
+Client client = api.getClient();
 client.setEvaluationContext(clientCtx);
 
 // set a value to the invocation context
@@ -292,7 +292,7 @@ If a domain has no associated provider, the global provider is used.
 FeatureProvider scopedProvider = new MyProvider();
 
 // registering the default provider
-OpenFeatureAPI.getInstance().setProvider(LocalProvider());
+OpenFeatureAPI.getInstance().setProvider(new LocalProvider());
 // registering a provider to a domain
 OpenFeatureAPI.getInstance().setProvider("my-domain", new CachedProvider());
 
@@ -452,25 +452,26 @@ This can be a new repository or included in [the existing contrib repository](ht
 Implement your own hook by conforming to the `Hook interface`.
 
 ```java
-class MyHook implements Hook {
+class MyHook implements Hook<Object> {
 
     @Override
-    public Optional before(HookContext ctx, Map hints) {
+    public Optional<EvaluationContext> before(HookContext<Object> ctx, Map<String, Object> hints) {
         // code that runs before the flag evaluation
+        return Optional.empty();
     }
 
     @Override
-    public void after(HookContext ctx, FlagEvaluationDetails details, Map hints) {
+    public void after(HookContext<Object> ctx, FlagEvaluationDetails<Object> details, Map<String, Object> hints) {
         // code that runs after the flag evaluation succeeds
     }
 
     @Override
-    public void error(HookContext ctx, Exception error, Map hints) {
+    public void error(HookContext<Object> ctx, Exception error, Map<String, Object> hints) {
         // code that runs when there's an error during a flag evaluation
     }
 
     @Override
-    public void finallyAfter(HookContext ctx, FlagEvaluationDetails details, Map hints) {
+    public void finallyAfter(HookContext<Object> ctx, FlagEvaluationDetails<Object> details, Map<String, Object> hints) {
         // code that runs regardless of success or error
     }
 };


### PR DESCRIPTION
## Summary

- Fix multiple code examples in the README that would fail to compile as written

## Changes

1. **Targeting section**: Fixed `System.getEnv("us-east-1")` (both occurrences). The method is `System.getenv(...)` (lowercase `e` — `getEnv` does not exist in Java). The argument was also wrong — `"us-east-1"` is a region value, not an env var name. Changed to `System.getenv("AWS_REGION")` which reads the region from the environment variable
2. **Targeting section**: Simplified `api.getInstance().getClient()` to `api.getClient()`. Calling `getInstance()` (a static method) through the `api` instance reference is redundant since `api` was already assigned the singleton on the line above
3. **Domains section**: Added missing `new` keyword in `setProvider(LocalProvider())` — without `new`, Java parses it as a method call to a nonexistent static `LocalProvider()` method, causing a compile error
4. **Hook example**: Parameterized all raw types to match the actual `Hook<T>` interface signatures:
   - `Hook` -> `Hook<Object>`
   - `HookContext ctx` -> `HookContext<Object> ctx`
   - `Map hints` -> `Map<String, Object> hints`
   - `Optional` (return of `before`) -> `Optional<EvaluationContext>`
   - `FlagEvaluationDetails details` -> `FlagEvaluationDetails<Object> details`
5. **Hook example**: Added `return Optional.empty();` to `before()`. Once the return type is parameterized as `Optional<EvaluationContext>` (instead of raw `Optional`), a missing return becomes a compile error rather than silently compiling

All fixed examples were verified to compile cleanly against the current main branch. Original broken versions were confirmed to fail compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated targeting configuration example to read region from environment variables instead of hardcoded values
  * Updated domain provider registration example with clearer syntax patterns
  * Updated hook development example with improved type safety using generics and typed interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->