### PR TITLE
fix: shutdown now clears hooks, evaluationContext and transactionContextPropagator as per spec 1.6.2

### DIFF
--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -356,7 +356,7 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
                 providerRepository = new ProviderRepository(this);
                 eventSupport = new EventSupport();
                 clearHooks();
-                setEvaluationContext(new ImmutableContext());
+                setEvaluationContext(ImmutableContext.EMPTY);
                 setTransactionContextPropagator(new NoOpTransactionContextPropagator());
             }
         }

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.java
@@ -355,6 +355,9 @@ public class OpenFeatureAPI implements EventBus<OpenFeatureAPI> {
             try (AutoCloseableLock ignored = lock.writeLockAutoCloseable()) {
                 providerRepository = new ProviderRepository(this);
                 eventSupport = new EventSupport();
+                clearHooks();
+                setEvaluationContext(new ImmutableContext());
+                setTransactionContextPropagator(new NoOpTransactionContextPropagator());
             }
         }
     }

--- a/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
@@ -141,9 +141,10 @@ class ShutdownBehaviorSpecTest {
         void apiStateMustBeResetOnShuttingDownApi() {
 
             FeatureProvider provider = ProviderFixture.createMockedProvider();
-            TransactionContextPropagator transactionContextPropagator = new NoOpTransactionContextPropagator();
+            TransactionContextPropagator transactionContextPropagator = mock(TransactionContextPropagator.class);
             EvaluationContext evaluationContext = mock(EvaluationContext.class);
 
+            api.addHooks(mock(Hook.class));
             api.setProvider(provider);
             api.setEvaluationContext(evaluationContext);
             api.setTransactionContextPropagator(transactionContextPropagator);

--- a/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -155,6 +156,10 @@ class ShutdownBehaviorSpecTest {
             assertTrue(api.getHooks().isEmpty());
             assertNotEquals(evaluationContext, api.getEvaluationContext());
             assertNotEquals(transactionContextPropagator, api.getTransactionContextPropagator());
+
+            assertInstanceOf(NoOpProvider.class, api.getProvider());
+            assertInstanceOf(ImmutableContext.class, api.getEvaluationContext());
+            assertInstanceOf(NoOpTransactionContextPropagator.class, api.getTransactionContextPropagator());
         }
 
         @Test

--- a/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/ShutdownBehaviorSpecTest.java
@@ -1,5 +1,7 @@
 package dev.openfeature.sdk;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import dev.openfeature.sdk.fixtures.ProviderFixture;
@@ -131,16 +133,27 @@ class ShutdownBehaviorSpecTest {
         }
 
         @Test
-        @DisplayName("once shutdown is complete, api must be ready to use again")
-        void apiIsReadyToUseAfterShutdown() {
+        @Specification(
+                number = "1.6.2",
+                text =
+                        "The API's `shutdown` function MUST reset all state of the API, removing all hooks, event handlers, evaluation context, transaction context propagators, and providers.")
+        @DisplayName("shutdown must reset the state of the API")
+        void apiStateMustBeResetOnShuttingDownApi() {
 
-            NoOpProvider p1 = new NoOpProvider();
-            api.setProvider(p1);
+            FeatureProvider provider = ProviderFixture.createMockedProvider();
+            TransactionContextPropagator transactionContextPropagator = new NoOpTransactionContextPropagator();
+            EvaluationContext evaluationContext = mock(EvaluationContext.class);
+
+            api.setProvider(provider);
+            api.setEvaluationContext(evaluationContext);
+            api.setTransactionContextPropagator(transactionContextPropagator);
 
             api.shutdown();
 
-            NoOpProvider p2 = new NoOpProvider();
-            api.setProvider(p2);
+            assertNotEquals(provider, api.getProvider());
+            assertTrue(api.getHooks().isEmpty());
+            assertNotEquals(evaluationContext, api.getEvaluationContext());
+            assertNotEquals(transactionContextPropagator, api.getTransactionContextPropagator());
         }
 
         @Test


### PR DESCRIPTION

## This PR

Ensures that Spec 1.6.2 is implemented correctly. shutdown will now also clear the hooks, evaluationContext and transactionContextPropagator.


### Related Issues

Fixes #1926

### Notes
N/A

### Follow-up Tasks
N/A

### How to test
 Unit test added to cover this change

