### PR TITLE
perf: cache clientMetadata lambda to avoid per-call allocation

### DIFF
--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -51,6 +51,7 @@ public class OpenFeatureClient implements Client {
     private final AtomicReference<EvaluationContext> evaluationContext = new AtomicReference<>();
 
     private final HookSupport hookSupport;
+    private final ClientMetadata clientMetadata;
 
     /**
      * Deprecated public constructor. Use OpenFeature.API.getClient() instead.
@@ -70,6 +71,7 @@ public class OpenFeatureClient implements Client {
         this.version = version;
         this.hookSupport = new HookSupport();
         this.clientHooks = new ConcurrentLinkedQueue<>();
+        this.clientMetadata = this::getDomain;
     }
 
     /**
@@ -467,7 +469,7 @@ public class OpenFeatureClient implements Client {
 
     @Override
     public ClientMetadata getMetadata() {
-        return this::getDomain;
+        return clientMetadata;
     }
 
     /**


### PR DESCRIPTION
## This PR

  - Caches the `ClientMetadata` lambda in a final field to avoid re-allocating it on every `getMetadata()` call

### Related Issues
None

### Notes
 `getMetadata()` is called once per flag evaluation to build the `SharedHookContext`. Previously it returned `this::getDomain` — a new lambda instance each time. The field is initialized once in the constructor.

Allocation impact is negligible, but reduces on `totalAllocatedInstances` can be seen.

| Metric | `main` (baseline) | This PR | Delta |
  |--------|-------------------|------|-------|                                                                                                                                                               
  | `run:+totalAllocatedBytes` | 124,265,984 | 124,265,984 | **0** |
  | `run:+totalAllocatedInstances` | 2,723,316 | 2,674,636 | −48,680 (−1.8%) |

### Follow-up Tasks
  - More PRs with memory improvements
  - Update benchmark.txt after all are applied