### PR TITLE
perf: skip unmodifiableMap wrapper when hookHints is empty

### DIFF
--- a/src/main/java/dev/openfeature/sdk/FlagEvaluationOptions.java
+++ b/src/main/java/dev/openfeature/sdk/FlagEvaluationOptions.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,4 +20,13 @@ public class FlagEvaluationOptions {
 
     @Builder.Default
     Map<String, Object> hookHints = new HashMap<>();
+
+    public static class FlagEvaluationOptionsBuilder {
+        /** Sets hook hints, normalizing null to an empty map. */
+        public FlagEvaluationOptionsBuilder hookHints(Map<String, Object> hookHints) {
+            this.hookHints$value = hookHints != null ? hookHints : Collections.emptyMap();
+            this.hookHints$set = true;
+            return this;
+        }
+    }
 }

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -170,7 +170,8 @@ public class OpenFeatureClient implements Client {
             flagOptions = options;
         }
 
-        hookSupportData.hints = Collections.unmodifiableMap(flagOptions.getHookHints());
+        var hookHints = flagOptions.getHookHints();
+        hookSupportData.hints = hookHints.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(hookHints);
         var context = new LayeredEvaluationContext(
                 openfeatureApi.getEvaluationContext(),
                 openfeatureApi.getTransactionContext(),

--- a/src/test/java/dev/openfeature/sdk/HookSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSpecTest.java
@@ -511,6 +511,13 @@ class HookSpecTest implements HookFixtures {
     }
 
     @Test
+    void null_hook_hints_does_not_throw() {
+        FlagEvaluationOptions feo =
+                FlagEvaluationOptions.builder().hookHints(null).build();
+        assertThat(feo.getHookHints()).isNotNull().isEmpty();
+    }
+
+    @Test
     void flag_eval_hook_order() {
         Hook hook = mockBooleanHook();
         FeatureProvider provider = mock(FeatureProvider.class);

--- a/src/test/java/dev/openfeature/sdk/HookSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSpecTest.java
@@ -512,9 +512,20 @@ class HookSpecTest implements HookFixtures {
 
     @Test
     void null_hook_hints_does_not_throw() {
-        FlagEvaluationOptions feo =
-                FlagEvaluationOptions.builder().hookHints(null).build();
-        assertThat(feo.getHookHints()).isNotNull().isEmpty();
+        Hook hook = mockBooleanHook();
+        FeatureProvider provider = mock(FeatureProvider.class);
+        when(provider.getBooleanEvaluation(any(), any(), any()))
+                .thenReturn(ProviderEvaluation.<Boolean>builder().value(true).build());
+
+        api.setProviderAndWait(provider);
+        Client client = api.getClient();
+
+        assertThatCode(() -> client.getBooleanValue(
+                        "key",
+                        false,
+                        new ImmutableContext(),
+                        FlagEvaluationOptions.builder().hook(hook).hookHints(null).build()))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/HookSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSpecTest.java
@@ -524,7 +524,10 @@ class HookSpecTest implements HookFixtures {
                         "key",
                         false,
                         new ImmutableContext(),
-                        FlagEvaluationOptions.builder().hook(hook).hookHints(null).build()))
+                        FlagEvaluationOptions.builder()
+                                .hook(hook)
+                                .hookHints(null)
+                                .build()))
                 .doesNotThrowAnyException();
     }
 


### PR DESCRIPTION
## This PR

 - Skips the `Collections.unmodifiableMap()` wrapper when `hookHints` is empty (the common case)

### Related Issues
None

### Notes
 `hookHints` is resolved once per flag evaluation. Previously it was always wrapped in an unmodifiable view, even when empty. This PR avoids that allocation by returning `Collections.emptyMap()` directly when there are
  no hints.

Allocation impact is negligible, but reduces on `totalAllocatedInstances` can be seen.

  | Metric | `main` (baseline) | PR 2 | Delta |
  |--------|-------------------|------|-------|
  | `run:+totalAllocatedBytes` | 124,265,984 | 124,268,232 | ~0 (noise) |
  | `run:+totalAllocatedInstances` | 2,723,316 | 2,691,291 | −32,025 (−1.2%) |

### Follow-up Tasks
- More PRs with memory improvements
- Update benchmark.txt after all are applied