### PR TITLE
perf: replace copy+reverse with index-based traversal in executeBefor…

### DIFF
--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -1,7 +1,6 @@
 package dev.openfeature.sdk;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -51,10 +50,9 @@ class HookSupport {
 
     public void executeBeforeHooks(HookSupportData data) {
         // These traverse backwards from normal.
-        List<Pair<Hook, HookContext>> reversedHooks = new ArrayList<>(data.getHooks());
-        Collections.reverse(reversedHooks);
-
-        for (Pair<Hook, HookContext> hookContextPair : reversedHooks) {
+        List<Pair<Hook, HookContext>> hooks = data.getHooks();
+        for (int i = hooks.size() - 1; i >= 0; i--) {
+            var hookContextPair = hooks.get(i);
             var hook = hookContextPair.getKey();
             var hookContext = hookContextPair.getValue();
 


### PR DESCRIPTION
## This PR

- Replaces the copy-and-reverse pattern in `executeBeforeHooks` with an index-based reverse loop

### Related Issues
None
                                                                                                                                                                                                
### Notes                                                                                                                                                                                                
Previously `executeBeforeHooks` copied the hook list into a new `ArrayList` and called `Collections.reverse()` before iterating. This allocated one extra list per flag evaluation. The change iterates the existing list in reverse using an index loop, which requires no additional allocation.

  | Metric | `main` (baseline) | This PR | Delta |
  |--------|-------------------|------|-------|
  | `run:+totalAllocatedBytes` | 124,265,984 | 120,069,632 | −4,196,352 (−3.4%) |
  | `run:+totalAllocatedInstances` | 2,723,316 | 2,654,727 | −68,589 (−2.5%) |

### Follow-up Tasks
- More PRs with memory improvements
- Update benchmark.txt after all are applied