### PR TITLE
perf: avoid Optional.ofNullable wrapping on hook.before() return value

### DIFF
--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -56,10 +56,8 @@ class HookSupport {
             var hook = hookContextPair.getKey();
             var hookContext = hookContextPair.getValue();
 
-            Optional<EvaluationContext> returnedEvalContext = Optional.ofNullable(
-                            hook.before(hookContext, data.getHints()))
-                    .orElse(Optional.empty());
-            if (returnedEvalContext.isPresent()) {
+            Optional<EvaluationContext> returnedEvalContext = hook.before(hookContext, data.getHints());
+            if (returnedEvalContext != null && returnedEvalContext.isPresent()) {
                 var returnedContext = returnedEvalContext.get();
                 // yes, we want to check for reference equality here, this prevents recursive layered contexts
                 if (returnedContext != hookContext.getCtx() && !returnedContext.isEmpty()) {

--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -48,6 +48,8 @@ class HookSupport {
         }
     }
 
+    // S2789: Hook is user-implemented; defensive null check against non-conforming impls returning null.
+    @SuppressWarnings("java:S2789")
     public void executeBeforeHooks(HookSupportData data) {
         // These traverse backwards from normal.
         List<Pair<Hook, HookContext>> hooks = data.getHooks();


### PR DESCRIPTION
## This PR

- Replaces `Optional.ofNullable(hook.before(...)).orElse(Optional.empty())` with a direct null check

### Related Issues
None

### Notes
The previous pattern wrapped the return value of `hook.before()` in `Optional.ofNullable()` to guard against `null` returns (which are non-standard but possible). This created up to two temporary `Optional` objects per hook call. The replacement assigns the return value directly and guards with an explicit `!= null` check, which is semantically equivalent.

Allocation impact is negligible, but reduces on totalAllocatedInstances can be seen.

  | Metric | `main` (baseline) | PR 4 | Delta |
  |--------|-------------------|------|-------|
  | `run:+totalAllocatedBytes` | 124,265,984 | 124,268,232 | ~0 (noise) |
  | `run:+totalAllocatedInstances` | 2,723,316 | 2,700,508 | −22,808 (−0.8%) |

### Follow-up Tasks
-More PRs with memory improvements
- Update benchmark.txt after all are applied