### PR TITLE
perf: eliminate merge allocation in setHooks by accepting hook sources directly

### DIFF
--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -16,7 +16,10 @@ class HookSupport {
     /**
      * Sets the {@link Hook}-{@link HookContext}-{@link Pair} list in the given data object with {@link HookContext}
      * set to null. Filters hooks by supported {@link FlagValueType}.
-     * Sources are iterated in order: provider → options → client → API.
+     * Sources are iterated in order: provider, options, client, API (reversed for the {@code before} stage by
+     * {@link #executeBeforeHooks}).
+     *
+     * <p>The four hook sources are accepted as separate collections to avoid allocation on the evaluation hot path.
      *
      * @param hookSupportData the data object to modify
      * @param providerHooks   provider-level hooks

--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -2,7 +2,6 @@ package dev.openfeature.sdk;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -1,6 +1,8 @@
 package dev.openfeature.sdk;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -15,19 +17,37 @@ class HookSupport {
     /**
      * Sets the {@link Hook}-{@link HookContext}-{@link Pair} list in the given data object with {@link HookContext}
      * set to null. Filters hooks by supported {@link FlagValueType}.
+     * Sources are iterated in order: provider → options → client → API.
      *
      * @param hookSupportData the data object to modify
-     * @param hooks           the hooks to set
+     * @param providerHooks   provider-level hooks
+     * @param optionHooks     per-evaluation option hooks
+     * @param clientHooks     client-level hooks
+     * @param apiHooks        API-level hooks
      * @param type            the flag value type to filter unsupported hooks
      */
-    public void setHooks(HookSupportData hookSupportData, List<Hook> hooks, FlagValueType type) {
+    public void setHooks(
+            HookSupportData hookSupportData,
+            Collection<Hook> providerHooks,
+            Collection<Hook> optionHooks,
+            Collection<Hook> clientHooks,
+            Collection<Hook> apiHooks,
+            FlagValueType type) {
         List<Pair<Hook, HookContext>> hookContextPairs = new ArrayList<>();
-        for (Hook hook : hooks) {
+        addFilteredHooks(hookContextPairs, providerHooks, type);
+        addFilteredHooks(hookContextPairs, optionHooks, type);
+        addFilteredHooks(hookContextPairs, clientHooks, type);
+        addFilteredHooks(hookContextPairs, apiHooks, type);
+        hookSupportData.hooks = hookContextPairs;
+    }
+
+    private static void addFilteredHooks(
+            List<Pair<Hook, HookContext>> dest, Collection<Hook> source, FlagValueType type) {
+        for (Hook hook : source) {
             if (hook.supportsFlagValueType(type)) {
-                hookContextPairs.add(Pair.of(hook, null));
+                dest.add(Pair.of(hook, null));
             }
         }
-        hookSupportData.hooks = hookContextPairs;
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
+++ b/src/main/java/dev/openfeature/sdk/OpenFeatureClient.java
@@ -5,7 +5,6 @@ import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
-import dev.openfeature.sdk.internal.ObjectUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -188,9 +187,13 @@ public class OpenFeatureClient implements Client {
             final var state = stateManager.getState();
 
             // Hooks are initialized as early as possible to enable the execution of error stages
-            var mergedHooks = ObjectUtils.merge(
-                    provider.getProviderHooks(), flagOptions.getHooks(), clientHooks, openfeatureApi.getMutableHooks());
-            hookSupport.setHooks(hookSupportData, mergedHooks, type);
+            hookSupport.setHooks(
+                    hookSupportData,
+                    provider.getProviderHooks(),
+                    flagOptions.getHooks(),
+                    clientHooks,
+                    openfeatureApi.getMutableHooks(),
+                    type);
 
             var sharedHookContext =
                     new SharedHookContext(key, type, this.getMetadata(), provider.getMetadata(), defaultValue);

--- a/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
+++ b/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
@@ -1,5 +1,7 @@
 package dev.openfeature.sdk.internal;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -53,5 +55,23 @@ public class ObjectUtils {
             return defaultValue.get();
         }
         return source;
+    }
+
+    /**
+     * Concatenate a bunch of lists.
+     *
+     * @param sources bunch of lists.
+     * @param <T>     list type
+     * @return resulting object
+     * @deprecated Not used in the project anymore. This method will be removed in a future release.
+     */
+    @Deprecated(forRemoval = true)
+    @SafeVarargs
+    public static <T> List<T> merge(Collection<T>... sources) {
+        List<T> merged = new ArrayList<>();
+        for (Collection<T> source : sources) {
+            merged.addAll(source);
+        }
+        return merged;
     }
 }

--- a/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
+++ b/src/main/java/dev/openfeature/sdk/internal/ObjectUtils.java
@@ -1,7 +1,5 @@
 package dev.openfeature.sdk.internal;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -55,21 +53,5 @@ public class ObjectUtils {
             return defaultValue.get();
         }
         return source;
-    }
-
-    /**
-     * Concatenate a bunch of lists.
-     *
-     * @param sources bunch of lists.
-     * @param <T>     list type
-     * @return resulting object
-     */
-    @SafeVarargs
-    public static <T> List<T> merge(Collection<T>... sources) {
-        List<T> merged = new ArrayList<>();
-        for (Collection<T> source : sources) {
-            merged.addAll(source);
-        }
-        return merged;
     }
 }

--- a/src/test/java/dev/openfeature/sdk/HookSupportTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSupportTest.java
@@ -66,9 +66,9 @@ class HookSupportTest implements HookFixtures {
         var hookSupportData = new HookSupportData();
         hookSupport.setHooks(
                 hookSupportData,
-                Collections.emptyList(),
-                Collections.emptyList(),
                 List.of(genericHook),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Collections.emptyList(),
                 flagValueType);
 
@@ -89,8 +89,8 @@ class HookSupportTest implements HookFixtures {
         hookSupport.setHooks(
                 hookSupportData,
                 Collections.emptyList(),
-                Collections.emptyList(),
                 List.of(testHook),
+                Collections.emptyList(),
                 Collections.emptyList(),
                 flagValueType);
         hookSupport.setHookContexts(
@@ -125,8 +125,8 @@ class HookSupportTest implements HookFixtures {
                 hookSupportData,
                 Collections.emptyList(),
                 Collections.emptyList(),
-                List.of(testHook1, testHook2),
                 Collections.emptyList(),
+                List.of(testHook1, testHook2),
                 flagValueType);
         hookSupport.setHookContexts(
                 hookSupportData,
@@ -137,6 +137,28 @@ class HookSupportTest implements HookFixtures {
 
         assertHookData(testHook1, 1, "before", "after", "finallyAfter", "error");
         assertHookData(testHook2, 2, "before", "after", "finallyAfter", "error");
+    }
+
+    @Test
+    @DisplayName("should place hooks in provider → options → client → API order")
+    void shouldOrderHooksBySource() {
+        Hook<?> providerHook = mockGenericHook();
+        Hook<?> optionHook = mockGenericHook();
+        Hook<?> clientHook = mockGenericHook();
+        Hook<?> apiHook = mockGenericHook();
+
+        var hookSupportData = new HookSupportData();
+        hookSupport.setHooks(
+                hookSupportData,
+                List.of(providerHook),
+                List.of(optionHook),
+                List.of(clientHook),
+                List.of(apiHook),
+                FlagValueType.STRING);
+
+        assertThat(hookSupportData.getHooks())
+                .extracting(Pair::getKey)
+                .containsExactly(providerHook, optionHook, clientHook, apiHook);
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/HookSupportTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSupportTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import dev.openfeature.sdk.fixtures.HookFixtures;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,13 @@ class HookSupportTest implements HookFixtures {
         var sharedContext = getBaseHookContextForType(FlagValueType.STRING);
         var hookSupportData = new HookSupportData();
         hookSupportData.evaluationContext = layered;
-        hookSupport.setHooks(hookSupportData, Arrays.asList(hook1, hook2), FlagValueType.STRING);
+        hookSupport.setHooks(
+                hookSupportData,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Arrays.asList(hook1, hook2),
+                Collections.emptyList(),
+                FlagValueType.STRING);
         hookSupport.setHookContexts(hookSupportData, sharedContext, layered);
 
         hookSupport.executeBeforeHooks(hookSupportData);
@@ -57,7 +64,13 @@ class HookSupportTest implements HookFixtures {
         Hook<?> genericHook = mockGenericHook();
 
         var hookSupportData = new HookSupportData();
-        hookSupport.setHooks(hookSupportData, List.of(genericHook), flagValueType);
+        hookSupport.setHooks(
+                hookSupportData,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                List.of(genericHook),
+                Collections.emptyList(),
+                flagValueType);
 
         callAllHooks(hookSupportData);
 
@@ -73,7 +86,13 @@ class HookSupportTest implements HookFixtures {
     void shouldPassDataAcrossStages(FlagValueType flagValueType) {
         var testHook = new TestHookWithData();
         var hookSupportData = new HookSupportData();
-        hookSupport.setHooks(hookSupportData, List.of(testHook), flagValueType);
+        hookSupport.setHooks(
+                hookSupportData,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                List.of(testHook),
+                Collections.emptyList(),
+                flagValueType);
         hookSupport.setHookContexts(
                 hookSupportData,
                 getBaseHookContextForType(flagValueType),
@@ -102,7 +121,13 @@ class HookSupportTest implements HookFixtures {
         var testHook2 = new TestHookWithData(2);
 
         var hookSupportData = new HookSupportData();
-        hookSupport.setHooks(hookSupportData, List.of(testHook1, testHook2), flagValueType);
+        hookSupport.setHooks(
+                hookSupportData,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                List.of(testHook1, testHook2),
+                Collections.emptyList(),
+                flagValueType);
         hookSupport.setHookContexts(
                 hookSupportData,
                 getBaseHookContextForType(flagValueType),
@@ -132,7 +157,13 @@ class HookSupportTest implements HookFixtures {
         var layeredEvaluationContext =
                 new LayeredEvaluationContext(evaluationContextWithValue("key", "value"), null, null, null);
         hookSupportData.evaluationContext = layeredEvaluationContext;
-        hookSupport.setHooks(hookSupportData, List.of(recursiveHook, emptyHook), FlagValueType.STRING);
+        hookSupport.setHooks(
+                hookSupportData,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                List.of(recursiveHook, emptyHook),
+                Collections.emptyList(),
+                FlagValueType.STRING);
         hookSupport.setHookContexts(
                 hookSupportData, getBaseHookContextForType(FlagValueType.STRING), layeredEvaluationContext);
 


### PR DESCRIPTION
## This PR

- Eliminates the intermediate merged list in `setHooks` by accepting the four hook sources directly

### Related Issues
None
                                                                                                                                                                                                
### Notes
Previously `OpenFeatureClient` called `ObjectUtils.merge(providerHooks, optionHooks, clientHooks, apiHooks)` to concatenate all hook sources into a single `ArrayList` before passing it to `HookSupport.setHooks`. This allocated one list per flag evaluation solely to iterate it once. The change accepts the four sources as separate `Collection<Hook>` parameters and iterates them directly via a private `addFilteredHooks` helper, removing the intermediate allocation entirely.

  | Metric | `main` (baseline) | PR 5 | Delta |
  |--------|-------------------|------|-------|                                                                                                                                                 
  | `run:+totalAllocatedBytes` | 124,265,984 | 111,685,320 | −12,580,664 (−10.1%) |
  | `run:+totalAllocatedInstances` | 2,723,316 | 2,444,048 | −279,268 (−10.3%) |

### Follow-up Tasks
- Update benchmark.txt after all are applied
