### PR TITLE
fix: keep distributionManagement in flattened pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,10 @@
                 <version>1.7.0</version>
                 <configuration>
                     <flattenMode>ossrh</flattenMode>
+                    <pomElements>
+                        <!-- keep distributionManagement so the central-publishing plugin can resolve the snapshot repo during deploy -->
+                        <distributionManagement>resolve</distributionManagement>
+                    </pomElements>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Follow-up to #1951. Flatten was stripping `<distributionManagement>`, which broke the snapshot deploy in `on-merge` (central-publishing falls back to it for the snapshots URL).