### PR TITLE
perf: skip iterating over empty list

### DIFF
--- a/src/main/java/dev/openfeature/sdk/HookSupport.java
+++ b/src/main/java/dev/openfeature/sdk/HookSupport.java
@@ -45,6 +45,9 @@ class HookSupport {
 
     private static void addFilteredHooks(
             List<Pair<Hook, HookContext>> dest, Collection<Hook> source, FlagValueType type) {
+        if (source.isEmpty()) {
+            return;
+        }
         for (Hook hook : source) {
             if (hook.supportsFlagValueType(type)) {
                 dest.add(Pair.of(hook, null));

--- a/src/test/java/dev/openfeature/sdk/HookSupportTest.java
+++ b/src/test/java/dev/openfeature/sdk/HookSupportTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -159,6 +160,37 @@ class HookSupportTest implements HookFixtures {
         assertThat(hookSupportData.getHooks())
                 .extracting(Pair::getKey)
                 .containsExactly(providerHook, optionHook, clientHook, apiHook);
+    }
+
+    @Test
+    @DisplayName("empty ConcurrentLinkedQueue sources produce no hooks")
+    void emptyQueueSourcesProduceNoHooks() {
+        var hookSupportData = new HookSupportData();
+        hookSupport.setHooks(
+                hookSupportData,
+                new ConcurrentLinkedQueue<>(),
+                new ConcurrentLinkedQueue<>(),
+                new ConcurrentLinkedQueue<>(),
+                new ConcurrentLinkedQueue<>(),
+                FlagValueType.STRING);
+        assertThat(hookSupportData.getHooks()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("non-empty ConcurrentLinkedQueue source is not skipped")
+    void nonEmptyQueueSourceIsNotSkipped() {
+        Hook<?> hook = mockGenericHook();
+        var queue = new ConcurrentLinkedQueue<Hook>();
+        queue.add(hook);
+        var hookSupportData = new HookSupportData();
+        hookSupport.setHooks(
+                hookSupportData,
+                new ConcurrentLinkedQueue<>(),
+                new ConcurrentLinkedQueue<>(),
+                queue,
+                new ConcurrentLinkedQueue<>(),
+                FlagValueType.STRING);
+        assertThat(hookSupportData.getHooks()).extracting(Pair::getKey).containsExactly(hook);
     }
 
     @Test


### PR DESCRIPTION
## This PR

- Adds an early-exit guard in `HookSupport.addFilteredHooks` when the source collection is empty

### Related Issues
None

### Notes
`addFilteredHooks` is called four times per flag evaluation (provider, options, client, API hooks). In the common case three of those sources are empty, but a for-each loop always calls `collection.iterator()` before checking `hasNext()`, allocating a `ConcurrentLinkedQueue$Itr` or `ArrayList$Itr` unnecessarily. The `isEmpty()` check short-circuits before the iterator is ever created.

  | Metric | `benchmark.txt` | `main` | This PR | Delta vs `main` |
  |--------|-----------------|--------|---------|-----------------|
  | `run:+totalAllocatedBytes` | 139,359,040 | 107,492,056 | 103,293,456 | −4,198,600 (−3.9%) |
  | `run:+totalAllocatedInstances` | 4,452,140 | 2,228,290 | 2,117,789 | −110,501 (−4.9%) |

### Follow-up Tasks
- More PRs with memory improvements
- Update `benchmark.txt` after all are applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Improved hook handling efficiency when processing empty sources.

* **Tests**
  * Added test coverage for hook-source behavior with concurrent queue implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->