### PR TITLE
perf: empty default for ProviderEvaluation

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderEvaluation.java
@@ -23,5 +23,5 @@ public class ProviderEvaluation<T> implements BaseEvaluation<T> {
     private String errorMessage;
 
     @Builder.Default
-    private ImmutableMetadata flagMetadata = ImmutableMetadata.builder().build();
+    private ImmutableMetadata flagMetadata = ImmutableMetadata.EMPTY;
 }


### PR DESCRIPTION
## This PR

- Use `ImmutableMetadata.EMPTY` singleton as the default value for `ProviderEvaluation.flagMetadata`

### Related Issues
None

### Notes
Every `ProviderEvaluation` built without explicit metadata allocated a fresh empty `ImmutableMetadata` instance via `@Builder.Default`. Reusing the existing `ImmutableMetadata.EMPTY` singleton is safe because the class has no mutation methods, and `FlagEvaluationDetails` already uses the same singleton as its default.

  | Metric | `benchmark.txt` | `main` | This PR | Delta vs `main` |
  |--------|-----------------|--------|---------|-----------------|
  | `run:+totalAllocatedBytes` | 139,359,040 | 107,492,056 | 103,292,056 | −4,200,000 (−3.9%) |
  | `run:+totalAllocatedInstances` | 4,452,140 | 2,228,290 | 2,109,848 | −118,442 (−5.3%) |

### Follow-up Tasks
- More PRs with memory improvements
- Update `benchmark.txt` after all are applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release includes internal optimizations with no user-facing changes.

* **Chores**
  * Optimized initialization of default metadata values for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->