### PR TITLE
perf: skip ImmutableMetadata allocation when builder has no entries

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableMetadata.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableMetadata.java
@@ -101,7 +101,7 @@ public class ImmutableMetadata {
     }
 
     public Map<String, Object> asUnmodifiableMap() {
-        return Collections.unmodifiableMap(metadata);
+        return metadata.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(metadata);
     }
 
     public boolean isEmpty() {
@@ -199,6 +199,9 @@ public class ImmutableMetadata {
          * Retrieve {@link ImmutableMetadata} with provided key,value pairs.
          */
         public ImmutableMetadata build() {
+            if (metadata.isEmpty()) {
+                return EMPTY;
+            }
             return new ImmutableMetadata(this.metadata);
         }
     }

--- a/src/test/java/dev/openfeature/sdk/ImmutableMetadataTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableMetadataTest.java
@@ -1,10 +1,12 @@
 package dev.openfeature.sdk;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ImmutableMetadataTest {
@@ -37,5 +39,19 @@ class ImmutableMetadataTest {
         assertEquals(unmodifiableMap.size(), 1);
         assertEquals(unmodifiableMap.get("key1"), "value1");
         Assertions.assertThrows(UnsupportedOperationException.class, () -> unmodifiableMap.put("key3", "value3"));
+    }
+
+    @Test
+    @DisplayName("empty builder returns EMPTY singleton")
+    void emptyBuilderReturnsEmptySingleton() {
+        assertThat(ImmutableMetadata.builder().build()).isSameAs(ImmutableMetadata.EMPTY);
+    }
+
+    @Test
+    @DisplayName("asUnmodifiableMap on empty metadata returns empty unmodifiable map")
+    void asUnmodifiableMapOnEmptyMetadataIsUnmodifiable() {
+        Map<String, Object> map = ImmutableMetadata.EMPTY.asUnmodifiableMap();
+        assertThat(map).isEmpty();
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> map.put("key", "value"));
     }
 }


### PR DESCRIPTION
## This PR

- `ImmutableMetadata.build()` returns `EMPTY` singleton when the builder's metadata map is empty
- `ImmutableMetadata.asUnmodifiableMap()` returns `Collections.emptyMap()` singleton when metadata is empty

### Related Issues
None

### Notes

`ImmutableMetadata.builder().build()` is the `@Builder.Default` for `ProviderEvaluation.flagMetadata`, so every flag evaluation without explicit metadata allocated a throwaway `ImmutableMetadata` backed by an empty `HashMap`. Returning `EMPTY` is safe — `ImmutableMetadata` has no mutation methods.

`asUnmodifiableMap()` now returns the JDK `Collections.emptyMap()` singleton for empty metadata, avoiding the `UnmodifiableMap` wrapper allocation.

| Metric | Baseline | This PR | Delta |
|--------|----------|---------|-------|
| `run:+totalAllocatedInstances` | 2,239,379 | 2,145,282 | −94,097 (−4.2%) |
| `run:+totalAllocatedBytes` | 106,304,128 | 102,105,728 | −4,198,400 (−3.9%) |

### Follow-up Tasks
- More PRs with memory improvements
- Update `benchmark.txt` after all are applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized empty metadata handling to improve performance and ensure consistent behavior across metadata operations.

* **Tests**
  * Enhanced test coverage for empty metadata scenarios, including validation of immutability guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->