### PR TITLE
perf: avoid ImmutableStructure allocation for empty ImmutableContext

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -2,7 +2,6 @@ package dev.openfeature.sdk;
 
 import dev.openfeature.sdk.internal.ExcludeFromGeneratedCoverageReport;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import lombok.ToString;
@@ -32,7 +31,7 @@ public final class ImmutableContext implements EvaluationContext {
      * provided.
      */
     public ImmutableContext() {
-        this(new HashMap<>());
+        this(Collections.emptyMap());
     }
 
     /**
@@ -41,7 +40,7 @@ public final class ImmutableContext implements EvaluationContext {
      * @param targetingKey targeting key
      */
     public ImmutableContext(String targetingKey) {
-        this(targetingKey, new HashMap<>());
+        this(targetingKey, Collections.emptyMap());
     }
 
     /**
@@ -63,6 +62,8 @@ public final class ImmutableContext implements EvaluationContext {
     public ImmutableContext(String targetingKey, Map<String, Value> attributes) {
         if (targetingKey != null) {
             this.structure = new ImmutableStructure(targetingKey, attributes);
+        } else if (attributes == null || attributes.isEmpty()) {
+            this.structure = ImmutableStructure.EMPTY;
         } else {
             this.structure = new ImmutableStructure(attributes);
         }

--- a/src/main/java/dev/openfeature/sdk/ImmutableStructure.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableStructure.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -20,6 +21,8 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @SuppressWarnings({"PMD.BeanMembersShouldSerialize", "checkstyle:MissingJavadocType"})
 public final class ImmutableStructure extends AbstractStructure {
+
+    static final ImmutableStructure EMPTY = new ImmutableStructure(Collections.emptyMap());
 
     /**
      * create an immutable structure with the empty attributes.

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -1,6 +1,7 @@
 package dev.openfeature.sdk;
 
 import static dev.openfeature.sdk.EvaluationContext.TARGETING_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -214,6 +215,42 @@ class ImmutableContextTest {
         int first = ctx.hashCode();
         int second = ctx.hashCode();
         assertEquals(first, second);
+    }
+
+    @Nested
+    @DisplayName("ImmutableContext(String, Map) branch logic")
+    class ConstructorBranches {
+
+        @Test
+        @DisplayName("non-null targeting key with empty attributes is preserved")
+        void nonNullTargetingKeyWithEmptyAttributesIsPreserved() {
+            ImmutableContext ctx = new ImmutableContext("key", Collections.emptyMap());
+            assertThat(ctx.getTargetingKey()).isEqualTo("key");
+            assertThat(ctx.keySet()).contains(TARGETING_KEY);
+        }
+
+        @Test
+        @DisplayName("non-null targeting key with null attributes is preserved")
+        void nonNullTargetingKeyWithNullAttributesIsPreserved() {
+            ImmutableContext ctx = new ImmutableContext("key", null);
+            assertThat(ctx.getTargetingKey()).isEqualTo("key");
+        }
+
+        @Test
+        @DisplayName("null targeting key with empty attributes yields empty context")
+        void nullTargetingKeyWithEmptyAttributesYieldsEmptyContext() {
+            ImmutableContext ctx = new ImmutableContext((String) null, Collections.emptyMap());
+            assertThat(ctx.getTargetingKey()).isNull();
+            assertThat(ctx.isEmpty()).isTrue();
+        }
+
+        @Test
+        @DisplayName("null targeting key with null attributes yields empty context")
+        void nullTargetingKeyWithNullAttributesYieldsEmptyContext() {
+            ImmutableContext ctx = new ImmutableContext((String) null, null);
+            assertThat(ctx.getTargetingKey()).isNull();
+            assertThat(ctx.isEmpty()).isTrue();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## This PR

- Add `ImmutableStructure.EMPTY` singleton (package-private)
- `ImmutableContext()` and `ImmutableContext(String)` pass `Collections.emptyMap()` instead of `new HashMap<>()`
- `ImmutableContext(String targetingKey, Map attributes)` reuses `ImmutableStructure.EMPTY` when `targetingKey` is null and attributes are empty
- Tests to guard the constructor branch logic

### Related Issues
None

### Notes

Before-hook implementations commonly return `new ImmutableContext()` to signal no context change. Each call previously allocated a throwaway `HashMap` as the constructor argument, then a second `HashMap` inside `ImmutableStructure`. Passing `Collections.emptyMap()` eliminates the first allocation; reusing `ImmutableStructure.EMPTY` eliminates both the `ImmutableStructure` and its backing map entirely.

The sharing should be fine: `ImmutableStructure` never mutates `attributes` — `getValue` clones values, `asMap`/`keySet` return copies.

The `ConstructorBranches` tests guard the `targetingKey != null` branch so that a future refactor cannot accidentally return `EMPTY` for a context that carries a targeting key.

| Metric | `main` | This PR | Delta |
|--------|--------|---------|-------|
| `run:+totalAllocatedInstances` | 2,145,282 | 1,825,005 | −320,277 (−14.9%) |
| `run:+totalAllocatedBytes` | 102,105,728 | 93,695,320 | −8,410,408 (−8.2%) |

:warning: seems I might have used another branch as baseline instead of main. Result proportions should be right, but not the exact values.

### Follow-up Tasks
- More PRs with memory improvements
- Update `benchmark.txt` after all are applied