### PR TITLE
perf: return ImmutableContext.EMPTY when merging two empty contexts

### DIFF
--- a/src/main/java/dev/openfeature/sdk/ImmutableContext.java
+++ b/src/main/java/dev/openfeature/sdk/ImmutableContext.java
@@ -88,6 +88,9 @@ public final class ImmutableContext implements EvaluationContext {
     @Override
     public EvaluationContext merge(EvaluationContext overridingContext) {
         if (overridingContext == null || overridingContext.isEmpty()) {
+            if (this.isEmpty()) {
+                return ImmutableContext.EMPTY;
+            }
             return new ImmutableContext(this.asUnmodifiableMap());
         }
         if (this.isEmpty()) {

--- a/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
+++ b/src/test/java/dev/openfeature/sdk/ImmutableContextTest.java
@@ -254,6 +254,41 @@ class ImmutableContextTest {
     }
 
     @Nested
+    @DisplayName("ImmutableContext.merge() empty short-circuit")
+    class MergeEmpty {
+
+        @Test
+        @DisplayName("merging two empty contexts returns the EMPTY singleton")
+        void mergingTwoEmptyContextsReturnsEmptySingleton() {
+            EvaluationContext result = new ImmutableContext().merge(new ImmutableContext());
+            assertThat(result).isSameAs(ImmutableContext.EMPTY);
+        }
+
+        @Test
+        @DisplayName("merging empty context with null returns the EMPTY singleton")
+        void mergingEmptyContextWithNullReturnsEmptySingleton() {
+            EvaluationContext result = new ImmutableContext().merge(null);
+            assertThat(result).isSameAs(ImmutableContext.EMPTY);
+        }
+
+        @Test
+        @DisplayName("merging non-empty context with null does not return EMPTY")
+        void mergingNonEmptyContextWithNullDoesNotReturnEmpty() {
+            EvaluationContext result = new ImmutableContext("key").merge(null);
+            assertThat(result).isNotSameAs(ImmutableContext.EMPTY);
+            assertThat(result.getTargetingKey()).isEqualTo("key");
+        }
+
+        @Test
+        @DisplayName("merging non-empty context with empty override does not return EMPTY")
+        void mergingNonEmptyContextWithEmptyOverrideDoesNotReturnEmpty() {
+            EvaluationContext result = new ImmutableContext("key").merge(new ImmutableContext());
+            assertThat(result).isNotSameAs(ImmutableContext.EMPTY);
+            assertThat(result.getTargetingKey()).isEqualTo("key");
+        }
+    }
+
+    @Nested
     class Equals {
         ImmutableContext ctx = new ImmutableContext("c", Map.of("a", new Value("b")));
 


### PR DESCRIPTION
## This PR

- `ImmutableContext.merge()` returns `ImmutableContext.EMPTY` when both `this` and the overriding context are empty

### Related Issues
None

### Notes

When merging two empty contexts the previous code still allocated a new `ImmutableContext` (via `this.asUnmodifiableMap()`). The result is always semantically equivalent to `EMPTY`, so we can return the existing singleton directly.

This path is not exercised by the current benchmark workload, so no allocation numbers are provided.

### Follow-up Tasks
- More PRs with memory improvements