### PR TITLE
perf: return ImmutableContext.EMPTY from NoOpTransactionContextPropag…

### DIFF
--- a/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
+++ b/src/main/java/dev/openfeature/sdk/NoOpTransactionContextPropagator.java
@@ -12,7 +12,7 @@ public class NoOpTransactionContextPropagator implements TransactionContextPropa
      */
     @Override
     public EvaluationContext getTransactionContext() {
-        return new ImmutableContext();
+        return ImmutableContext.EMPTY;
     }
 
     /**

--- a/src/test/java/dev/openfeature/sdk/NoOpTransactionContextPropagatorTest.java
+++ b/src/test/java/dev/openfeature/sdk/NoOpTransactionContextPropagatorTest.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
@@ -14,6 +15,11 @@ class NoOpTransactionContextPropagatorTest {
     public void emptyTransactionContext() {
         EvaluationContext result = contextPropagator.getTransactionContext();
         assertTrue(result.asMap().isEmpty());
+    }
+
+    @Test
+    public void getTransactionContextReturnsEmptySingleton() {
+        assertThat(contextPropagator.getTransactionContext()).isSameAs(ImmutableContext.EMPTY);
     }
 
     @Test


### PR DESCRIPTION
## This PR

`NoOpTransactionContextPropagator.getTransactionContext()` is called on every flag evaluation to retrieve the transaction context. The default implementation returned `new ImmutableContext()` on every call, allocating a new `ImmutableContext`, `ImmutableStructure`, and a `HashMap` each time — even though the result is always semantically identical.

## Fix

Return the existing `ImmutableContext.EMPTY` singleton instead of allocating a new instance. Since `ImmutableContext` is immutable and `NoOpTransactionContextPropagator` always returns an empty context, the singleton is a correct and safe substitute.

## Benchmark

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| `run:+totalAllocatedInstances` | 2,252,509 | 2,013,891 | −238,618 (−10.6%) |
| `run:+totalAllocatedBytes` | 107,492,056 | 103,293,456 | −4,198,600 (−3.9%) |

### Follow-up Tasks
- Update `benchmark.txt` after all PRs are applied
