### PR TITLE
feat: supply bound domain to provider initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target
 
 # used for spec compliance tooling
 java-report.json
+.worktrees/

--- a/src/main/java/dev/openfeature/sdk/FeatureProvider.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProvider.java
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -183,6 +184,38 @@ public interface FeatureProvider {
      */
     default void initialize(EvaluationContext evaluationContext) throws Exception {
         // Intentionally left blank
+    }
+
+    /**
+     * This method is called before a provider is used to evaluate flags, with the
+     * bound domain supplied when the provider is registered to a named client.
+     *
+     * <p>
+     * The default provider is initialized with a {@code null} domain. Providers that
+     * maintain per-domain state (for example a persistent cache) should override this
+     * method and declare themselves {@linkplain #isDomainScoped() domain-scoped}.
+     * </p>
+     *
+     * @param evaluationContext the global evaluation context
+     * @param domain            the bound domain, or {@code null} for the default provider
+     */
+    default void initialize(EvaluationContext evaluationContext, @Nullable String domain) throws Exception {
+        initialize(evaluationContext);
+    }
+
+    /**
+     * Returns whether this provider maintains state specific to a single domain that
+     * cannot be shared across domains.
+     *
+     * <p>
+     * Domain-scoped providers may only be bound to one domain within a single API
+     * instance.
+     * </p>
+     *
+     * @return {@code true} if this provider is domain-scoped
+     */
+    default boolean isDomainScoped() {
+        return false;
     }
 
     /**

--- a/src/main/java/dev/openfeature/sdk/FeatureProvider.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProvider.java
@@ -2,7 +2,6 @@ package dev.openfeature.sdk;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * The interface implemented by upstream flag providers to resolve flags for
@@ -199,7 +198,7 @@ public interface FeatureProvider {
      * @param evaluationContext the global evaluation context
      * @param domain            the bound domain, or {@code null} for the default provider
      */
-    default void initialize(EvaluationContext evaluationContext, @Nullable String domain) throws Exception {
+    default void initialize(EvaluationContext evaluationContext, String domain) throws Exception {
         initialize(evaluationContext);
     }
 

--- a/src/main/java/dev/openfeature/sdk/FeatureProvider.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProvider.java
@@ -1,8 +1,8 @@
 package dev.openfeature.sdk;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * The interface implemented by upstream flag providers to resolve flags for

--- a/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
@@ -1,6 +1,7 @@
 package dev.openfeature.sdk;
 
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
@@ -19,11 +20,15 @@ class FeatureProviderStateManager implements EventProviderListener {
     }
 
     public void initialize(EvaluationContext evaluationContext) throws Exception {
+        initialize(evaluationContext, null);
+    }
+
+    public void initialize(EvaluationContext evaluationContext, @Nullable String domain) throws Exception {
         if (isInitialized.getAndSet(true)) {
             return;
         }
         try {
-            delegate.initialize(evaluationContext);
+            delegate.initialize(evaluationContext, domain);
             setState(ProviderState.READY);
         } catch (OpenFeatureError openFeatureError) {
             if (ErrorCode.PROVIDER_FATAL.equals(openFeatureError.getErrorCode())) {

--- a/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
@@ -3,7 +3,6 @@ package dev.openfeature.sdk;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -23,7 +22,7 @@ class FeatureProviderStateManager implements EventProviderListener {
         initialize(evaluationContext, null);
     }
 
-    public void initialize(EvaluationContext evaluationContext, @Nullable String domain) throws Exception {
+    public void initialize(EvaluationContext evaluationContext, String domain) throws Exception {
         if (isInitialized.getAndSet(true)) {
             return;
         }

--- a/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
@@ -1,9 +1,9 @@
 package dev.openfeature.sdk;
 
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -17,7 +17,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -155,7 +154,7 @@ class ProviderRepository {
     }
 
     private void prepareAndInitializeProvider(
-            @Nullable String domain,
+            String domain,
             FeatureProvider newProvider,
             Consumer<FeatureProvider> afterSet,
             Consumer<FeatureProvider> afterInit,
@@ -196,28 +195,22 @@ class ProviderRepository {
         }
     }
 
-    private void validateDomainScopedBinding(@Nullable String domain, FeatureProvider newProvider) {
+    private void validateDomainScopedBinding(String domain, FeatureProvider newProvider) {
         if (!newProvider.isDomainScoped()) {
             return;
         }
 
-        boolean currentlyDefault = isDefaultProviderInstance(newProvider);
-        List<String> boundNamedDomains = getBoundDomainsForProviderInstance(newProvider);
-
-        if (!currentlyDefault && boundNamedDomains.isEmpty()) {
+        // a re-set to the identical binding is always allowed (it's a no-op)
+        boolean alreadyBoundHere = domain == null
+                ? isDefaultProviderInstance(newProvider)
+                : getBoundDomainsForProviderInstance(newProvider).contains(domain);
+        if (alreadyBoundHere) {
             return;
         }
 
-        if (domain == null) {
-            if (!currentlyDefault) {
-                throw new IllegalArgumentException("Domain-scoped provider cannot be bound to more than one domain");
-            }
-            return;
-        }
-        if (boundNamedDomains.contains(domain)) {
-            return;
-        }
-        if (!boundNamedDomains.isEmpty() || currentlyDefault) {
+        // any other existing binding means this instance would span more than one domain
+        if (isDefaultProviderInstance(newProvider)
+                || !getBoundDomainsForProviderInstance(newProvider).isEmpty()) {
             throw new IllegalArgumentException("Domain-scoped provider cannot be bound to more than one domain");
         }
     }
@@ -254,7 +247,7 @@ class ProviderRepository {
     }
 
     private void initializeProvider(
-            @Nullable String domain,
+            String domain,
             FeatureProviderStateManager newManager,
             Consumer<FeatureProvider> afterInit,
             Consumer<FeatureProvider> afterShutdown,

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -169,8 +169,8 @@ class ProviderRepository {
             if (isShuttingDown.get()) {
                 throw new IllegalStateException("Provider cannot be set while repository is shutting down");
             }
-            validateDomainScopedBinding(domain, newProvider);
             FeatureProviderStateManager existing = getExistingStateManagerForProvider(newProvider);
+            validateDomainScopedBinding(domain, newProvider, existing);
             if (existing == null) {
                 openFeatureAPI.registerGlobalProvider(newProvider);
                 newStateManager = new FeatureProviderStateManager(newProvider);
@@ -196,11 +196,11 @@ class ProviderRepository {
         }
     }
 
-    private void validateDomainScopedBinding(@Nullable String domain, FeatureProvider newProvider) {
+    private void validateDomainScopedBinding(
+            @Nullable String domain, FeatureProvider newProvider, @Nullable FeatureProviderStateManager existing) {
         if (!newProvider.isDomainScoped()) {
             return;
         }
-        FeatureProviderStateManager existing = getExistingStateManagerForProvider(newProvider);
         if (existing == null) {
             return;
         }

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -170,7 +170,7 @@ class ProviderRepository {
                 throw new IllegalStateException("Provider cannot be set while repository is shutting down");
             }
             FeatureProviderStateManager existing = getExistingStateManagerForProvider(newProvider);
-            validateDomainScopedBinding(domain, newProvider, existing);
+            validateDomainScopedBinding(domain, newProvider);
             if (existing == null) {
                 openFeatureAPI.registerGlobalProvider(newProvider);
                 newStateManager = new FeatureProviderStateManager(newProvider);
@@ -196,16 +196,18 @@ class ProviderRepository {
         }
     }
 
-    private void validateDomainScopedBinding(
-            @Nullable String domain, FeatureProvider newProvider, @Nullable FeatureProviderStateManager existing) {
+    private void validateDomainScopedBinding(@Nullable String domain, FeatureProvider newProvider) {
         if (!newProvider.isDomainScoped()) {
             return;
         }
-        if (existing == null) {
+
+        boolean currentlyDefault = isDefaultProviderInstance(newProvider);
+        List<String> boundNamedDomains = getBoundDomainsForProviderInstance(newProvider);
+
+        if (!currentlyDefault && boundNamedDomains.isEmpty()) {
             return;
         }
-        boolean currentlyDefault = isDefaultProvider(newProvider);
-        List<String> boundNamedDomains = getDomainsForProvider(newProvider);
+
         if (domain == null) {
             if (!currentlyDefault) {
                 throw new IllegalArgumentException("Domain-scoped provider cannot be bound to more than one domain");
@@ -220,17 +222,35 @@ class ProviderRepository {
         }
     }
 
+    private boolean isDefaultProviderInstance(FeatureProvider provider) {
+        return defaultStateManger.get().getProvider() == provider;
+    }
+
+    private List<String> getBoundDomainsForProviderInstance(FeatureProvider provider) {
+        return stateManagers.entrySet().stream()
+                .filter(entry -> entry.getValue().getProvider() == provider)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
     private FeatureProviderStateManager getExistingStateManagerForProvider(FeatureProvider provider) {
         for (FeatureProviderStateManager stateManager : stateManagers.values()) {
-            if (stateManager.hasSameProvider(provider)) {
+            if (matchesProvider(stateManager.getProvider(), provider)) {
                 return stateManager;
             }
         }
         FeatureProviderStateManager defaultFeatureProviderStateManager = defaultStateManger.get();
-        if (defaultFeatureProviderStateManager.hasSameProvider(provider)) {
+        if (matchesProvider(defaultFeatureProviderStateManager.getProvider(), provider)) {
             return defaultFeatureProviderStateManager;
         }
         return null;
+    }
+
+    private boolean matchesProvider(FeatureProvider registered, FeatureProvider candidate) {
+        if (candidate.isDomainScoped()) {
+            return registered == candidate;
+        }
+        return registered.equals(candidate);
     }
 
     private void initializeProvider(

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -3,6 +3,7 @@ package dev.openfeature.sdk;
 import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.internal.ConfigurableThreadFactory;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -154,7 +155,7 @@ class ProviderRepository {
     }
 
     private void prepareAndInitializeProvider(
-            String domain,
+            @Nullable String domain,
             FeatureProvider newProvider,
             Consumer<FeatureProvider> afterSet,
             Consumer<FeatureProvider> afterInit,
@@ -168,6 +169,7 @@ class ProviderRepository {
             if (isShuttingDown.get()) {
                 throw new IllegalStateException("Provider cannot be set while repository is shutting down");
             }
+            validateDomainScopedBinding(domain, newProvider);
             FeatureProviderStateManager existing = getExistingStateManagerForProvider(newProvider);
             if (existing == null) {
                 openFeatureAPI.registerGlobalProvider(newProvider);
@@ -185,12 +187,36 @@ class ProviderRepository {
         }
 
         if (waitForInit) {
-            initializeProvider(newStateManager, afterInit, afterShutdown, afterError, oldStateManager);
+            initializeProvider(domain, newStateManager, afterInit, afterShutdown, afterError, oldStateManager);
         } else {
             taskExecutor.submit(() -> {
                 // initialization happens in a different thread if we're not waiting for it
-                initializeProvider(newStateManager, afterInit, afterShutdown, afterError, oldStateManager);
+                initializeProvider(domain, newStateManager, afterInit, afterShutdown, afterError, oldStateManager);
             });
+        }
+    }
+
+    private void validateDomainScopedBinding(@Nullable String domain, FeatureProvider newProvider) {
+        if (!newProvider.isDomainScoped()) {
+            return;
+        }
+        FeatureProviderStateManager existing = getExistingStateManagerForProvider(newProvider);
+        if (existing == null) {
+            return;
+        }
+        boolean currentlyDefault = isDefaultProvider(newProvider);
+        List<String> boundNamedDomains = getDomainsForProvider(newProvider);
+        if (domain == null) {
+            if (!currentlyDefault) {
+                throw new IllegalArgumentException("Domain-scoped provider cannot be bound to more than one domain");
+            }
+            return;
+        }
+        if (boundNamedDomains.contains(domain)) {
+            return;
+        }
+        if (!boundNamedDomains.isEmpty() || currentlyDefault) {
+            throw new IllegalArgumentException("Domain-scoped provider cannot be bound to more than one domain");
         }
     }
 
@@ -208,6 +234,7 @@ class ProviderRepository {
     }
 
     private void initializeProvider(
+            @Nullable String domain,
             FeatureProviderStateManager newManager,
             Consumer<FeatureProvider> afterInit,
             Consumer<FeatureProvider> afterShutdown,
@@ -215,7 +242,7 @@ class ProviderRepository {
             FeatureProviderStateManager oldManager) {
         try {
             if (ProviderState.NOT_READY.equals(newManager.getState())) {
-                newManager.initialize(openFeatureAPI.getEvaluationContext());
+                newManager.initialize(openFeatureAPI.getEvaluationContext(), domain);
                 afterInit.accept(newManager.getProvider());
             }
             shutDownOld(oldManager, afterShutdown);

--- a/src/main/java/dev/openfeature/sdk/ProviderRepository.java
+++ b/src/main/java/dev/openfeature/sdk/ProviderRepository.java
@@ -3,7 +3,6 @@ package dev.openfeature.sdk;
 import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
 import dev.openfeature.sdk.internal.ConfigurableThreadFactory;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -18,6 +17,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -6,6 +6,7 @@ import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -84,6 +85,19 @@ public class MultiProvider extends EventProvider {
      */
     @Override
     public void initialize(EvaluationContext evaluationContext) throws Exception {
+        initialize(evaluationContext, null);
+    }
+
+    /**
+     * Initialize the provider with the bound domain, if any.
+     *
+     * @param evaluationContext evaluation context
+     * @param domain            the bound domain, or {@code null} for the default provider
+     * @throws Exception on error (e.g. wrapped {@link java.util.concurrent.ExecutionException}
+     *                   from a failing provider)
+     */
+    @Override
+    public void initialize(EvaluationContext evaluationContext, @Nullable String domain) throws Exception {
         var metadataBuilder = MultiProviderMetadata.builder().name(NAME);
         HashMap<String, Metadata> providersMetadata = new HashMap<>();
 
@@ -98,7 +112,7 @@ public class MultiProvider extends EventProvider {
             Collection<Callable<Void>> tasks = new ArrayList<>(providers.size());
             for (FeatureProvider provider : providers.values()) {
                 tasks.add(() -> {
-                    provider.initialize(evaluationContext);
+                    provider.initialize(evaluationContext, null);
                     return null;
                 });
                 Metadata providerMetadata = provider.getMetadata();

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -112,7 +112,7 @@ public class MultiProvider extends EventProvider {
             Collection<Callable<Void>> tasks = new ArrayList<>(providers.size());
             for (FeatureProvider provider : providers.values()) {
                 tasks.add(() -> {
-                    provider.initialize(evaluationContext, null);
+                    provider.initialize(evaluationContext, domain);
                     return null;
                 });
                 Metadata providerMetadata = provider.getMetadata();

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -6,7 +6,6 @@ import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.Value;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -20,6 +19,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/MultiProvider.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -77,9 +76,8 @@ public class MultiProvider extends EventProvider {
     }
 
     /**
-     * Initialize the provider.
+     * {@inheritDoc}
      *
-     * @param evaluationContext evaluation context
      * @throws Exception on error (e.g. wrapped {@link java.util.concurrent.ExecutionException}
      *                   from a failing provider)
      */
@@ -89,15 +87,13 @@ public class MultiProvider extends EventProvider {
     }
 
     /**
-     * Initialize the provider with the bound domain, if any.
+     * {@inheritDoc}
      *
-     * @param evaluationContext evaluation context
-     * @param domain            the bound domain, or {@code null} for the default provider
      * @throws Exception on error (e.g. wrapped {@link java.util.concurrent.ExecutionException}
      *                   from a failing provider)
      */
     @Override
-    public void initialize(EvaluationContext evaluationContext, @Nullable String domain) throws Exception {
+    public void initialize(EvaluationContext evaluationContext, String domain) throws Exception {
         var metadataBuilder = MultiProviderMetadata.builder().name(NAME);
         HashMap<String, Metadata> providersMetadata = new HashMap<>();
 

--- a/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
@@ -118,6 +118,22 @@ class DomainScopedProviderSpecTest {
     }
 
     @Test
+    @DisplayName("allows equal-but-distinct domain-scoped instances on separate domains")
+    void allowsEqualDistinctDomainScopedInstancesOnSeparateDomains() throws Exception {
+        EqualDomainScopedProvider providerA = new EqualDomainScopedProvider("shared-key");
+        EqualDomainScopedProvider providerB = new EqualDomainScopedProvider("shared-key");
+
+        assertThat(providerA).isEqualTo(providerB);
+        assertThat(providerA).isNotSameAs(providerB);
+
+        api.setProviderAndWait(DOMAIN_A, providerA);
+
+        assertThatCode(() -> api.setProviderAndWait(DOMAIN_B, providerB)).doesNotThrowAnyException();
+        assertThat(api.getProvider(DOMAIN_A)).isSameAs(providerA);
+        assertThat(api.getProvider(DOMAIN_B)).isSameAs(providerB);
+    }
+
+    @Test
     @DisplayName("allows binding a non-domain-scoped provider to multiple domains")
     void allowsBindingNonDomainScopedProviderToMultipleDomains() throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
@@ -150,7 +166,7 @@ class DomainScopedProviderSpecTest {
                 .untilAsserted(() -> assertThat(provider.initDomain.get()).isEqualTo(DOMAIN_A));
     }
 
-    private static final class DomainScopedTestProvider extends EventProvider {
+    private static class DomainScopedTestProvider extends EventProvider {
 
         private final AtomicReference<String> initDomain = new AtomicReference<>();
         private final AtomicInteger initializeCount = new AtomicInteger();
@@ -200,6 +216,29 @@ class DomainScopedProviderSpecTest {
 
         int initCount() {
             return initializeCount.get();
+        }
+    }
+
+    private static final class EqualDomainScopedProvider extends DomainScopedTestProvider {
+
+        private final String key;
+
+        EqualDomainScopedProvider(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof EqualDomainScopedProvider)) {
+                return false;
+            }
+            EqualDomainScopedProvider other = (EqualDomainScopedProvider) obj;
+            return key.equals(other.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return key.hashCode();
         }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
@@ -1,0 +1,171 @@
+package dev.openfeature.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DomainScopedProviderSpecTest {
+
+    private static final String DOMAIN_A = "domain-a";
+    private static final String DOMAIN_B = "domain-b";
+    private OpenFeatureAPI api;
+
+    @BeforeEach
+    void setupTest() {
+        api = new OpenFeatureAPI();
+        api.setProvider(new NoOpProvider());
+    }
+
+    @Specification(
+            number = "1.1.8.1",
+            text = "The `provider mutator` MUST NOT bind a `domain-scoped` provider instance to more than one "
+                    + "`domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.")
+    @Test
+    @DisplayName("rejects binding a domain-scoped provider to a second named domain")
+    void rejectsBindingDomainScopedProviderToSecondNamedDomain() {
+        DomainScopedTestProvider provider = new DomainScopedTestProvider();
+
+        api.setProvider(DOMAIN_A, provider);
+
+        assertThatThrownBy(() -> api.setProvider(DOMAIN_B, provider))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Domain-scoped provider cannot be bound to more than one domain");
+    }
+
+    @Specification(
+            number = "1.1.8.1",
+            text = "The `provider mutator` MUST NOT bind a `domain-scoped` provider instance to more than one "
+                    + "`domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.")
+    @Test
+    @DisplayName("rejects binding a domain-scoped named provider as the default provider")
+    void rejectsBindingDomainScopedNamedProviderAsDefault() {
+        DomainScopedTestProvider provider = new DomainScopedTestProvider();
+
+        api.setProvider(DOMAIN_A, provider);
+
+        assertThatThrownBy(() -> api.setProvider(provider))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Domain-scoped provider cannot be bound to more than one domain");
+    }
+
+    @Specification(
+            number = "1.1.8.1",
+            text = "The `provider mutator` MUST NOT bind a `domain-scoped` provider instance to more than one "
+                    + "`domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.")
+    @Test
+    @DisplayName("rejects binding a domain-scoped default provider to a named domain")
+    void rejectsBindingDomainScopedDefaultProviderToNamedDomain() {
+        DomainScopedTestProvider provider = new DomainScopedTestProvider();
+
+        api.setProvider(provider);
+
+        assertThatThrownBy(() -> api.setProvider(DOMAIN_A, provider))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Domain-scoped provider cannot be bound to more than one domain");
+    }
+
+    @Test
+    @DisplayName("allows rebinding a domain-scoped provider to the same named domain")
+    void allowsRebindingDomainScopedProviderToSameNamedDomain() throws Exception {
+        DomainScopedTestProvider provider = new DomainScopedTestProvider();
+        FeatureProvider replacement = mock(FeatureProvider.class);
+        doReturn(ProviderState.NOT_READY).when(replacement).getState();
+        doReturn(true).when(replacement).isDomainScoped();
+
+        api.setProvider(DOMAIN_A, provider);
+
+        assertThatCode(() -> api.setProvider(DOMAIN_A, replacement)).doesNotThrowAnyException();
+        verify(replacement, timeout(1000)).initialize(any(), eq(DOMAIN_A));
+    }
+
+    @Test
+    @DisplayName("allows binding a non-domain-scoped provider to multiple domains")
+    void allowsBindingNonDomainScopedProviderToMultipleDomains() throws Exception {
+        FeatureProvider provider = mock(FeatureProvider.class);
+        doReturn(ProviderState.NOT_READY).when(provider).getState();
+
+        assertThatCode(() -> {
+                    api.setProvider(DOMAIN_A, provider);
+                    api.setProvider(DOMAIN_B, provider);
+                })
+                .doesNotThrowAnyException();
+
+        verify(provider, timeout(1000)).initialize(any(), eq(DOMAIN_A));
+    }
+
+    @Specification(
+            number = "2.4.3",
+            text =
+                    "The `provider` MAY declare that it is `domain-scoped`, indicating that it maintains state "
+                            + "specific to a single `domain`, such as a persistent cache, that cannot be shared across `domains`.")
+    @Test
+    @DisplayName("domain-scoped provider receives bound domain at initialization")
+    void domainScopedProviderReceivesBoundDomainAtInitialization() {
+        DomainScopedTestProvider provider = new DomainScopedTestProvider();
+
+        api.setProvider(DOMAIN_A, provider);
+
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(provider.initDomain.get()).isEqualTo(DOMAIN_A));
+    }
+
+    private static final class DomainScopedTestProvider extends EventProvider {
+
+        private final AtomicReference<String> initDomain = new AtomicReference<>();
+
+        @Override
+        public Metadata getMetadata() {
+            return () -> "domain-scoped-test";
+        }
+
+        @Override
+        public boolean isDomainScoped() {
+            return true;
+        }
+
+        @Override
+        public void initialize(EvaluationContext evaluationContext, String domain) {
+            initDomain.set(domain);
+        }
+
+        @Override
+        public ProviderEvaluation<Boolean> getBooleanEvaluation(
+                String key, Boolean defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Boolean>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<String>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Integer> getIntegerEvaluation(
+                String key, Integer defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Integer>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Double>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Value>builder().value(defaultValue).build();
+        }
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,11 @@ class DomainScopedProviderSpecTest {
     void setupTest() {
         api = new OpenFeatureAPI();
         api.setProvider(new NoOpProvider());
+    }
+
+    @AfterEach
+    void tearDown() {
+        api.shutdown();
     }
 
     @Specification(

--- a/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -93,6 +94,30 @@ class DomainScopedProviderSpecTest {
     }
 
     @Test
+    @DisplayName("allows rebinding the same domain-scoped provider instance to the same named domain")
+    void allowsRebindingSameDomainScopedInstanceToSameNamedDomain() throws Exception {
+        DomainScopedTestProvider provider = new DomainScopedTestProvider();
+
+        api.setProviderAndWait(DOMAIN_A, provider);
+        api.setProviderAndWait(DOMAIN_A, provider);
+
+        assertThat(provider.initCount()).isOne();
+        assertThat(provider.initDomain.get()).isEqualTo(DOMAIN_A);
+    }
+
+    @Test
+    @DisplayName("allows rebinding the same domain-scoped provider instance as the default provider")
+    void allowsRebindingSameDomainScopedInstanceAsDefault() throws Exception {
+        DomainScopedTestProvider provider = new DomainScopedTestProvider();
+
+        api.setProviderAndWait(provider);
+        api.setProviderAndWait(provider);
+
+        assertThat(provider.initCount()).isOne();
+        assertThat(provider.initDomain.get()).isNull();
+    }
+
+    @Test
     @DisplayName("allows binding a non-domain-scoped provider to multiple domains")
     void allowsBindingNonDomainScopedProviderToMultipleDomains() throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
@@ -128,6 +153,7 @@ class DomainScopedProviderSpecTest {
     private static final class DomainScopedTestProvider extends EventProvider {
 
         private final AtomicReference<String> initDomain = new AtomicReference<>();
+        private final AtomicInteger initializeCount = new AtomicInteger();
 
         @Override
         public Metadata getMetadata() {
@@ -141,6 +167,7 @@ class DomainScopedProviderSpecTest {
 
         @Override
         public void initialize(EvaluationContext evaluationContext, String domain) {
+            initializeCount.incrementAndGet();
             initDomain.set(domain);
         }
 
@@ -169,6 +196,10 @@ class DomainScopedProviderSpecTest {
         @Override
         public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
             return ProviderEvaluation.<Value>builder().value(defaultValue).build();
+        }
+
+        int initCount() {
+            return initializeCount.get();
         }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
@@ -96,14 +97,16 @@ class DomainScopedProviderSpecTest {
     void allowsBindingNonDomainScopedProviderToMultipleDomains() throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
         doReturn(ProviderState.NOT_READY).when(provider).getState();
+        Metadata metadata = mock(Metadata.class);
+        doReturn("shared-provider").when(metadata).getName();
+        doReturn(metadata).when(provider).getMetadata();
 
-        assertThatCode(() -> {
-                    api.setProvider(DOMAIN_A, provider);
-                    api.setProvider(DOMAIN_B, provider);
-                })
-                .doesNotThrowAnyException();
+        api.setProviderAndWait(DOMAIN_A, provider);
+        api.setProviderAndWait(DOMAIN_B, provider);
 
-        verify(provider, timeout(1000)).initialize(any(), eq(DOMAIN_A));
+        assertThat(api.getProvider(DOMAIN_A)).isSameAs(provider);
+        assertThat(api.getProvider(DOMAIN_B)).isSameAs(provider);
+        verify(provider, times(1)).initialize(any(), eq(DOMAIN_A));
     }
 
     @Specification(

--- a/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/DomainScopedProviderSpecTest.java
@@ -43,14 +43,15 @@ class DomainScopedProviderSpecTest {
                     + "`domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.")
     @Test
     @DisplayName("rejects binding a domain-scoped provider to a second named domain")
-    void rejectsBindingDomainScopedProviderToSecondNamedDomain() {
+    void rejectsBindingDomainScopedProviderToSecondNamedDomain() throws Exception {
         DomainScopedTestProvider provider = new DomainScopedTestProvider();
 
-        api.setProvider(DOMAIN_A, provider);
+        api.setProviderAndWait(DOMAIN_A, provider);
 
         assertThatThrownBy(() -> api.setProvider(DOMAIN_B, provider))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Domain-scoped provider cannot be bound to more than one domain");
+        assertThat(provider.initCount()).isOne();
     }
 
     @Specification(
@@ -59,14 +60,15 @@ class DomainScopedProviderSpecTest {
                     + "`domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.")
     @Test
     @DisplayName("rejects binding a domain-scoped named provider as the default provider")
-    void rejectsBindingDomainScopedNamedProviderAsDefault() {
+    void rejectsBindingDomainScopedNamedProviderAsDefault() throws Exception {
         DomainScopedTestProvider provider = new DomainScopedTestProvider();
 
-        api.setProvider(DOMAIN_A, provider);
+        api.setProviderAndWait(DOMAIN_A, provider);
 
         assertThatThrownBy(() -> api.setProvider(provider))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Domain-scoped provider cannot be bound to more than one domain");
+        assertThat(provider.initCount()).isOne();
     }
 
     @Specification(
@@ -75,14 +77,15 @@ class DomainScopedProviderSpecTest {
                     + "`domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.")
     @Test
     @DisplayName("rejects binding a domain-scoped default provider to a named domain")
-    void rejectsBindingDomainScopedDefaultProviderToNamedDomain() {
+    void rejectsBindingDomainScopedDefaultProviderToNamedDomain() throws Exception {
         DomainScopedTestProvider provider = new DomainScopedTestProvider();
 
-        api.setProvider(provider);
+        api.setProviderAndWait(provider);
 
         assertThatThrownBy(() -> api.setProvider(DOMAIN_A, provider))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Domain-scoped provider cannot be bound to more than one domain");
+        assertThat(provider.initCount()).isOne();
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/FeatureProviderStateManagerTest.java
+++ b/src/test/java/dev/openfeature/sdk/FeatureProviderStateManagerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.GeneralError;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,13 @@ class FeatureProviderStateManagerTest {
     public void setUp() {
         testDelegate = new TestDelegate();
         wrapper = new FeatureProviderStateManager(testDelegate);
+    }
+
+    @SneakyThrows
+    @Test
+    void shouldPassDomainToDelegateOnInit() {
+        wrapper.initialize(null, "billing");
+        assertThat(testDelegate.initDomain.get()).isEqualTo("billing");
     }
 
     @SneakyThrows
@@ -156,6 +164,7 @@ class FeatureProviderStateManagerTest {
     static class TestDelegate extends EventProvider {
         private final AtomicInteger initCalled = new AtomicInteger();
         private final AtomicInteger shutdownCalled = new AtomicInteger();
+        private final AtomicReference<String> initDomain = new AtomicReference<>();
         private @Nullable Exception throwOnInit;
 
         @Override
@@ -188,6 +197,12 @@ class FeatureProviderStateManagerTest {
         @Override
         public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
             return null;
+        }
+
+        @Override
+        public void initialize(EvaluationContext evaluationContext, String domain) throws Exception {
+            initDomain.set(domain);
+            initialize(evaluationContext);
         }
 
         @Override

--- a/src/test/java/dev/openfeature/sdk/InitializeBehaviorSpecTest.java
+++ b/src/test/java/dev/openfeature/sdk/InitializeBehaviorSpecTest.java
@@ -1,7 +1,9 @@
 package dev.openfeature.sdk;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -41,7 +43,22 @@ class InitializeBehaviorSpecTest {
 
             api.setProvider(featureProvider);
 
-            verify(featureProvider, timeout(1000)).initialize(any());
+            verify(featureProvider, timeout(1000)).initialize(any(), isNull());
+        }
+
+        @Specification(
+                number = "2.4.1",
+                text = "The `provider` MAY define an initialization function which accepts the global "
+                        + "`evaluation context` and an optional bound `domain`.")
+        @Test
+        @DisplayName("must pass null domain when initializing the default provider")
+        void mustPassNullDomainWhenInitializingTheDefaultProvider() throws Exception {
+            FeatureProvider featureProvider = mock(FeatureProvider.class);
+            doReturn(ProviderState.NOT_READY).when(featureProvider).getState();
+
+            api.setProvider(featureProvider);
+
+            verify(featureProvider, timeout(1000)).initialize(any(), isNull());
         }
 
         @Specification(
@@ -55,11 +72,11 @@ class InitializeBehaviorSpecTest {
         void shouldCatchExceptionThrownByTheProviderOnInitialization() throws Exception {
             FeatureProvider featureProvider = mock(FeatureProvider.class);
             doReturn(ProviderState.NOT_READY).when(featureProvider).getState();
-            doThrow(TestException.class).when(featureProvider).initialize(any());
+            doThrow(TestException.class).when(featureProvider).initialize(any(), isNull());
 
             assertThatCode(() -> api.setProvider(featureProvider)).doesNotThrowAnyException();
 
-            verify(featureProvider, timeout(1000)).initialize(any());
+            verify(featureProvider, timeout(1000)).initialize(any(), isNull());
         }
     }
 
@@ -80,7 +97,22 @@ class InitializeBehaviorSpecTest {
 
             api.setProvider(DOMAIN_NAME, featureProvider);
 
-            verify(featureProvider, timeout(1000)).initialize(any());
+            verify(featureProvider, timeout(1000)).initialize(any(), eq(DOMAIN_NAME));
+        }
+
+        @Specification(
+                number = "2.4.1",
+                text = "The `provider` MAY define an initialization function which accepts the global "
+                        + "`evaluation context` and an optional bound `domain`.")
+        @Test
+        @DisplayName("must pass bound domain when initializing a named provider")
+        void mustPassBoundDomainWhenInitializingANamedProvider() throws Exception {
+            FeatureProvider featureProvider = mock(FeatureProvider.class);
+            doReturn(ProviderState.NOT_READY).when(featureProvider).getState();
+
+            api.setProvider(DOMAIN_NAME, featureProvider);
+
+            verify(featureProvider, timeout(1000)).initialize(any(), eq(DOMAIN_NAME));
         }
 
         @Specification(
@@ -94,11 +126,11 @@ class InitializeBehaviorSpecTest {
         void shouldCatchExceptionThrownByTheNamedClientProviderOnInitialization() throws Exception {
             FeatureProvider featureProvider = mock(FeatureProvider.class);
             doReturn(ProviderState.NOT_READY).when(featureProvider).getState();
-            doThrow(TestException.class).when(featureProvider).initialize(any());
+            doThrow(TestException.class).when(featureProvider).initialize(any(), eq(DOMAIN_NAME));
 
             assertThatCode(() -> api.setProvider(DOMAIN_NAME, featureProvider)).doesNotThrowAnyException();
 
-            verify(featureProvider, timeout(1000)).initialize(any());
+            verify(featureProvider, timeout(1000)).initialize(any(), eq(DOMAIN_NAME));
         }
     }
 }

--- a/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
+++ b/src/test/java/dev/openfeature/sdk/OpenFeatureAPITest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -117,7 +118,7 @@ class OpenFeatureAPITest {
 
         api.getClient().track("track-event", new ImmutableContext(), new MutableTrackingEventDetails(22.2f));
 
-        verify(featureProvider).initialize(any());
+        verify(featureProvider).initialize(any(), isNull());
         verify(featureProvider, times(2)).getMetadata();
         verify(featureProvider).track(any(), any(), any());
     }

--- a/src/test/java/dev/openfeature/sdk/ProviderInitializeBackwardCompatibilityTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderInitializeBackwardCompatibilityTest.java
@@ -22,80 +22,44 @@ class ProviderInitializeBackwardCompatibilityTest {
         @Test
         @DisplayName("two-arg default delegates to a single-arg override")
         void twoArgDefaultDelegatesToSingleArgOverride() throws Exception {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            LegacySingleArgInitProvider provider = new LegacySingleArgInitProvider();
 
             provider.initialize(new ImmutableContext(), DOMAIN);
 
-            assertThat(singleArgInitCount).hasValue(1);
+            assertThat(provider.singleArgInitCount()).isOne();
         }
 
         @Test
         @DisplayName("two-arg override is used without invoking single-arg")
         void twoArgOverrideDoesNotInvokeSingleArg() throws Exception {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            AtomicReference<String> domainReceived = new AtomicReference<>();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext, String domain) {
-                    domainReceived.set(domain);
-                }
-
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            TwoArgInitProvider provider = new TwoArgInitProvider();
 
             provider.initialize(new ImmutableContext(), DOMAIN);
 
-            assertThat(domainReceived).hasValue(DOMAIN);
-            assertThat(singleArgInitCount).hasValue(0);
+            assertThat(provider.initDomain()).isEqualTo(DOMAIN);
+            assertThat(provider.singleArgInitCount()).isZero();
         }
 
         @Test
         @DisplayName("two-arg-only override receives null domain for default binding")
         void twoArgOnlyOverrideReceivesNullDomain() throws Exception {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            AtomicReference<String> domainReceived = new AtomicReference<>("unset");
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext, String domain) {
-                    domainReceived.set(domain);
-                }
-
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            TwoArgInitProvider provider = new TwoArgInitProvider();
 
             provider.initialize(new ImmutableContext(), null);
 
-            assertThat(domainReceived.get()).isNull();
-            assertThat(singleArgInitCount).hasValue(0);
+            assertThat(provider.initDomain()).isNull();
+            assertThat(provider.singleArgInitCount()).isZero();
         }
 
         @Test
         @DisplayName("single-arg override is only invoked once per initialization")
         void singleArgOverrideIsOnlyInvokedOnce() throws Exception {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            LegacySingleArgInitProvider provider = new LegacySingleArgInitProvider();
 
             provider.initialize(new ImmutableContext(), DOMAIN);
             provider.initialize(new ImmutableContext(), DOMAIN);
 
-            assertThat(singleArgInitCount).hasValue(2);
+            assertThat(provider.singleArgInitCount()).isEqualTo(2);
         }
     }
 
@@ -114,84 +78,48 @@ class ProviderInitializeBackwardCompatibilityTest {
         @Test
         @DisplayName("legacy single-arg provider is initialized when registered to a named domain")
         void legacySingleArgProviderInitializedForNamedDomain() {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            LegacySingleArgInitProvider provider = new LegacySingleArgInitProvider();
 
             api.setProvider(DOMAIN, provider);
 
-            await().atMost(Duration.ofSeconds(5))
-                    .untilAsserted(() -> assertThat(singleArgInitCount).hasValue(1));
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(provider.singleArgInitCount())
+                    .isOne());
         }
 
         @Test
         @DisplayName("legacy single-arg provider is initialized when registered as the default provider")
         void legacySingleArgProviderInitializedAsDefault() {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            LegacySingleArgInitProvider provider = new LegacySingleArgInitProvider();
 
             api.setProvider(provider);
 
-            await().atMost(Duration.ofSeconds(5))
-                    .untilAsserted(() -> assertThat(singleArgInitCount).hasValue(1));
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(provider.singleArgInitCount())
+                    .isOne());
         }
 
         @Test
         @DisplayName("two-arg-only provider receives the bound domain from the SDK")
         void twoArgOnlyProviderReceivesBoundDomainFromSdk() {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            AtomicReference<String> domainReceived = new AtomicReference<>();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext, String domain) {
-                    domainReceived.set(domain);
-                }
-
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            TwoArgInitProvider provider = new TwoArgInitProvider();
 
             api.setProvider(DOMAIN, provider);
 
             await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-                assertThat(domainReceived).hasValue(DOMAIN);
-                assertThat(singleArgInitCount).hasValue(0);
+                assertThat(provider.initDomain()).isEqualTo(DOMAIN);
+                assertThat(provider.singleArgInitCount()).isZero();
             });
         }
 
         @Test
         @DisplayName("two-arg-only default provider receives null domain from the SDK")
         void twoArgOnlyDefaultProviderReceivesNullDomainFromSdk() {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            AtomicReference<String> domainReceived = new AtomicReference<>("unset");
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext, String domain) {
-                    domainReceived.set(domain);
-                }
-
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            TwoArgInitProvider provider = new TwoArgInitProvider();
 
             api.setProvider(provider);
 
             await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-                assertThat(domainReceived.get()).isNull();
-                assertThat(singleArgInitCount).hasValue(0);
+                assertThat(provider.initDomain()).isNull();
+                assertThat(provider.singleArgInitCount()).isZero();
             });
         }
     }
@@ -203,40 +131,74 @@ class ProviderInitializeBackwardCompatibilityTest {
         @Test
         @DisplayName("delegates two-arg initialize to a legacy single-arg provider")
         void delegatesTwoArgInitializeToLegacySingleArgProvider() throws Exception {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            LegacySingleArgInitProvider provider = new LegacySingleArgInitProvider();
             FeatureProviderStateManager stateManager = new FeatureProviderStateManager(provider);
 
             stateManager.initialize(new ImmutableContext(), DOMAIN);
 
-            assertThat(singleArgInitCount).hasValue(1);
+            assertThat(provider.singleArgInitCount()).isOne();
         }
 
         @Test
         @DisplayName("only invokes two-arg initialize once for a legacy single-arg provider")
         void onlyInvokesLegacySingleArgProviderOncePerStateManagerInit() throws Exception {
-            AtomicInteger singleArgInitCount = new AtomicInteger();
-            FeatureProvider provider = new TestProvider() {
-                @Override
-                public void initialize(EvaluationContext evaluationContext) {
-                    singleArgInitCount.incrementAndGet();
-                }
-            };
+            LegacySingleArgInitProvider provider = new LegacySingleArgInitProvider();
             FeatureProviderStateManager stateManager = new FeatureProviderStateManager(provider);
 
             stateManager.initialize(new ImmutableContext(), DOMAIN);
             stateManager.initialize(new ImmutableContext(), DOMAIN);
 
-            assertThat(singleArgInitCount).hasValue(1);
+            assertThat(provider.singleArgInitCount()).isOne();
         }
     }
 
-    private abstract static class TestProvider extends EventProvider {
+    /**
+     * Legacy provider that only overrides single-arg {@link FeatureProvider#initialize(EvaluationContext)}.
+     */
+    private static final class LegacySingleArgInitProvider extends StubProvider {
+
+        private final AtomicInteger singleArgInitCount = new AtomicInteger();
+
+        @Override
+        public void initialize(EvaluationContext evaluationContext) {
+            singleArgInitCount.incrementAndGet();
+        }
+
+        int singleArgInitCount() {
+            return singleArgInitCount.get();
+        }
+    }
+
+    /**
+     * Domain-aware provider that only overrides two-arg
+     * {@link FeatureProvider#initialize(EvaluationContext, String)}. Single-arg is overridden solely to detect
+     * accidental delegation.
+     */
+    private static final class TwoArgInitProvider extends StubProvider {
+
+        private final AtomicInteger singleArgInitCount = new AtomicInteger();
+        private final AtomicReference<String> initDomain = new AtomicReference<>();
+
+        @Override
+        public void initialize(EvaluationContext evaluationContext, String domain) {
+            initDomain.set(domain);
+        }
+
+        @Override
+        public void initialize(EvaluationContext evaluationContext) {
+            singleArgInitCount.incrementAndGet();
+        }
+
+        int singleArgInitCount() {
+            return singleArgInitCount.get();
+        }
+
+        String initDomain() {
+            return initDomain.get();
+        }
+    }
+
+    private abstract static class StubProvider extends EventProvider {
 
         @Override
         public Metadata getMetadata() {

--- a/src/test/java/dev/openfeature/sdk/ProviderInitializeBackwardCompatibilityTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderInitializeBackwardCompatibilityTest.java
@@ -20,6 +20,12 @@ class ProviderInitializeBackwardCompatibilityTest {
     class DefaultMethodDelegation {
 
         @Test
+        @DisplayName("default isDomainScoped returns false for non-domain-scoped providers")
+        void defaultIsDomainScopedReturnsFalse() {
+            assertThat(new LegacySingleArgInitProvider().isDomainScoped()).isFalse();
+        }
+
+        @Test
         @DisplayName("two-arg default delegates to a single-arg override")
         void twoArgDefaultDelegatesToSingleArgOverride() throws Exception {
             LegacySingleArgInitProvider provider = new LegacySingleArgInitProvider();

--- a/src/test/java/dev/openfeature/sdk/ProviderInitializeBackwardCompatibilityTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderInitializeBackwardCompatibilityTest.java
@@ -1,0 +1,273 @@
+package dev.openfeature.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ProviderInitializeBackwardCompatibilityTest {
+
+    private static final String DOMAIN = "billing";
+
+    @Nested
+    @DisplayName("FeatureProvider default method delegation")
+    class DefaultMethodDelegation {
+
+        @Test
+        @DisplayName("two-arg default delegates to a single-arg override")
+        void twoArgDefaultDelegatesToSingleArgOverride() throws Exception {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            provider.initialize(new ImmutableContext(), DOMAIN);
+
+            assertThat(singleArgInitCount).hasValue(1);
+        }
+
+        @Test
+        @DisplayName("two-arg override is used without invoking single-arg")
+        void twoArgOverrideDoesNotInvokeSingleArg() throws Exception {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            AtomicReference<String> domainReceived = new AtomicReference<>();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext, String domain) {
+                    domainReceived.set(domain);
+                }
+
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            provider.initialize(new ImmutableContext(), DOMAIN);
+
+            assertThat(domainReceived).hasValue(DOMAIN);
+            assertThat(singleArgInitCount).hasValue(0);
+        }
+
+        @Test
+        @DisplayName("two-arg-only override receives null domain for default binding")
+        void twoArgOnlyOverrideReceivesNullDomain() throws Exception {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            AtomicReference<String> domainReceived = new AtomicReference<>("unset");
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext, String domain) {
+                    domainReceived.set(domain);
+                }
+
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            provider.initialize(new ImmutableContext(), null);
+
+            assertThat(domainReceived.get()).isNull();
+            assertThat(singleArgInitCount).hasValue(0);
+        }
+
+        @Test
+        @DisplayName("single-arg override is only invoked once per initialization")
+        void singleArgOverrideIsOnlyInvokedOnce() throws Exception {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            provider.initialize(new ImmutableContext(), DOMAIN);
+            provider.initialize(new ImmutableContext(), DOMAIN);
+
+            assertThat(singleArgInitCount).hasValue(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("SDK initialization path")
+    class SdkIntegration {
+
+        private OpenFeatureAPI api;
+
+        @BeforeEach
+        void setupTest() {
+            api = new OpenFeatureAPI();
+            api.setProvider(new NoOpProvider());
+        }
+
+        @Test
+        @DisplayName("legacy single-arg provider is initialized when registered to a named domain")
+        void legacySingleArgProviderInitializedForNamedDomain() {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            api.setProvider(DOMAIN, provider);
+
+            await().atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(singleArgInitCount).hasValue(1));
+        }
+
+        @Test
+        @DisplayName("legacy single-arg provider is initialized when registered as the default provider")
+        void legacySingleArgProviderInitializedAsDefault() {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            api.setProvider(provider);
+
+            await().atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(singleArgInitCount).hasValue(1));
+        }
+
+        @Test
+        @DisplayName("two-arg-only provider receives the bound domain from the SDK")
+        void twoArgOnlyProviderReceivesBoundDomainFromSdk() {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            AtomicReference<String> domainReceived = new AtomicReference<>();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext, String domain) {
+                    domainReceived.set(domain);
+                }
+
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            api.setProvider(DOMAIN, provider);
+
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                assertThat(domainReceived).hasValue(DOMAIN);
+                assertThat(singleArgInitCount).hasValue(0);
+            });
+        }
+
+        @Test
+        @DisplayName("two-arg-only default provider receives null domain from the SDK")
+        void twoArgOnlyDefaultProviderReceivesNullDomainFromSdk() {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            AtomicReference<String> domainReceived = new AtomicReference<>("unset");
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext, String domain) {
+                    domainReceived.set(domain);
+                }
+
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+
+            api.setProvider(provider);
+
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                assertThat(domainReceived.get()).isNull();
+                assertThat(singleArgInitCount).hasValue(0);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("FeatureProviderStateManager")
+    class StateManager {
+
+        @Test
+        @DisplayName("delegates two-arg initialize to a legacy single-arg provider")
+        void delegatesTwoArgInitializeToLegacySingleArgProvider() throws Exception {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+            FeatureProviderStateManager stateManager = new FeatureProviderStateManager(provider);
+
+            stateManager.initialize(new ImmutableContext(), DOMAIN);
+
+            assertThat(singleArgInitCount).hasValue(1);
+        }
+
+        @Test
+        @DisplayName("only invokes two-arg initialize once for a legacy single-arg provider")
+        void onlyInvokesLegacySingleArgProviderOncePerStateManagerInit() throws Exception {
+            AtomicInteger singleArgInitCount = new AtomicInteger();
+            FeatureProvider provider = new TestProvider() {
+                @Override
+                public void initialize(EvaluationContext evaluationContext) {
+                    singleArgInitCount.incrementAndGet();
+                }
+            };
+            FeatureProviderStateManager stateManager = new FeatureProviderStateManager(provider);
+
+            stateManager.initialize(new ImmutableContext(), DOMAIN);
+            stateManager.initialize(new ImmutableContext(), DOMAIN);
+
+            assertThat(singleArgInitCount).hasValue(1);
+        }
+    }
+
+    private abstract static class TestProvider extends EventProvider {
+
+        @Override
+        public Metadata getMetadata() {
+            return () -> "initialize-backward-compat-test";
+        }
+
+        @Override
+        public ProviderEvaluation<Boolean> getBooleanEvaluation(
+                String key, Boolean defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Boolean>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<String> getStringEvaluation(String key, String defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<String>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Integer> getIntegerEvaluation(
+                String key, Integer defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Integer>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Double>builder().value(defaultValue).build();
+        }
+
+        @Override
+        public ProviderEvaluation<Value> getObjectEvaluation(String key, Value defaultValue, EvaluationContext ctx) {
+            return ProviderEvaluation.<Value>builder().value(defaultValue).build();
+        }
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import dev.openfeature.sdk.exceptions.OpenFeatureError;
@@ -64,7 +65,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the provider mutator")
             void shouldImmediatelyReturnWhenCallingTheProviderMutator() throws Exception {
                 FeatureProvider featureProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(new ImmutableContext());
+                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(any(), any());
 
                 await().alias("wait for provider mutator to return")
                         .pollDelay(Duration.ofMillis(1))
@@ -77,11 +78,11 @@ class ProviderRepositoryTest {
                                     mockAfterShutdown(),
                                     mockAfterError(),
                                     false);
-                            verify(featureProvider, timeout(TIMEOUT)).initialize(any());
+                            verify(featureProvider, timeout(TIMEOUT)).initialize(any(), isNull());
                             return true;
                         });
 
-                verify(featureProvider, timeout(TIMEOUT)).initialize(any());
+                verify(featureProvider, timeout(TIMEOUT)).initialize(any(), isNull());
             }
         }
 
@@ -121,7 +122,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the domain provider mutator")
             void shouldImmediatelyReturnWhenCallingTheDomainProviderMutator() throws Exception {
                 FeatureProvider featureProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(any());
+                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(any(), any());
 
                 await().alias("wait for provider mutator to return")
                         .pollDelay(Duration.ofMillis(1))
@@ -135,7 +136,7 @@ class ProviderRepositoryTest {
                                     mockAfterShutdown(),
                                     mockAfterError(),
                                     false);
-                            verify(featureProvider, timeout(TIMEOUT)).initialize(any());
+                            verify(featureProvider, timeout(TIMEOUT)).initialize(any(), eq("a domain"));
                             return true;
                         });
             }
@@ -152,7 +153,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the provider mutator")
             void shouldImmediatelyReturnWhenCallingTheProviderMutator() throws Exception {
                 FeatureProvider newProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any());
+                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any(), any());
 
                 await().alias("wait for provider mutator to return")
                         .pollDelay(Duration.ofMillis(1))
@@ -165,11 +166,11 @@ class ProviderRepositoryTest {
                                     mockAfterShutdown(),
                                     mockAfterError(),
                                     false);
-                            verify(newProvider, timeout(TIMEOUT)).initialize(any());
+                            verify(newProvider, timeout(TIMEOUT)).initialize(any(), isNull());
                             return true;
                         });
 
-                verify(newProvider, timeout(TIMEOUT)).initialize(any());
+                verify(newProvider, timeout(TIMEOUT)).initialize(any(), isNull());
             }
 
             @Test
@@ -193,7 +194,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the provider mutator")
             void shouldImmediatelyReturnWhenCallingTheProviderMutator() throws Exception {
                 FeatureProvider newProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any());
+                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any(), any());
 
                 Future<?> providerMutation = executorService.submit(() -> providerRepository.setProvider(
                         DOMAIN_NAME,
@@ -357,7 +358,7 @@ class ProviderRepositoryTest {
                 FeatureProvider slowInitProvider = createMockedProvider();
                 AtomicBoolean shutdownCalled = new AtomicBoolean(false);
 
-                doDelayResponse(Duration.ofMillis(500)).when(slowInitProvider).initialize(any());
+                doDelayResponse(Duration.ofMillis(500)).when(slowInitProvider).initialize(any(), any());
 
                 doAnswer(invocation -> {
                             shutdownCalled.set(true);
@@ -456,7 +457,7 @@ class ProviderRepositoryTest {
                             return null;
                         })
                         .when(oldProvider)
-                        .initialize(any());
+                        .initialize(any(), any());
 
                 // Start async initialization (will block)
                 providerRepository.setProvider(

--- a/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
+++ b/src/test/java/dev/openfeature/sdk/ProviderRepositoryTest.java
@@ -65,7 +65,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the provider mutator")
             void shouldImmediatelyReturnWhenCallingTheProviderMutator() throws Exception {
                 FeatureProvider featureProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(any(), any());
+                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(any(), isNull());
 
                 await().alias("wait for provider mutator to return")
                         .pollDelay(Duration.ofMillis(1))
@@ -122,7 +122,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the domain provider mutator")
             void shouldImmediatelyReturnWhenCallingTheDomainProviderMutator() throws Exception {
                 FeatureProvider featureProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(any(), any());
+                doDelayResponse(Duration.ofSeconds(10)).when(featureProvider).initialize(any(), eq("a domain"));
 
                 await().alias("wait for provider mutator to return")
                         .pollDelay(Duration.ofMillis(1))
@@ -153,7 +153,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the provider mutator")
             void shouldImmediatelyReturnWhenCallingTheProviderMutator() throws Exception {
                 FeatureProvider newProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any(), any());
+                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any(), isNull());
 
                 await().alias("wait for provider mutator to return")
                         .pollDelay(Duration.ofMillis(1))
@@ -194,7 +194,7 @@ class ProviderRepositoryTest {
             @DisplayName("should immediately return when calling the provider mutator")
             void shouldImmediatelyReturnWhenCallingTheProviderMutator() throws Exception {
                 FeatureProvider newProvider = createMockedProvider();
-                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any(), any());
+                doDelayResponse(Duration.ofSeconds(10)).when(newProvider).initialize(any(), eq(DOMAIN_NAME));
 
                 Future<?> providerMutation = executorService.submit(() -> providerRepository.setProvider(
                         DOMAIN_NAME,
@@ -358,7 +358,7 @@ class ProviderRepositoryTest {
                 FeatureProvider slowInitProvider = createMockedProvider();
                 AtomicBoolean shutdownCalled = new AtomicBoolean(false);
 
-                doDelayResponse(Duration.ofMillis(500)).when(slowInitProvider).initialize(any(), any());
+                doDelayResponse(Duration.ofMillis(500)).when(slowInitProvider).initialize(any(), isNull());
 
                 doAnswer(invocation -> {
                             shutdownCalled.set(true);
@@ -457,7 +457,7 @@ class ProviderRepositoryTest {
                             return null;
                         })
                         .when(oldProvider)
-                        .initialize(any(), any());
+                        .initialize(any(), isNull());
 
                 // Start async initialization (will block)
                 providerRepository.setProvider(

--- a/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
@@ -4,6 +4,7 @@ import static dev.openfeature.sdk.testutils.TestFlagsUtils.buildFlags;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -94,10 +95,10 @@ public class ProviderSteps {
                             while (true) {}
                         })
                         .when(mockProvider)
-                        .initialize(any(), any());
+                        .initialize(any(), eq(providerState.name()));
                 break;
             case FATAL:
-                doThrow(new FatalError(errorMessage)).when(mockProvider).initialize(any(), any());
+                doThrow(new FatalError(errorMessage)).when(mockProvider).initialize(any(), eq(providerState.name()));
                 break;
         }
         // Configure all evaluation methods with a single helper

--- a/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
+++ b/src/test/java/dev/openfeature/sdk/e2e/steps/ProviderSteps.java
@@ -94,10 +94,10 @@ public class ProviderSteps {
                             while (true) {}
                         })
                         .when(mockProvider)
-                        .initialize(any());
+                        .initialize(any(), any());
                 break;
             case FATAL:
-                doThrow(new FatalError(errorMessage)).when(mockProvider).initialize(any());
+                doThrow(new FatalError(errorMessage)).when(mockProvider).initialize(any(), any());
                 break;
         }
         // Configure all evaluation methods with a single helper

--- a/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
+++ b/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
@@ -1,13 +1,14 @@
 package dev.openfeature.sdk.fixtures;
 
 import static dev.openfeature.sdk.testutils.stubbing.ConditionStubber.doBlock;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.ProviderState;
 import java.io.FileNotFoundException;
 import java.util.concurrent.CountDownLatch;
@@ -32,13 +33,15 @@ public class ProviderFixture {
     public static FeatureProvider createMockedErrorProvider() throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
         doReturn(ProviderState.NOT_READY).when(provider).getState();
-        doThrow(FileNotFoundException.class).when(provider).initialize(any(), any());
+        doThrow(FileNotFoundException.class).when(provider).initialize(new ImmutableContext(), nullable(String.class));
         return provider;
     }
 
     public static FeatureProvider createBlockedProvider(CountDownLatch latch, Runnable onAnswer) throws Exception {
         FeatureProvider provider = createMockedProvider();
-        doBlock(latch, createAnswerExecutingCode(onAnswer)).when(provider).initialize(any(), any());
+        doBlock(latch, createAnswerExecutingCode(onAnswer))
+                .when(provider)
+                .initialize(new ImmutableContext(), nullable(String.class));
         doReturn("blockedProvider").when(provider).toString();
         return provider;
     }
@@ -57,7 +60,7 @@ public class ProviderFixture {
                     return null;
                 })
                 .when(provider)
-                .initialize(any(), any());
+                .initialize(new ImmutableContext(), nullable(String.class));
         doReturn("unblockingProvider").when(provider).toString();
         return provider;
     }

--- a/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
+++ b/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
@@ -1,6 +1,7 @@
 package dev.openfeature.sdk.fixtures;
 
 import static dev.openfeature.sdk.testutils.stubbing.ConditionStubber.doBlock;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -33,7 +34,7 @@ public class ProviderFixture {
     public static FeatureProvider createMockedErrorProvider() throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
         doReturn(ProviderState.NOT_READY).when(provider).getState();
-        doThrow(FileNotFoundException.class).when(provider).initialize(new ImmutableContext(), nullable(String.class));
+        doThrow(FileNotFoundException.class).when(provider).initialize(any(), nullable(String.class));
         return provider;
     }
 

--- a/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
+++ b/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
@@ -1,20 +1,15 @@
 package dev.openfeature.sdk.fixtures;
 
-import static dev.openfeature.sdk.testutils.stubbing.ConditionStubber.doBlock;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import dev.openfeature.sdk.FeatureProvider;
-import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.ProviderState;
 import java.io.FileNotFoundException;
-import java.util.concurrent.CountDownLatch;
 import lombok.experimental.UtilityClass;
-import org.mockito.stubbing.Answer;
 
 @UtilityClass
 public class ProviderFixture {
@@ -35,34 +30,6 @@ public class ProviderFixture {
         FeatureProvider provider = mock(FeatureProvider.class);
         doReturn(ProviderState.NOT_READY).when(provider).getState();
         doThrow(FileNotFoundException.class).when(provider).initialize(any(), nullable(String.class));
-        return provider;
-    }
-
-    public static FeatureProvider createBlockedProvider(CountDownLatch latch, Runnable onAnswer) throws Exception {
-        FeatureProvider provider = createMockedProvider();
-        doBlock(latch, createAnswerExecutingCode(onAnswer))
-                .when(provider)
-                .initialize(new ImmutableContext(), nullable(String.class));
-        doReturn("blockedProvider").when(provider).toString();
-        return provider;
-    }
-
-    private static Answer<?> createAnswerExecutingCode(Runnable onAnswer) {
-        return invocation -> {
-            onAnswer.run();
-            return null;
-        };
-    }
-
-    public static FeatureProvider createUnblockingProvider(CountDownLatch latch) throws Exception {
-        FeatureProvider provider = createMockedProvider();
-        doAnswer(invocation -> {
-                    latch.countDown();
-                    return null;
-                })
-                .when(provider)
-                .initialize(new ImmutableContext(), nullable(String.class));
-        doReturn("unblockingProvider").when(provider).toString();
         return provider;
     }
 }

--- a/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
+++ b/src/test/java/dev/openfeature/sdk/fixtures/ProviderFixture.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import dev.openfeature.sdk.FeatureProvider;
-import dev.openfeature.sdk.ImmutableContext;
 import dev.openfeature.sdk.ProviderState;
 import java.io.FileNotFoundException;
 import java.util.concurrent.CountDownLatch;
@@ -33,13 +32,13 @@ public class ProviderFixture {
     public static FeatureProvider createMockedErrorProvider() throws Exception {
         FeatureProvider provider = mock(FeatureProvider.class);
         doReturn(ProviderState.NOT_READY).when(provider).getState();
-        doThrow(FileNotFoundException.class).when(provider).initialize(any());
+        doThrow(FileNotFoundException.class).when(provider).initialize(any(), any());
         return provider;
     }
 
     public static FeatureProvider createBlockedProvider(CountDownLatch latch, Runnable onAnswer) throws Exception {
         FeatureProvider provider = createMockedProvider();
-        doBlock(latch, createAnswerExecutingCode(onAnswer)).when(provider).initialize(new ImmutableContext());
+        doBlock(latch, createAnswerExecutingCode(onAnswer)).when(provider).initialize(any(), any());
         doReturn("blockedProvider").when(provider).toString();
         return provider;
     }
@@ -58,7 +57,7 @@ public class ProviderFixture {
                     return null;
                 })
                 .when(provider)
-                .initialize(new ImmutableContext());
+                .initialize(any(), any());
         doReturn("unblockingProvider").when(provider).toString();
         return provider;
     }

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
@@ -5,9 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import dev.openfeature.sdk.ErrorCode;
@@ -16,8 +19,10 @@ import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.Metadata;
 import dev.openfeature.sdk.MutableContext;
 import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.ProviderState;
 import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.GeneralError;
+import dev.openfeature.sdk.providers.memory.InMemoryProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +56,45 @@ class MultiProviderTest extends BaseStrategyTest {
         assertEquals(mockMetaData1, map.get(mockProvider1.getMetadata().getName()));
         assertEquals(mockMetaData2, map.get(mockProvider2.getMetadata().getName()));
         assertEquals("multiprovider", multiProvider.getMetadata().getName());
+    }
+
+    @SneakyThrows
+    @Test
+    void forwardsDomainToChildProviderInitialize() {
+        List<FeatureProvider> providers = new ArrayList<>(2);
+        providers.add(mockProvider1);
+        providers.add(mockProvider2);
+        MultiProvider multiProvider = new MultiProvider(providers);
+        EvaluationContext context = new MutableContext().add("targetingKey", "user");
+
+        multiProvider.initialize(context, "my-domain");
+
+        verify(mockProvider1).initialize(same(context), eq("my-domain"));
+        verify(mockProvider2).initialize(same(context), eq("my-domain"));
+    }
+
+    @SneakyThrows
+    @Test
+    void forwardsDomainToLegacySingleArgChildProvidersWithoutError() {
+        InMemoryProvider legacyProvider1 = new InMemoryProvider(Map.of()) {
+            @Override
+            public Metadata getMetadata() {
+                return () -> "legacy-provider-1";
+            }
+        };
+        InMemoryProvider legacyProvider2 = new InMemoryProvider(Map.of()) {
+            @Override
+            public Metadata getMetadata() {
+                return () -> "legacy-provider-2";
+            }
+        };
+        MultiProvider multiProvider = new MultiProvider(List.of(legacyProvider1, legacyProvider2));
+        EvaluationContext context = new MutableContext().add("targetingKey", "user");
+
+        multiProvider.initialize(context, "my-domain");
+
+        assertEquals(ProviderState.READY, legacyProvider1.getState());
+        assertEquals(ProviderState.READY, legacyProvider2.getState());
     }
 
     @SneakyThrows

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -55,7 +56,7 @@ class MultiProviderTest extends BaseStrategyTest {
     @SneakyThrows
     @Test
     void shouldHandleInitializationFailure() {
-        doThrow(new GeneralError()).when(mockProvider1).initialize(any());
+        doThrow(new GeneralError()).when(mockProvider1).initialize(any(), isNull());
         doThrow(new GeneralError()).when(mockProvider1).shutdown();
         List<FeatureProvider> providers = new ArrayList<>(2);
         providers.add(mockProvider1);

--- a/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/MultiProviderTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -56,6 +57,20 @@ class MultiProviderTest extends BaseStrategyTest {
         assertEquals(mockMetaData1, map.get(mockProvider1.getMetadata().getName()));
         assertEquals(mockMetaData2, map.get(mockProvider2.getMetadata().getName()));
         assertEquals("multiprovider", multiProvider.getMetadata().getName());
+    }
+
+    @SneakyThrows
+    @Test
+    void singleArgInitializeForwardsNullDomainToChildren() {
+        List<FeatureProvider> providers = new ArrayList<>(2);
+        providers.add(mockProvider1);
+        providers.add(mockProvider2);
+        MultiProvider multiProvider = new MultiProvider(providers);
+
+        multiProvider.initialize(null);
+
+        verify(mockProvider1).initialize(isNull(), isNull());
+        verify(mockProvider2).initialize(isNull(), isNull());
     }
 
     @SneakyThrows
@@ -109,6 +124,18 @@ class MultiProviderTest extends BaseStrategyTest {
         MultiProvider multiProvider = new MultiProvider(providers, strategy);
         assertThrows(ExecutionException.class, () -> multiProvider.initialize(null));
         assertDoesNotThrow(multiProvider::shutdown);
+    }
+
+    @SneakyThrows
+    @Test
+    void continuesWhenShutdownFailsAfterInitializeFailure() {
+        doThrow(new GeneralError()).when(mockProvider1).initialize(any(), isNull());
+        MultiProvider multiProvider = spy(new MultiProvider(List.of(mockProvider1)));
+        doThrow(new RuntimeException("shutdown failed")).when(multiProvider).shutdown();
+
+        assertThrows(ExecutionException.class, () -> multiProvider.initialize(null));
+
+        verify(multiProvider).shutdown();
     }
 
     @Test

--- a/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
+++ b/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
@@ -32,7 +32,7 @@ class ProviderRepositoryCT {
                 })
                 .when(provider)
                 .shutdown();
-        doAnswer(invocation -> null).when(provider).initialize(any());
+        doAnswer(invocation -> null).when(provider).initialize(any(), any());
         return provider;
     }
 

--- a/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
+++ b/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
@@ -2,6 +2,7 @@ package dev.openfeature.sdk.vmlens;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -32,7 +33,7 @@ class ProviderRepositoryCT {
                 })
                 .when(provider)
                 .shutdown();
-        doAnswer(invocation -> null).when(provider).initialize(any(), any());
+        doAnswer(invocation -> null).when(provider).initialize(any(), isNull());
         return provider;
     }
 

--- a/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
+++ b/src/test/java/dev/openfeature/sdk/vmlens/ProviderRepositoryCT.java
@@ -156,4 +156,35 @@ class ProviderRepositoryCT {
             }
         }
     }
+
+    @Test
+    void concurrentRegistrationToSameDomain_exactlyOneBoundAndLoserShutDown() throws Exception {
+        final String domain = "domain-1";
+        try (AllInterleavings allInterleavings = new AllInterleavings("Concurrent registration to the same domain")) {
+            while (allInterleavings.hasNext()) {
+                AtomicInteger provider1ShutdownCount = new AtomicInteger(0);
+                AtomicInteger provider2ShutdownCount = new AtomicInteger(0);
+                FeatureProvider provider1 = createMockedProvider("provider-1", provider1ShutdownCount);
+                FeatureProvider provider2 = createMockedProvider("provider-2", provider2ShutdownCount);
+                OpenFeatureAPI api = OpenFeatureAPITestUtil.createAPI();
+
+                // two different providers race to bind to the same domain
+                Runner.runParallel(
+                        () -> api.setProviderAndWait(domain, provider1),
+                        () -> api.setProviderAndWait(domain, provider2));
+
+                // the domain resolves to exactly one of the two providers
+                FeatureProvider bound = api.getProvider(domain);
+                assertThat(bound).isIn(provider1, provider2);
+
+                // the provider that lost the race is shut down exactly once; the winner is left running
+                AtomicInteger winner = bound == provider1 ? provider1ShutdownCount : provider2ShutdownCount;
+                AtomicInteger loser = bound == provider1 ? provider2ShutdownCount : provider1ShutdownCount;
+                assertThat(loser.get())
+                        .as("Losing provider shut down exactly once")
+                        .isEqualTo(1);
+                assertThat(winner.get()).as("Winning provider not shut down").isZero();
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add optional `domain` parameter to provider `initialize` and pass the bound domain from the provider mutator (spec 1.1.2.2, 2.4.1)
- Add `isDomainScoped()` provider declaration and reject binding a domain-scoped instance to more than one domain (spec 2.4.3, 1.1.8.1)
- Forward `domain` through `MultiProvider` `initialize` to each child provider
- Add spec conformance tests, including backward compatibility for providers that only override single-arg `initialize`

## Motivation

Unblocks OFREP static-context providers that need the bound `domain` at init time to scope persisted cache keys per [open-feature/spec#393](https://github.com/open-feature/spec/pull/393) and [protocol ADR 0009](https://github.com/open-feature/protocol/blob/main/service/adrs/0009-local-storage-for-static-context-providers.md).

Parallel implementation in js-sdk: [open-feature/js-sdk#1433](https://github.com/open-feature/js-sdk/pull/1433).

### Notes

- Non-breaking: `domain` is an optional second parameter via a default method on `FeatureProvider`
- Non-domain-scoped providers retain existing behavior (single instance can back multiple domains; `initialize` runs once)
- Legacy providers that only implement `initialize(context)` remain compatible; the extra `domain` argument is ignored if unused
- Default provider is initialized with a `null` domain; named clients receive the bound domain string

### Related Issues

Fixes #1981

Relates to: [open-feature/spec#393](https://github.com/open-feature/spec/pull/393), [open-feature/js-sdk#1433](https://github.com/open-feature/js-sdk/pull/1433)

## Test plan

- [x] `InitializeBehaviorSpecTest` verifies domain is passed at init (2.4.1)
- [x] `DomainScopedProviderSpecTest` covers 1.1.8.1 and 2.4.3
- [x] `mvn test` passes after rebase onto `main`
