### PR TITLE
fix: changed log level of provider state change transition messages to debug

### DIFF
--- a/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
@@ -70,7 +70,22 @@ class FeatureProviderStateManager implements EventProviderListener {
             } else {
                 providerName = delegate.getMetadata().getName();
             }
-            log.debug("Provider {} transitioned from state {} to state {}", providerName, oldState, state);
+            logProviderStateTransition(providerName, oldState, state);
+        }
+    }
+
+    private void logProviderStateTransition(String providerName, ProviderState oldState, ProviderState newState) {
+        var logMessage = "Provider {} transitioned from state {} to state {}";
+        switch (newState) {
+            case ERROR:
+                log.error(logMessage, providerName, oldState, newState);
+                break;
+            case FATAL:
+                log.warn(logMessage, providerName, oldState, newState);
+                break;
+            default:
+                log.debug(logMessage, providerName, oldState, newState);
+                break;
         }
     }
 

--- a/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
@@ -76,16 +76,12 @@ class FeatureProviderStateManager implements EventProviderListener {
 
     private void logProviderStateTransition(String providerName, ProviderState oldState, ProviderState newState) {
         var logMessage = "Provider {} transitioned from state {} to state {}";
-        switch (newState) {
-            case ERROR:
-                log.error(logMessage, providerName, oldState, newState);
-                break;
-            case FATAL:
-                log.warn(logMessage, providerName, oldState, newState);
-                break;
-            default:
-                log.debug(logMessage, providerName, oldState, newState);
-                break;
+        if (ProviderState.FATAL.equals(newState) || ProviderState.ERROR.equals(newState)) {
+            log.error(logMessage, providerName, oldState, newState);
+        } else if (ProviderState.ERROR.equals(oldState) || ProviderState.FATAL.equals(oldState)) {
+            log.info(logMessage, providerName, oldState, newState);
+        } else {
+            log.debug(logMessage, providerName, oldState, newState);
         }
     }
 

--- a/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
+++ b/src/main/java/dev/openfeature/sdk/FeatureProviderStateManager.java
@@ -70,7 +70,7 @@ class FeatureProviderStateManager implements EventProviderListener {
             } else {
                 providerName = delegate.getMetadata().getName();
             }
-            log.info("Provider {} transitioned from state {} to state {}", providerName, oldState, state);
+            log.debug("Provider {} transitioned from state {} to state {}", providerName, oldState, state);
         }
     }
 


### PR DESCRIPTION

## This PR

Changes the logging level of provider state change transition messages from info to debug to reduce logging noise.

### Related Issues

Fixes #1986 


