### PR TITLE
feat(multiprovider): add ComparisonStrategy

### DIFF
--- a/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
@@ -4,6 +4,7 @@ import dev.openfeature.sdk.ErrorCode;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.FeatureProvider;
 import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.internal.ConfigurableThreadFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -14,7 +15,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -30,10 +31,25 @@ import lombok.Getter;
  * and the fallback provider's result is returned.
  * If any provider returns an error, all errors are collected and a {@link MultiProviderEvaluation}
  * with {@link ErrorCode#GENERAL} and per-provider {@link ProviderError} details is returned.
+ *
+ * <p>Providers that do not respond before the internal timeout do not fail the evaluation. The
+ * fallback provider's result is still returned, carrying a {@link ProviderError} for each provider
+ * that timed out, so that a slow provider under comparison cannot degrade evaluations. Only a
+ * timeout of the fallback provider itself produces an error result.
  */
 public class ComparisonStrategy implements Strategy {
 
     private static final long DEFAULT_TIMEOUT_MS = 30_000;
+
+    /**
+     * Shared pool used when no executor is supplied.
+     *
+     * <p>Provider evaluations block, so they are kept off {@link java.util.concurrent.ForkJoinPool
+     * #commonPool()} to avoid starving unrelated parallel work in the host application. Threads are
+     * daemon threads, so this pool never prevents JVM shutdown.
+     */
+    private static final ExecutorService DEFAULT_EXECUTOR =
+            Executors.newCachedThreadPool(new ConfigurableThreadFactory("openfeature-comparison-strategy", true));
 
     @Getter
     private final String fallbackProvider;
@@ -45,8 +61,6 @@ public class ComparisonStrategy implements Strategy {
     /**
      * Constructs a comparison strategy with a fallback provider.
      *
-     * <p>Uses a shared {@link ForkJoinPool#commonPool()} for parallel evaluation.
-     *
      * @param fallbackProvider provider name to use as fallback when successful
      *                         providers disagree
      */
@@ -57,8 +71,6 @@ public class ComparisonStrategy implements Strategy {
     /**
      * Constructs a comparison strategy with fallback provider and mismatch callback.
      *
-     * <p>Uses a shared {@link ForkJoinPool#commonPool()} for parallel evaluation.
-     *
      * @param fallbackProvider provider name to use as fallback when successful
      *                         providers disagree
      * @param onMismatch       callback invoked with all successful evaluations
@@ -66,11 +78,14 @@ public class ComparisonStrategy implements Strategy {
      */
     public ComparisonStrategy(
             String fallbackProvider, BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch) {
-        this(fallbackProvider, onMismatch, ForkJoinPool.commonPool(), DEFAULT_TIMEOUT_MS);
+        this(fallbackProvider, onMismatch, DEFAULT_EXECUTOR, DEFAULT_TIMEOUT_MS);
     }
 
     /**
-     * Constructs a comparison strategy with a caller-supplied executor.
+     * Constructs a comparison strategy with a caller-supplied executor and timeout.
+     *
+     * <p>Intentionally not public: the executor and timeout are implementation details, and the
+     * public surface is kept aligned with the js-sdk reference implementation.
      *
      * @param fallbackProvider provider name to use as fallback when successful
      *                         providers disagree
@@ -80,7 +95,7 @@ public class ComparisonStrategy implements Strategy {
      * @param timeoutMs        maximum time in milliseconds to wait for all
      *                         providers to complete
      */
-    public ComparisonStrategy(
+    ComparisonStrategy(
             String fallbackProvider,
             BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch,
             ExecutorService executorService,
@@ -111,72 +126,92 @@ public class ComparisonStrategy implements Strategy {
         int capacity = providers.size() * 4 / 3 + 1;
         Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(capacity);
         Map<String, ProviderError> providerErrors = new ConcurrentHashMap<>(capacity);
+        Map<String, ProviderError> timeoutErrors = new ConcurrentHashMap<>(capacity);
 
         Optional<ProviderEvaluation<T>> runFailure =
-                runEvaluations(providers, providerFunction, successfulResults, providerErrors);
+                runEvaluations(providers, providerFunction, successfulResults, providerErrors, timeoutErrors);
         if (runFailure.isPresent()) {
             return runFailure.get();
         }
 
         if (!providerErrors.isEmpty()) {
-            return errorResult("Provider errors during comparison", providers, providerErrors);
+            return errorResult(
+                    "Provider errors during comparison", orderedErrors(providers, providerErrors, timeoutErrors));
         }
 
         ProviderEvaluation<T> fallbackResult = successfulResults.get(fallbackProvider);
         if (fallbackResult == null) {
             return errorResult(
-                    "Fallback provider did not return a successful evaluation: " + fallbackProvider,
-                    providers,
-                    providerErrors);
+                    fallbackFailureMessage(timeoutErrors), orderedErrors(providers, providerErrors, timeoutErrors));
         }
 
-        if (allEvaluationsMatch(successfulResults)) {
-            return fallbackResult;
-        }
-
-        if (onMismatch != null) {
+        if (onMismatch != null && !allEvaluationsMatch(successfulResults)) {
             onMismatch.accept(key, orderedResults(providers, successfulResults));
         }
-        return fallbackResult;
+
+        if (timeoutErrors.isEmpty()) {
+            return fallbackResult;
+        }
+        // A provider under comparison was too slow. Report it, but keep serving the fallback result.
+        return withProviderErrors(fallbackResult, orderedErrors(providers, providerErrors, timeoutErrors));
+    }
+
+    private String fallbackFailureMessage(Map<String, ProviderError> timeoutErrors) {
+        if (timeoutErrors.containsKey(fallbackProvider)) {
+            return "Fallback provider did not respond within " + timeoutMs + "ms: " + fallbackProvider;
+        }
+        return "Fallback provider did not return a successful evaluation: " + fallbackProvider;
     }
 
     /**
-     * Evaluates every provider in parallel, recording each outcome into {@code successfulResults} or
-     * {@code providerErrors}.
+     * Evaluates every provider in parallel, recording each outcome into {@code successfulResults},
+     * {@code providerErrors}, or, for providers that did not finish in time, {@code timeoutErrors}.
      *
-     * @return an error evaluation if the parallel run itself could not complete (timeout,
-     *     interruption, or executor failure), otherwise {@link Optional#empty()}
+     * @return an error evaluation if the parallel run itself could not complete (interruption or
+     *     executor failure), otherwise {@link Optional#empty()}
      */
     private <T> Optional<ProviderEvaluation<T>> runEvaluations(
             Map<String, FeatureProvider> providers,
             Function<FeatureProvider, ProviderEvaluation<T>> providerFunction,
             Map<String, ProviderEvaluation<T>> successfulResults,
-            Map<String, ProviderError> providerErrors) {
+            Map<String, ProviderError> providerErrors,
+            Map<String, ProviderError> timeoutErrors) {
         try {
+            List<String> providerNames = new ArrayList<>(providers.keySet());
             List<Callable<Void>> tasks = new ArrayList<>(providers.size());
-            for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
-                String providerName = entry.getKey();
-                FeatureProvider provider = entry.getValue();
+            for (String providerName : providerNames) {
+                FeatureProvider provider = providers.get(providerName);
                 tasks.add(() -> {
                     recordEvaluation(providerName, provider, providerFunction, successfulResults, providerErrors);
                     return null;
                 });
             }
+            // invokeAll returns futures in task submission order, which matches providerNames.
             List<Future<Void>> futures = executorService.invokeAll(tasks, timeoutMs, TimeUnit.MILLISECONDS);
-            for (Future<Void> future : futures) {
+            for (int i = 0; i < futures.size(); i++) {
+                Future<Void> future = futures.get(i);
+                String providerName = providerNames.get(i);
                 if (future.isCancelled()) {
-                    return Optional.of(errorResult(
-                            "Comparison strategy timed out after " + timeoutMs + "ms", providers, providerErrors));
+                    timeoutErrors.put(
+                            providerName,
+                            ProviderError.fromResult(
+                                    providerName,
+                                    ErrorCode.GENERAL,
+                                    "Provider did not respond within " + timeoutMs + "ms"));
+                } else {
+                    future.get();
                 }
-                future.get();
             }
             return Optional.empty();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            return Optional.of(
-                    errorResult("Comparison strategy interrupted: " + e.getMessage(), providers, providerErrors));
+            return Optional.of(errorResult(
+                    "Comparison strategy interrupted: " + e.getMessage(),
+                    orderedErrors(providers, providerErrors, timeoutErrors)));
         } catch (Exception e) {
-            return Optional.of(errorResult("Comparison strategy failed: " + e.getMessage(), providers, providerErrors));
+            return Optional.of(errorResult(
+                    "Comparison strategy failed: " + e.getMessage(),
+                    orderedErrors(providers, providerErrors, timeoutErrors)));
         }
     }
 
@@ -205,22 +240,47 @@ public class ComparisonStrategy implements Strategy {
         }
     }
 
+    /** Builds a {@link MultiProviderEvaluation} carrying per-provider error details. */
+    private <T> ProviderEvaluation<T> errorResult(String baseMessage, List<ProviderError> orderedErrors) {
+        return MultiProviderEvaluation.<T>builder()
+                .errorCode(ErrorCode.GENERAL)
+                .errorMessage(ProviderError.buildAggregateMessage(baseMessage, orderedErrors))
+                .providerErrors(orderedErrors)
+                .build();
+    }
+
     /**
-     * Builds a {@link MultiProviderEvaluation} carrying per-provider error details, ordered by the
-     * provider registration order so the aggregate message is stable across runs.
+     * Merges the recorded errors into a single list ordered by provider registration order, so that
+     * aggregate messages are stable across runs.
      */
-    private <T> ProviderEvaluation<T> errorResult(
-            String baseMessage, Map<String, FeatureProvider> providers, Map<String, ProviderError> providerErrors) {
-        List<ProviderError> orderedErrors = new ArrayList<>(providerErrors.size());
+    private List<ProviderError> orderedErrors(
+            Map<String, FeatureProvider> providers,
+            Map<String, ProviderError> providerErrors,
+            Map<String, ProviderError> timeoutErrors) {
+        List<ProviderError> orderedErrors = new ArrayList<>(providerErrors.size() + timeoutErrors.size());
         for (String providerName : providers.keySet()) {
             ProviderError error = providerErrors.get(providerName);
+            if (error == null) {
+                error = timeoutErrors.get(providerName);
+            }
             if (error != null) {
                 orderedErrors.add(error);
             }
         }
+        return orderedErrors;
+    }
+
+    /**
+     * Returns the successful evaluation as a {@link MultiProviderEvaluation} carrying the given
+     * per-provider errors, so callers can see which providers were skipped or timed out.
+     */
+    private <T> ProviderEvaluation<T> withProviderErrors(
+            ProviderEvaluation<T> evaluation, List<ProviderError> orderedErrors) {
         return MultiProviderEvaluation.<T>builder()
-                .errorCode(ErrorCode.GENERAL)
-                .errorMessage(ProviderError.buildAggregateMessage(baseMessage, orderedErrors))
+                .value(evaluation.getValue())
+                .variant(evaluation.getVariant())
+                .reason(evaluation.getReason())
+                .flagMetadata(evaluation.getFlagMetadata())
                 .providerErrors(orderedErrors)
                 .build();
     }

--- a/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
+++ b/src/main/java/dev/openfeature/sdk/multiprovider/ComparisonStrategy.java
@@ -1,0 +1,254 @@
+package dev.openfeature.sdk.multiprovider;
+
+import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.ProviderEvaluation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import lombok.Getter;
+
+/**
+ * Comparison strategy.
+ *
+ * <p>Evaluates all providers in parallel and compares successful results.
+ * If all providers agree on the value, the fallback provider's result is returned.
+ * If providers disagree, the optional {@code onMismatch} callback is invoked
+ * and the fallback provider's result is returned.
+ * If any provider returns an error, all errors are collected and a {@link MultiProviderEvaluation}
+ * with {@link ErrorCode#GENERAL} and per-provider {@link ProviderError} details is returned.
+ */
+public class ComparisonStrategy implements Strategy {
+
+    private static final long DEFAULT_TIMEOUT_MS = 30_000;
+
+    @Getter
+    private final String fallbackProvider;
+
+    private final BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch;
+    private final ExecutorService executorService;
+    private final long timeoutMs;
+
+    /**
+     * Constructs a comparison strategy with a fallback provider.
+     *
+     * <p>Uses a shared {@link ForkJoinPool#commonPool()} for parallel evaluation.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful
+     *                         providers disagree
+     */
+    public ComparisonStrategy(String fallbackProvider) {
+        this(fallbackProvider, null);
+    }
+
+    /**
+     * Constructs a comparison strategy with fallback provider and mismatch callback.
+     *
+     * <p>Uses a shared {@link ForkJoinPool#commonPool()} for parallel evaluation.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful
+     *                         providers disagree
+     * @param onMismatch       callback invoked with all successful evaluations
+     *                         when they disagree
+     */
+    public ComparisonStrategy(
+            String fallbackProvider, BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch) {
+        this(fallbackProvider, onMismatch, ForkJoinPool.commonPool(), DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * Constructs a comparison strategy with a caller-supplied executor.
+     *
+     * @param fallbackProvider provider name to use as fallback when successful
+     *                         providers disagree
+     * @param onMismatch       callback invoked with all successful evaluations
+     *                         when they disagree (may be {@code null})
+     * @param executorService  executor to use for parallel evaluation
+     * @param timeoutMs        maximum time in milliseconds to wait for all
+     *                         providers to complete
+     */
+    public ComparisonStrategy(
+            String fallbackProvider,
+            BiConsumer<String, Map<String, ProviderEvaluation<?>>> onMismatch,
+            ExecutorService executorService,
+            long timeoutMs) {
+        this.fallbackProvider = Objects.requireNonNull(fallbackProvider, "fallbackProvider must not be null");
+        this.onMismatch = onMismatch;
+        this.executorService = Objects.requireNonNull(executorService, "executorService must not be null");
+        this.timeoutMs = timeoutMs;
+    }
+
+    @Override
+    public <T> ProviderEvaluation<T> evaluate(
+            Map<String, FeatureProvider> providers,
+            String key,
+            T defaultValue,
+            EvaluationContext ctx,
+            Function<FeatureProvider, ProviderEvaluation<T>> providerFunction) {
+        if (providers.isEmpty()) {
+            return ProviderEvaluation.<T>builder()
+                    .errorCode(ErrorCode.GENERAL)
+                    .errorMessage("No providers configured")
+                    .build();
+        }
+        if (!providers.containsKey(fallbackProvider)) {
+            throw new IllegalArgumentException("fallbackProvider not found in providers: " + fallbackProvider);
+        }
+
+        int capacity = providers.size() * 4 / 3 + 1;
+        Map<String, ProviderEvaluation<T>> successfulResults = new ConcurrentHashMap<>(capacity);
+        Map<String, ProviderError> providerErrors = new ConcurrentHashMap<>(capacity);
+
+        Optional<ProviderEvaluation<T>> runFailure =
+                runEvaluations(providers, providerFunction, successfulResults, providerErrors);
+        if (runFailure.isPresent()) {
+            return runFailure.get();
+        }
+
+        if (!providerErrors.isEmpty()) {
+            return errorResult("Provider errors during comparison", providers, providerErrors);
+        }
+
+        ProviderEvaluation<T> fallbackResult = successfulResults.get(fallbackProvider);
+        if (fallbackResult == null) {
+            return errorResult(
+                    "Fallback provider did not return a successful evaluation: " + fallbackProvider,
+                    providers,
+                    providerErrors);
+        }
+
+        if (allEvaluationsMatch(successfulResults)) {
+            return fallbackResult;
+        }
+
+        if (onMismatch != null) {
+            onMismatch.accept(key, orderedResults(providers, successfulResults));
+        }
+        return fallbackResult;
+    }
+
+    /**
+     * Evaluates every provider in parallel, recording each outcome into {@code successfulResults} or
+     * {@code providerErrors}.
+     *
+     * @return an error evaluation if the parallel run itself could not complete (timeout,
+     *     interruption, or executor failure), otherwise {@link Optional#empty()}
+     */
+    private <T> Optional<ProviderEvaluation<T>> runEvaluations(
+            Map<String, FeatureProvider> providers,
+            Function<FeatureProvider, ProviderEvaluation<T>> providerFunction,
+            Map<String, ProviderEvaluation<T>> successfulResults,
+            Map<String, ProviderError> providerErrors) {
+        try {
+            List<Callable<Void>> tasks = new ArrayList<>(providers.size());
+            for (Map.Entry<String, FeatureProvider> entry : providers.entrySet()) {
+                String providerName = entry.getKey();
+                FeatureProvider provider = entry.getValue();
+                tasks.add(() -> {
+                    recordEvaluation(providerName, provider, providerFunction, successfulResults, providerErrors);
+                    return null;
+                });
+            }
+            List<Future<Void>> futures = executorService.invokeAll(tasks, timeoutMs, TimeUnit.MILLISECONDS);
+            for (Future<Void> future : futures) {
+                if (future.isCancelled()) {
+                    return Optional.of(errorResult(
+                            "Comparison strategy timed out after " + timeoutMs + "ms", providers, providerErrors));
+                }
+                future.get();
+            }
+            return Optional.empty();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return Optional.of(
+                    errorResult("Comparison strategy interrupted: " + e.getMessage(), providers, providerErrors));
+        } catch (Exception e) {
+            return Optional.of(errorResult("Comparison strategy failed: " + e.getMessage(), providers, providerErrors));
+        }
+    }
+
+    /** Evaluates a single provider, recording either its result or its error. */
+    private <T> void recordEvaluation(
+            String providerName,
+            FeatureProvider provider,
+            Function<FeatureProvider, ProviderEvaluation<T>> providerFunction,
+            Map<String, ProviderEvaluation<T>> successfulResults,
+            Map<String, ProviderError> providerErrors) {
+        try {
+            ProviderEvaluation<T> evaluation = providerFunction.apply(provider);
+            if (evaluation == null) {
+                providerErrors.put(
+                        providerName, ProviderError.fromResult(providerName, ErrorCode.GENERAL, "null evaluation"));
+            } else if (evaluation.getErrorCode() == null) {
+                successfulResults.put(providerName, evaluation);
+            } else {
+                providerErrors.put(
+                        providerName,
+                        ProviderError.fromResult(
+                                providerName, evaluation.getErrorCode(), evaluation.getErrorMessage()));
+            }
+        } catch (Exception e) {
+            providerErrors.put(providerName, ProviderError.fromException(providerName, e));
+        }
+    }
+
+    /**
+     * Builds a {@link MultiProviderEvaluation} carrying per-provider error details, ordered by the
+     * provider registration order so the aggregate message is stable across runs.
+     */
+    private <T> ProviderEvaluation<T> errorResult(
+            String baseMessage, Map<String, FeatureProvider> providers, Map<String, ProviderError> providerErrors) {
+        List<ProviderError> orderedErrors = new ArrayList<>(providerErrors.size());
+        for (String providerName : providers.keySet()) {
+            ProviderError error = providerErrors.get(providerName);
+            if (error != null) {
+                orderedErrors.add(error);
+            }
+        }
+        return MultiProviderEvaluation.<T>builder()
+                .errorCode(ErrorCode.GENERAL)
+                .errorMessage(ProviderError.buildAggregateMessage(baseMessage, orderedErrors))
+                .providerErrors(orderedErrors)
+                .build();
+    }
+
+    /** Returns the successful evaluations in provider registration order. */
+    private <T> Map<String, ProviderEvaluation<?>> orderedResults(
+            Map<String, FeatureProvider> providers, Map<String, ProviderEvaluation<T>> successfulResults) {
+        Map<String, ProviderEvaluation<?>> ordered = new LinkedHashMap<>();
+        for (String providerName : providers.keySet()) {
+            ProviderEvaluation<T> evaluation = successfulResults.get(providerName);
+            if (evaluation != null) {
+                ordered.put(providerName, evaluation);
+            }
+        }
+        return Collections.unmodifiableMap(ordered);
+    }
+
+    private <T> boolean allEvaluationsMatch(Map<String, ProviderEvaluation<T>> results) {
+        ProviderEvaluation<T> baseline = null;
+        for (ProviderEvaluation<T> evaluation : results.values()) {
+            if (baseline == null) {
+                baseline = evaluation;
+                continue;
+            }
+            if (!Objects.equals(baseline.getValue(), evaluation.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
@@ -1,0 +1,283 @@
+package dev.openfeature.sdk.multiprovider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import dev.openfeature.sdk.ErrorCode;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.ProviderEvaluation;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class ComparisonStrategyTest extends BaseStrategyTest {
+
+    @Test
+    void shouldReturnFallbackResultWhenAllProvidersAgree() {
+        setupProviderSuccess(mockProvider1, "same");
+        setupProviderSuccess(mockProvider2, "same");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider2");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertNotNull(result);
+        assertEquals("same", result.getValue());
+        assertNull(result.getErrorCode());
+    }
+
+    @Test
+    void shouldCallMismatchCallbackAndReturnFallbackResult() {
+        setupProviderSuccess(mockProvider1, "first");
+        setupProviderSuccess(mockProvider2, "second");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        AtomicInteger callbackCount = new AtomicInteger();
+        ComparisonStrategy strategy =
+                new ComparisonStrategy("provider2", (key, evaluations) -> callbackCount.incrementAndGet());
+
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals("second", result.getValue());
+        assertNull(result.getErrorCode());
+        assertEquals(1, callbackCount.get());
+    }
+
+    @Test
+    void shouldReturnGeneralErrorWhenAnyProviderFails() {
+        setupProviderSuccess(mockProvider1, "ok");
+        setupProviderError(mockProvider2, ErrorCode.PARSE_ERROR);
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        assertTrue(result.getErrorMessage().contains("provider2"));
+
+        List<ProviderError> providerErrors = ((MultiProviderEvaluation<String>) result).getProviderErrors();
+        assertEquals(1, providerErrors.size());
+        assertEquals("provider2", providerErrors.get(0).getProviderName());
+        assertEquals(ErrorCode.PARSE_ERROR, providerErrors.get(0).getErrorCode());
+    }
+
+    @Test
+    void shouldThrowWhenFallbackProviderIsMissing() {
+        setupProviderSuccess(mockProvider1, "ok");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider2");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> strategy.evaluate(
+                        providers,
+                        FLAG_KEY,
+                        DEFAULT_STRING,
+                        null,
+                        p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null)));
+    }
+
+    @Test
+    void shouldEvaluateProvidersConcurrently() {
+        // Use a latch to prove that providers run in parallel:
+        // both providers block on the latch, so they must be on
+        // separate threads for the test to complete.
+        CountDownLatch bothStarted = new CountDownLatch(2);
+        Set<String> threadNames = ConcurrentHashMap.newKeySet();
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        setupProviderSuccess(mockProvider1, "val");
+        setupProviderSuccess(mockProvider2, "val");
+
+        // A dedicated pool of two threads: the default ForkJoinPool.commonPool() can have a
+        // parallelism of 1 on single-core runners, which would make this assertion flaky.
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, executor, 5_000);
+            ProviderEvaluation<String> result =
+                    strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
+                        threadNames.add(Thread.currentThread().getName());
+                        bothStarted.countDown();
+                        try {
+                            // Wait for both providers to signal they've started
+                            bothStarted.await(5, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
+                    });
+
+            assertNotNull(result);
+            assertEquals("val", result.getValue());
+            assertNull(result.getErrorCode());
+            // Verify that at least 2 different threads were used
+            assertTrue(
+                    threadNames.size() >= 2,
+                    "Expected concurrent execution on multiple threads, but only saw: " + threadNames);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldCollectAllProviderErrorsWhenMultipleFail() {
+        setupProviderError(mockProvider1, ErrorCode.PARSE_ERROR);
+        setupProviderError(mockProvider2, ErrorCode.FLAG_NOT_FOUND);
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        assertTrue(result.getErrorMessage().contains("provider1"), "Error should mention provider1");
+        assertTrue(result.getErrorMessage().contains("provider2"), "Error should mention provider2");
+
+        // Errors follow the provider registration order, not the internal concurrent map order.
+        List<ProviderError> providerErrors = ((MultiProviderEvaluation<String>) result).getProviderErrors();
+        assertEquals(2, providerErrors.size());
+        assertEquals("provider1", providerErrors.get(0).getProviderName());
+        assertEquals(ErrorCode.PARSE_ERROR, providerErrors.get(0).getErrorCode());
+        assertEquals("provider2", providerErrors.get(1).getProviderName());
+        assertEquals(ErrorCode.FLAG_NOT_FOUND, providerErrors.get(1).getErrorCode());
+    }
+
+    @Test
+    void shouldPassSuccessfulEvaluationsInRegistrationOrderToMismatchCallback() {
+        setupProviderSuccess(mockProvider1, "first");
+        setupProviderSuccess(mockProvider2, "second");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        AtomicReference<Map<String, ProviderEvaluation<?>>> captured = new AtomicReference<>();
+        ComparisonStrategy strategy =
+                new ComparisonStrategy("provider2", (key, evaluations) -> captured.set(evaluations));
+
+        strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertNotNull(captured.get());
+        assertEquals(
+                List.of("provider1", "provider2"), List.copyOf(captured.get().keySet()));
+    }
+
+    @Test
+    void shouldReturnErrorWhenNoProvidersConfigured() {
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                new LinkedHashMap<>(),
+                FLAG_KEY,
+                DEFAULT_STRING,
+                null,
+                p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        assertEquals("No providers configured", result.getErrorMessage());
+    }
+
+    @Test
+    void shouldRecordThrownProviderExceptionAsProviderError() {
+        setupProviderSuccess(mockProvider1, "ok");
+        setupProviderException(mockProvider2, new IllegalStateException("provider blew up"));
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        List<ProviderError> providerErrors = ((MultiProviderEvaluation<String>) result).getProviderErrors();
+        assertEquals(1, providerErrors.size());
+        assertEquals("provider2", providerErrors.get(0).getProviderName());
+        assertEquals("provider blew up", providerErrors.get(0).getErrorMessage());
+        assertNotNull(providerErrors.get(0).getException());
+    }
+
+    @Test
+    void shouldTreatNullEvaluationAsProviderError() {
+        setupProviderSuccess(mockProvider1, "ok");
+        when(mockProvider2.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null)).thenReturn(null);
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1");
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        List<ProviderError> providerErrors = ((MultiProviderEvaluation<String>) result).getProviderErrors();
+        assertEquals(1, providerErrors.size());
+        assertEquals("null evaluation", providerErrors.get(0).getErrorMessage());
+    }
+
+    @Test
+    void shouldReturnTimeoutErrorWhenProvidersExceedTheTimeout() {
+        setupProviderSuccess(mockProvider1, "ok");
+        setupProviderSuccess(mockProvider2, "ok");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, executor, 50);
+            ProviderEvaluation<String> result =
+                    strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
+                        try {
+                            Thread.sleep(5_000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
+                    });
+
+            assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+            assertTrue(
+                    result.getErrorMessage().contains("timed out after 50ms"),
+                    "Expected a timeout message, got: " + result.getErrorMessage());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
+++ b/src/test/java/dev/openfeature/sdk/multiprovider/ComparisonStrategyTest.java
@@ -119,8 +119,8 @@ class ComparisonStrategyTest extends BaseStrategyTest {
         setupProviderSuccess(mockProvider1, "val");
         setupProviderSuccess(mockProvider2, "val");
 
-        // A dedicated pool of two threads: the default ForkJoinPool.commonPool() can have a
-        // parallelism of 1 on single-core runners, which would make this assertion flaky.
+        // A dedicated pool of exactly two threads, so the assertion below cannot depend on how the
+        // strategy's shared default pool happens to be sized or already occupied.
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
             ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, executor, 5_000);
@@ -251,7 +251,7 @@ class ComparisonStrategyTest extends BaseStrategyTest {
     }
 
     @Test
-    void shouldReturnTimeoutErrorWhenProvidersExceedTheTimeout() {
+    void shouldReturnErrorWhenTheFallbackProviderExceedsTheTimeout() {
         setupProviderSuccess(mockProvider1, "ok");
         setupProviderSuccess(mockProvider2, "ok");
 
@@ -264,20 +264,126 @@ class ComparisonStrategyTest extends BaseStrategyTest {
             ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, executor, 50);
             ProviderEvaluation<String> result =
                     strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
-                        try {
-                            Thread.sleep(5_000);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                        }
+                        sleepUninterruptibly(5_000);
                         return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
                     });
 
             assertEquals(ErrorCode.GENERAL, result.getErrorCode());
             assertTrue(
-                    result.getErrorMessage().contains("timed out after 50ms"),
-                    "Expected a timeout message, got: " + result.getErrorMessage());
+                    result.getErrorMessage().contains("Fallback provider did not respond within 50ms: provider1"),
+                    "Expected a fallback timeout message, got: " + result.getErrorMessage());
         } finally {
             executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldReturnFallbackResultAndReportTimeoutWhenComparedProviderIsTooSlow() {
+        setupProviderSuccess(mockProvider1, "fast");
+        setupProviderSuccess(mockProvider2, "slow");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, executor, 100);
+            ProviderEvaluation<String> result =
+                    strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
+                        if (provider == mockProvider2) {
+                            sleepUninterruptibly(5_000);
+                        }
+                        return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
+                    });
+
+            assertNull(result.getErrorCode(), "a slow compared provider must not fail the evaluation");
+            assertEquals("fast", result.getValue());
+
+            List<ProviderError> providerErrors = ((MultiProviderEvaluation<String>) result).getProviderErrors();
+            assertEquals(1, providerErrors.size());
+            assertEquals("provider2", providerErrors.get(0).getProviderName());
+            assertEquals(
+                    "Provider did not respond within 100ms",
+                    providerErrors.get(0).getErrorMessage());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldNotInvokeMismatchCallbackWhenTheOnlyOtherProviderTimedOut() {
+        setupProviderSuccess(mockProvider1, "fast");
+        setupProviderSuccess(mockProvider2, "slow");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        AtomicInteger callbackCount = new AtomicInteger();
+        try {
+            ComparisonStrategy strategy = new ComparisonStrategy(
+                    "provider1", (key, evaluations) -> callbackCount.incrementAndGet(), executor, 100);
+            strategy.evaluate(providers, FLAG_KEY, DEFAULT_STRING, null, provider -> {
+                if (provider == mockProvider2) {
+                    sleepUninterruptibly(5_000);
+                }
+                return provider.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null);
+            });
+
+            assertEquals(0, callbackCount.get(), "a timed-out provider has no value to disagree with");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldNotInvokeMismatchCallbackWhenProvidersAgree() {
+        setupProviderSuccess(mockProvider1, "same");
+        setupProviderSuccess(mockProvider2, "same");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+        providers.put("provider2", mockProvider2);
+
+        AtomicInteger callbackCount = new AtomicInteger();
+        ComparisonStrategy strategy =
+                new ComparisonStrategy("provider2", (key, evaluations) -> callbackCount.incrementAndGet());
+
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals("same", result.getValue());
+        assertNull(result.getErrorCode());
+        assertEquals(0, callbackCount.get());
+    }
+
+    @Test
+    void shouldReturnErrorWhenTheExecutorRejectsTheEvaluations() {
+        setupProviderSuccess(mockProvider1, "ok");
+
+        Map<String, FeatureProvider> providers = new LinkedHashMap<>();
+        providers.put("provider1", mockProvider1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        executor.shutdown();
+
+        ComparisonStrategy strategy = new ComparisonStrategy("provider1", null, executor, 1_000);
+        ProviderEvaluation<String> result = strategy.evaluate(
+                providers, FLAG_KEY, DEFAULT_STRING, null, p -> p.getStringEvaluation(FLAG_KEY, DEFAULT_STRING, null));
+
+        assertEquals(ErrorCode.GENERAL, result.getErrorCode());
+        assertTrue(
+                result.getErrorMessage().contains("Comparison strategy failed"),
+                "Expected a strategy failure message, got: " + result.getErrorMessage());
+    }
+
+    private static void sleepUninterruptibly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ComparisonStrategy`, which evaluates every configured provider in parallel and compares the results.
- When all providers agree, the fallback provider's evaluation is returned. On mismatch, an optional callback receives the flag key and each provider's evaluation in registration order, and the fallback result is still returned.
- Provider errors, timeouts, and null evaluations are surfaced as structured `ProviderError` entries on the returned evaluation.

## Usage

```java
Strategy strategy = new ComparisonStrategy("primary", (flagKey, results) ->
        log.warn("providers disagree on {}: {}", flagKey, results));
FeatureProvider provider = new MultiProvider(List.of(primary, candidate), strategy);
```

## Notes

Providers are evaluated in parallel on a dedicated daemon thread pool, deliberately not `ForkJoinPool.commonPool()`, since provider calls block and would otherwise starve unrelated parallel work in the host application.

The public constructors mirror the js-sdk reference implementation. The executor and the 30s timeout are internal details rather than API.

A provider that doesn't respond in time does not fail the evaluation: the fallback provider's result is returned with a `ProviderError` describing the timeout. Only a timeout of the fallback provider itself yields an error result.

## Related PRs

This is one of three independent PRs that together close the multi-provider gaps identified in #1882. They branch off `main` separately and can be reviewed and merged in any order. Together they replace #1897.

- #2003 `ComparisonStrategy` (this PR)
- #2004 child provider event aggregation, state, and tracking
- #2005 child provider hook execution

Relates to #1882